### PR TITLE
Add aggregated generators of type solar and wind as GeneratorFluctuating

### DIFF
--- a/edisgo/data/import_data.py
+++ b/edisgo/data/import_data.py
@@ -1605,15 +1605,28 @@ def _import_genos_from_oedb(network):
                 for v_level, val2 in val.items():
                     for type, val3 in val2.items():
                         for subtype, val4 in val3.items():
-                            gen = Generator(
-                                id='agg-' + str(la_id) + '-' + '_'.join([
-                                    str(_) for _ in val4['ids']]),
-                                nominal_capacity=val4['capacity'],
-                                type=type,
-                                subtype=subtype,
-                                geom=network.mv_grid.station.geom,
-                                grid=network.mv_grid,
-                                v_level=4)
+                            if type in ['solar', 'wind']:
+                                gen = GeneratorFluctuating(
+                                    id='agg-' + str(la_id) + '-' + '_'.join([
+                                        str(_) for _ in val4['ids']]),
+                                    grid=network.mv_grid,
+                                    nominal_capacity=val4['capacity'],
+                                    type=type,
+                                    subtype=subtype,
+                                    v_level=4,
+                                    # ToDo: get correct w_id
+                                    weather_cell_id=row['w_id'],
+                                    geom=network.mv_grid.station.geom)
+                            else:
+                                gen = Generator(
+                                    id='agg-' + str(la_id) + '-' + '_'.join([
+                                        str(_) for _ in val4['ids']]),
+                                    nominal_capacity=val4['capacity'],
+                                    type=type,
+                                    subtype=subtype,
+                                    geom=network.mv_grid.station.geom,
+                                    grid=network.mv_grid,
+                                    v_level=4)
 
                             network.mv_grid.graph.add_node(
                                 gen, type='generator_aggr')


### PR DESCRIPTION
@nesnoj I have a question regarding the aggregated generators that are imported in import_generators(). We added the attribute weather cell ID for solar and wind generators and added this when instantiating non-aggregated generators. In the case of aggregated generators I am not sure where to get the weather ID from. Would we also need to aggregate by weather ID?
For now I implemented it using some random weather cell ID of a non-aggregated generator (see line 1618). @maltesc this will fix your weird error for grid 1729 for now, though it is not quite correct yet.