### PR TITLE
Fix/#43 speedup process_pfa_results

### DIFF
--- a/doc/whatsnew/v0-0-2.rst
+++ b/doc/whatsnew/v0-0-2.rst
@@ -12,4 +12,5 @@ Changes
   minimal load differences in both parts of the ring.
 * Switch disconnecters are always located in LV stations
   `#23 <https://github.com/openego/eDisGo/issues/23>`_
+* Made all round speed improvemnts as mentioned in the issues `#43 <https://github.com/openego/eDisGo/issues/43>`_
 

--- a/edisgo/tools/pypsa_io.py
+++ b/edisgo/tools/pypsa_io.py
@@ -1186,11 +1186,15 @@ def process_pfa_results(network, pypsa):
     network.results.pfa_p = p0.where(s0 > s1, p1) * 1e3
     network.results.pfa_q = q0.where(s0 > s1, q1) * 1e3
 
-    def voltage_at_lines(row):
-        return (pypsa.buses_t['v_mag_pu'][row['bus0']] +\
-            pypsa.buses_t['v_mag_pu'][row['bus1']]) / 2
+    lines_bus0 = pypsa.lines['bus0'].to_dict()
+    bus0_v_mag_pu = pypsa.buses_t['v_mag_pu'].T.loc[list(lines_bus0.values()), :].copy()
+    bus0_v_mag_pu.index = list(lines_bus0.keys())
 
-    line_voltage_avg = pypsa.lines.apply(voltage_at_lines, axis=1)
+    lines_bus1 = pypsa.lines['bus1'].to_dict()
+    bus1_v_mag_pu = pypsa.buses_t['v_mag_pu'].T.loc[list(lines_bus1.values()), :].copy()
+    bus1_v_mag_pu.index = list(lines_bus1.keys())
+
+    line_voltage_avg = 0.5 * (bus0_v_mag_pu + bus1_v_mag_pu)
 
     # Get voltage levels at line (avg. of buses at both sides)
     network.results._i_res = s0[pypsa.lines_t['q0'].columns].truediv(

--- a/edisgo/tools/pypsa_io.py
+++ b/edisgo/tools/pypsa_io.py
@@ -6,6 +6,7 @@ container.
 
 from edisgo.grid.components import Transformer, Line, LVStation, MVStation
 
+import numpy as np
 import pandas as pd
 from math import pi, sqrt, floor
 from pypsa import Network as PyPSANetwork
@@ -1157,29 +1158,29 @@ def process_pfa_results(network, pypsa):
     # get p and q of lines, LV transformers and MV Station (slack generator)
     # in absolute values
     q0 = pd.concat(
-        [abs(pypsa.lines_t['q0']),
-         abs(pypsa.transformers_t['q0']),
-         abs(pypsa.generators_t['q']['Generator_slack'].rename(
+        [np.abs(pypsa.lines_t['q0']),
+         np.abs(pypsa.transformers_t['q0']),
+         np.abs(pypsa.generators_t['q']['Generator_slack'].rename(
              repr(network.mv_grid.station)))], axis=1)
     q1 = pd.concat(
-        [abs(pypsa.lines_t['q1']),
-         abs(pypsa.transformers_t['q1']),
-         abs(pypsa.generators_t['q']['Generator_slack'].rename(
+        [np.abs(pypsa.lines_t['q1']),
+         np.abs(pypsa.transformers_t['q1']),
+         np.abs(pypsa.generators_t['q']['Generator_slack'].rename(
              repr(network.mv_grid.station)))], axis=1)
     p0 = pd.concat(
-        [abs(pypsa.lines_t['p0']),
-         abs(pypsa.transformers_t['p0']),
-         abs(pypsa.generators_t['p']['Generator_slack'].rename(
+        [np.abs(pypsa.lines_t['p0']),
+         np.abs(pypsa.transformers_t['p0']),
+         np.abs(pypsa.generators_t['p']['Generator_slack'].rename(
             repr(network.mv_grid.station)))], axis=1)
     p1 = pd.concat(
-        [abs(pypsa.lines_t['p1']),
-         abs(pypsa.transformers_t['p1']),
-         abs(pypsa.generators_t['p']['Generator_slack'].rename(
+        [np.abs(pypsa.lines_t['p1']),
+         np.abs(pypsa.transformers_t['p1']),
+         np.abs(pypsa.generators_t['p']['Generator_slack'].rename(
              repr(network.mv_grid.station)))], axis=1)
 
     # determine apparent power and line endings/transformers' side
-    s0 = (p0 ** 2 + q0 ** 2).applymap(sqrt)
-    s1 = (p1 ** 2 + q1 ** 2).applymap(sqrt)
+    s0 = np.hypot(p0, q0)
+    s1 = np.hypot(p1, q1)
 
     # choose p and q from line ending with max(s0,s1)
     network.results.pfa_p = p0.where(s0 > s1, p1) * 1e3


### PR DESCRIPTION
Speed increments in locations that these could be possible, typically using numpy methods rather than built in methods. The speed increments are shown in [eDisGo_issue-43-profiling_results.ipynb](https://gist.github.com/boltbeard/3242b44a0e2855c9aff976376fb53a5e). The overall speed increase is not measured. The speed increase is should make a visible difference based on the profiling results.