### PR TITLE
Fix/#53 speedup build generator list

### DIFF
--- a/edisgo/grid/grids.py
+++ b/edisgo/grid/grids.py
@@ -267,14 +267,6 @@ class Graph(nx.Graph):
             value
         """
 
-        # get all nodes that have the attribute 'type' set
-        #nodes_attributes = nx.get_node_attributes(self, attr)
-
-        # extract nodes where 'type' == attr_val
-        #nodes = [k for k, v in nodes_attributes.items() if v == attr_val]
-
-        #  speed improved code
-
         temp_nodes = getattr(self, 'node')
         nodes = list(filter(None, map(lambda x: x if temp_nodes[x][attr] == attr_val else None,
                                       temp_nodes.keys())))

--- a/edisgo/grid/grids.py
+++ b/edisgo/grid/grids.py
@@ -275,10 +275,9 @@ class Graph(nx.Graph):
 
         #  speed improved code
 
-        nodes = getattr(self,'_node')
-        nodes = list(map(lambda x: x if nodes[x][attr] == attr_val else None,
-                         nodes.keys()))
-	
+        temp_nodes = getattr(self, 'node')
+        nodes = list(filter(None, map(lambda x: x if temp_nodes[x][attr] == attr_val else None,
+                                      temp_nodes.keys())))
 
         return nodes
 

--- a/edisgo/grid/grids.py
+++ b/edisgo/grid/grids.py
@@ -268,10 +268,17 @@ class Graph(nx.Graph):
         """
 
         # get all nodes that have the attribute 'type' set
-        nodes_attributes = nx.get_node_attributes(self, attr)
+        #nodes_attributes = nx.get_node_attributes(self, attr)
 
         # extract nodes where 'type' == attr_val
-        nodes = [k for k, v in nodes_attributes.items() if v == attr_val]
+        #nodes = [k for k, v in nodes_attributes.items() if v == attr_val]
+
+        #  speed improved code
+
+        nodes = getattr(self,'_node')
+        nodes = list(map(lambda x: x if nodes[x][attr] == attr_val else None,
+                         nodes.keys()))
+	
 
         return nodes
 


### PR DESCRIPTION
Tested 2 things:

- [x] if the function nodes_by_attribute works with ding0 data
- [x] if the function calling nodes_by_by_attribute becomes faster by this speed improvement 

Refer to [speed_test_nodes_by_attribute.ipynb ](https://gist.github.com/boltbeard/03f019f1d382db5c22d4fb930174627c) for checking the results of speed tests using cProfile on nodes_by_attribute. improvements to the overall import procedure can be seen by comparing 
[speed_test_eDisGo_results_dev.txt](https://github.com/openego/eDisGo/files/1562817/speed_test_eDisGo_results_dev.txt) and 
[speed_test_eDisGo_results_fix#53.txt](https://github.com/openego/eDisGo/files/1562821/speed_test_eDisGo_results_fix.53.txt). 
Code used to generate the results check overall speed is at [speed_test_eDisGo.py](https://gist.github.com/boltbeard/07ae2e9838dc16244ffb1e3adbd16f7b)




