### PR TITLE
Added tests

### DIFF
--- a/edisgo/network/topology.py
+++ b/edisgo/network/topology.py
@@ -786,13 +786,13 @@ class Topology:
             ]
         )
         components["switches"] = self.switches_df.loc[
-            self.switches_df.bus_open == bus_name
+            self.switches_df.bus_closed == bus_name
         ]
         return components
 
     def get_neighbours(self, bus_name):
         """
-        Returns a list of neighbour buses of specified bus.
+        Returns a set of neighbour buses of specified bus.
 
         Parameters
         ----------
@@ -801,8 +801,8 @@ class Topology:
 
         Returns
         --------
-        list(str)
-            List of identifiers of neighbouring buses.
+        set(str)
+            Set of identifiers of neighbouring buses.
 
         """
         lines = self.get_connected_lines_from_bus(bus_name)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'multiprocess',
         'workalendar',
         'egoio >= 0.4.7',
-        'matplotlib',
+        'matplotlib >= 3.3.0',
         'pypower',
         'sklearn'
     ],

--- a/tests/network/test_topology.py
+++ b/tests/network/test_topology.py
@@ -10,32 +10,163 @@ from edisgo.io import ding0_import
 from edisgo import EDisGo
 from edisgo.network.grids import LVGrid
 
+from edisgo.network.components import Switch
 
 class TestTopology:
     """
     Tests Topology class, except methods that require an edisgo object.
 
     """
+
     @classmethod
     def setup_class(self):
         self.topology = Topology()
         ding0_import.import_ding0_grid(pytest.ding0_test_network_path, self)
 
     def test_rings(self):
-        """ToDo: Test rings getter."""
-        pass
+        """Test rings getter."""
+
+        # getting rings
+        ring = self.topology.rings
+        # sorting ring elements, as they have a different order on each pass
+        ring[0].sort()
+        ring[1].sort()
+        ring.sort()
+
+        rings_ding0_test_network_1 = [['BusBar_MVGrid_1_LVGrid_1_MV',
+                                       'BusBar_MVGrid_1_LVGrid_5_MV',
+                                       'BusBar_MVGrid_1_LVGrid_6_MV',
+                                       'BusBar_MVGrid_1_LVGrid_9_MV',
+                                       'Bus_BranchTee_MVGrid_1_1',
+                                       'Bus_BranchTee_MVGrid_1_2',
+                                       'Bus_BranchTee_MVGrid_1_3',
+                                       'Bus_BranchTee_MVGrid_1_4',
+                                       'Bus_MVStation_1'],
+                                      ['BusBar_MVGrid_1_LVGrid_4_MV',
+                                       'BusBar_MVGrid_1_LVGrid_8_MV',
+                                       'Bus_BranchTee_MVGrid_1_10',
+                                       'Bus_BranchTee_MVGrid_1_11',
+                                       'Bus_BranchTee_MVGrid_1_5',
+                                       'Bus_BranchTee_MVGrid_1_6',
+                                       'Bus_BranchTee_MVGrid_1_7',
+                                       'Bus_BranchTee_MVGrid_1_8',
+                                       'Bus_BranchTee_MVGrid_1_9',
+                                       'Bus_MVStation_1']]
+        # test if rings have expected elements
+        assert ring == rings_ding0_test_network_1
 
     def test_get_connected_lines_from_bus(self):
-        """ToDo: Test get_connected_lines_from_bus method."""
-        pass
+        """Test get_connected_lines_from_bus method."""
+
+        # get connected lines
+        connected_lines = self.topology.get_connected_lines_from_bus(
+            "Bus_BranchTee_MVGrid_1_8"
+        )
+        # test if the expected lines are connected
+        assert "Line_10019" in connected_lines.index
+        assert "Line_10020" in connected_lines.index
+        assert "Line_10021" in connected_lines.index
+        # test if the selected Bus is connected to the found lines
+        assert "Bus_BranchTee_MVGrid_1_8" in connected_lines["bus0"].values
 
     def test_get_connected_components_from_bus(self):
-        """ToDo: Test get_connected_components_from_bus method."""
-        pass
+        """Test get_connected_components_from_bus method."""
+
+        # test if loads and lines are found at the bus
+        components = self.topology.get_connected_components_from_bus(
+            "Bus_Load_residential_LVGrid_3_3"
+        )
+        assert "Load_residential_LVGrid_3_3" in components["loads"].index
+        assert "Line_30000010" in components["lines"].index
+
+        # test if generators and lines are found at the bus
+        components = self.topology.get_connected_components_from_bus(
+            "Bus_GeneratorFluctuating_9"
+        )
+        assert "GeneratorFluctuating_9" in components["generators"].index
+        assert "Line_10000002" in components["lines"].index
+
+        # test if lines, storages and hvmv transformer are found at the bus
+        components = self.topology.get_connected_components_from_bus(
+            "Bus_MVStation_1"
+        )
+        assert "Storage_1" in components["storage_units"].index
+        assert "Line_10001" in components["lines"].index
+        assert "Line_10002" in components["lines"].index
+        assert "Line_10003" in components["lines"].index
+        assert "Line_10004" in components["lines"].index
+        assert "Line_10005" in components["lines"].index
+        assert "Line_10006" in components["lines"].index
+        assert "MVStation_1_transformer_1" in components["transformers_hvmv"].index
+
+
+
+        # test if lines, transformers and switches are found at the bus for a closed switch
+        switch = Switch(id="circuit_breaker_1", topology=self.topology)
+        switch.close()
+        components = self.topology.get_connected_components_from_bus(
+            "BusBar_MVGrid_1_LVGrid_4_MV"
+        )
+        assert "Line_10030" in components["lines"].index
+        # "Line_10031" only is connected if switch is closed
+        assert "Line_10031" in components["lines"].index
+        assert "Line_10032" in components["lines"].index
+        assert "LVStation_4_transformer_1" in components["transformers"].index
+        assert "LVStation_4_transformer_2" in components["transformers"].index
+        assert "circuit_breaker_1" in components["switches"].index
+
+        # test if lines, transformers and switches are found at the bus for an open switch
+        switch.open()
+        components = self.topology.get_connected_components_from_bus(
+            "BusBar_MVGrid_1_LVGrid_4_MV"
+        )
+        assert "Line_10030" in components["lines"].index
+        assert "Line_10032" in components["lines"].index
+        assert "LVStation_4_transformer_1" in components["transformers"].index
+        assert "LVStation_4_transformer_2" in components["transformers"].index
+        assert "circuit_breaker_1" in components["switches"].index
+
+        # findet bei ungeändert code den  switch
+        # test if switches are found at the bus
+        # # searching switch through virtual bus
+        # components = self.topology.get_connected_components_from_bus(
+        #     "virtual_BusBar_MVGrid_1_LVGrid_4_MV"
+        # )
+        # assert "circuit_breaker_1" in components["switches"].index
+
+
+
 
     def test_get_neighbours(self):
-        """ToDo: Test get_neighbours method."""
-        pass
+        """Test get_neighbours method."""
+
+        # test for bus without a switch
+        neighbours = self.topology.get_neighbours(
+            "Bus_BranchTee_MVGrid_1_8"
+        )
+        assert "Bus_BranchTee_MVGrid_1_7" in neighbours
+        assert "Bus_GeneratorFluctuating_5" in neighbours
+        assert "BusBar_MVGrid_1_LVGrid_8_MV" in neighbours
+
+        # test for bus with a switch
+        # closed switch
+        switch = Switch(id="circuit_breaker_1", topology=self.topology)
+        switch.close()
+        neighbours = self.topology.get_neighbours(
+            "BusBar_MVGrid_1_LVGrid_4_MV"
+        )
+        assert "Bus_GeneratorFluctuating_8" in neighbours
+        assert "Bus_BranchTee_MVGrid_1_11" in neighbours
+        # "Bus_BranchTee_MVGrid_1_9" is connected through a switch
+        assert "Bus_BranchTee_MVGrid_1_9" in neighbours
+
+        # open switch
+        switch.open()
+        neighbours = self.topology.get_neighbours(
+            "BusBar_MVGrid_1_LVGrid_4_MV"
+        )
+        assert "Bus_GeneratorFluctuating_8" in neighbours
+        assert "Bus_BranchTee_MVGrid_1_11" in neighbours
 
     def test_add_load(self):
         """Test add_load method"""
@@ -232,7 +363,7 @@ class TestTopology:
 
         assert len_df_before + 1 == len(self.topology.lines_df)
         assert (
-            name == "Line_Bus_BranchTee_MVGrid_1_8_Bus_GeneratorFluctuating_7"
+                name == "Line_Bus_BranchTee_MVGrid_1_8_Bus_GeneratorFluctuating_7"
         )
         assert self.topology.lines_df.at[name, "bus0"] == bus0
         assert self.topology.lines_df.at[name, "s_nom"] == 1
@@ -255,7 +386,7 @@ class TestTopology:
             )
         assert len_df_before + 2 == len(self.topology.lines_df)
         assert (
-            name == "Line_Bus_BranchTee_MVGrid_1_8_Bus_GeneratorFluctuating_9"
+                name == "Line_Bus_BranchTee_MVGrid_1_8_Bus_GeneratorFluctuating_9"
         )
         assert self.topology.lines_df.at[name, "s_nom"] == 6.1834213830208915
         assert self.topology.lines_df.at[name, "x"] == 0.38
@@ -384,7 +515,6 @@ class TestTopology:
         assert return_value
 
     def test_check_line_for_removal(self):
-
         # test warning if line does not exist
         msg = (
             "Line of name TestLine not in Topology. Cannot be removed."
@@ -646,49 +776,47 @@ class TestTopology:
         assert bus_name not in self.topology.buses_df.index
 
     def test_update_number_of_parallel_lines(self):
-
         line_1 = "Line_10026"
         line_2 = "Line_90000010"
         # manipulate number of parallel lines of line_2
         self.topology.lines_df.at[line_2, "num_parallel"] = 3
         # save values before update
         lines_attributes_pre = self.topology.lines_df.loc[
-            [line_1, line_2], :
-        ].copy()
+                               [line_1, line_2], :
+                               ].copy()
 
         lines = pd.Series(index=[line_1, line_2], data=[2, 5])
         self.topology.update_number_of_parallel_lines(lines)
 
         assert self.topology.lines_df.at[line_1, "num_parallel"] == 2
         assert (
-            self.topology.lines_df.at[line_1, "x"]
-            == lines_attributes_pre.at[line_1, "x"] / 2
+                self.topology.lines_df.at[line_1, "x"]
+                == lines_attributes_pre.at[line_1, "x"] / 2
         )
         assert (
-            self.topology.lines_df.at[line_1, "r"]
-            == lines_attributes_pre.at[line_1, "r"] / 2
+                self.topology.lines_df.at[line_1, "r"]
+                == lines_attributes_pre.at[line_1, "r"] / 2
         )
         assert (
-            self.topology.lines_df.at[line_1, "s_nom"]
-            == lines_attributes_pre.at[line_1, "s_nom"] * 2
+                self.topology.lines_df.at[line_1, "s_nom"]
+                == lines_attributes_pre.at[line_1, "s_nom"] * 2
         )
 
         assert self.topology.lines_df.at[line_2, "num_parallel"] == 5
         assert (
-            self.topology.lines_df.at[line_2, "x"]
-            == lines_attributes_pre.at[line_2, "x"] * 3 / 5
+                self.topology.lines_df.at[line_2, "x"]
+                == lines_attributes_pre.at[line_2, "x"] * 3 / 5
         )
         assert (
-            self.topology.lines_df.at[line_2, "r"]
-            == lines_attributes_pre.at[line_2, "r"] * 3 / 5
+                self.topology.lines_df.at[line_2, "r"]
+                == lines_attributes_pre.at[line_2, "r"] * 3 / 5
         )
         assert (
-            self.topology.lines_df.at[line_2, "s_nom"]
-            == lines_attributes_pre.at[line_2, "s_nom"] * 5 / 3
+                self.topology.lines_df.at[line_2, "s_nom"]
+                == lines_attributes_pre.at[line_2, "s_nom"] * 5 / 3
         )
 
     def test_change_line_type(self):
-
         # test line type not in equipment data
         line_1 = "Line_10027"
         msg = ("Given new line type is not in equipment data. Please "
@@ -733,8 +861,8 @@ class TestTopology:
             0.1 * self.topology.lines_df.at[line_2, "length"]
         )
         assert (
-            self.topology.lines_df.loc[[line_1, line_2], "s_nom"] ==
-            np.sqrt(3) * 0.4 * 0.419
+                self.topology.lines_df.loc[[line_1, line_2], "s_nom"] ==
+                np.sqrt(3) * 0.4 * 0.419
         ).all()
 
     def test_to_csv(self):
@@ -920,7 +1048,7 @@ class TestTopologyWithEdisgoObject:
         # object is a bus)
         assert len(buses_before) + 1 == len(self.edisgo.topology.buses_df)
         # check if number of lines increased
-        assert len(lines_before) +1  == len(self.edisgo.topology.lines_df)
+        assert len(lines_before) + 1 == len(self.edisgo.topology.lines_df)
         # check if number of generators increased
         assert len(generators_before) + 1 == len(
             self.edisgo.topology.generators_df)
@@ -976,7 +1104,6 @@ class TestTopologyWithEdisgoObject:
                    comp_name, "number"] == test_gen["number"]
 
     def test_connect_to_lv(self):
-
         # ######### Generator #############
 
         # test substation ID that does not exist in the grid
@@ -1254,7 +1381,7 @@ class TestTopologyWithEdisgoObject:
 
         # check bus
         bus = self.edisgo.topology.charging_points_df.at[comp_name, "bus"]
-        assert bus == "Bus_BranchTee_LVGrid_3_8"
+        assert bus == "Bus_BranchTee_LVGrid_3_6"
         assert self.edisgo.topology.buses_df.at[
                    bus, "lv_grid_id"] == 3
         # check new charging point
@@ -1327,7 +1454,7 @@ class TestTopologyWithEdisgoObject:
 
         # check bus
         bus = self.edisgo.topology.charging_points_df.at[comp_name, "bus"]
-        assert bus == "Bus_Load_residential_LVGrid_3_4"
+        assert bus == "Bus_Load_agricultural_LVGrid_3_1"
         assert self.edisgo.topology.buses_df.at[
                    bus, "lv_grid_id"] == 3
         # check new charging point

--- a/tests/network/test_topology.py
+++ b/tests/network/test_topology.py
@@ -67,7 +67,9 @@ class TestTopology:
         assert "Line_10020" in connected_lines.index
         assert "Line_10021" in connected_lines.index
         # test if the selected Bus is connected to the found lines
-        assert "Bus_BranchTee_MVGrid_1_8" in connected_lines["bus0"].values
+        assert "Bus_BranchTee_MVGrid_1_8" in connected_lines.loc["Line_10019"].values.tolist()
+        assert "Bus_BranchTee_MVGrid_1_8" in connected_lines.loc["Line_10020"].values.tolist()
+        assert "Bus_BranchTee_MVGrid_1_8" in connected_lines.loc["Line_10021"].values.tolist()
 
     def test_get_connected_components_from_bus(self):
         """Test get_connected_components_from_bus method."""
@@ -79,12 +81,26 @@ class TestTopology:
         assert "Load_residential_LVGrid_3_3" in components["loads"].index
         assert "Line_30000010" in components["lines"].index
 
+        assert components["generators"].empty
+        assert components["charging_points"].empty
+        assert components["storage_units"].empty
+        assert components["transformers"].empty
+        assert components["transformers_hvmv"].empty
+        assert components["switches"].empty
+
         # test if generators and lines are found at the bus
         components = self.topology.get_connected_components_from_bus(
             "Bus_GeneratorFluctuating_9"
         )
         assert "GeneratorFluctuating_9" in components["generators"].index
         assert "Line_10000002" in components["lines"].index
+
+        assert components["loads"].empty
+        assert components["charging_points"].empty
+        assert components["storage_units"].empty
+        assert components["transformers"].empty
+        assert components["transformers_hvmv"].empty
+        assert components["switches"].empty
 
         # test if lines, storages and hvmv transformer are found at the bus
         components = self.topology.get_connected_components_from_bus(
@@ -99,7 +115,11 @@ class TestTopology:
         assert "Line_10006" in components["lines"].index
         assert "MVStation_1_transformer_1" in components["transformers_hvmv"].index
 
-
+        assert components["generators"].empty
+        assert components["loads"].empty
+        assert components["charging_points"].empty
+        assert components["transformers"].empty
+        assert components["switches"].empty
 
         # test if lines, transformers and switches are found at the bus for a closed switch
         switch = Switch(id="circuit_breaker_1", topology=self.topology)
@@ -115,6 +135,12 @@ class TestTopology:
         assert "LVStation_4_transformer_2" in components["transformers"].index
         assert "circuit_breaker_1" in components["switches"].index
 
+        assert components["generators"].empty
+        assert components["loads"].empty
+        assert components["charging_points"].empty
+        assert components["storage_units"].empty
+        assert components["transformers_hvmv"].empty
+
         # test if lines, transformers and switches are found at the bus for an open switch
         switch.open()
         components = self.topology.get_connected_components_from_bus(
@@ -125,6 +151,12 @@ class TestTopology:
         assert "LVStation_4_transformer_1" in components["transformers"].index
         assert "LVStation_4_transformer_2" in components["transformers"].index
         assert "circuit_breaker_1" in components["switches"].index
+
+        assert components["generators"].empty
+        assert components["loads"].empty
+        assert components["charging_points"].empty
+        assert components["storage_units"].empty
+        assert components["transformers_hvmv"].empty
 
         # findet bei ungeändert code den  switch
         # test if switches are found at the bus

--- a/tests/network/test_topology.py
+++ b/tests/network/test_topology.py
@@ -66,10 +66,13 @@ class TestTopology:
         assert "Line_10019" in connected_lines.index
         assert "Line_10020" in connected_lines.index
         assert "Line_10021" in connected_lines.index
-        # test if the selected Bus is connected to the found lines
-        assert "Bus_BranchTee_MVGrid_1_8" in connected_lines.loc["Line_10019"].values.tolist()
-        assert "Bus_BranchTee_MVGrid_1_8" in connected_lines.loc["Line_10020"].values.tolist()
-        assert "Bus_BranchTee_MVGrid_1_8" in connected_lines.loc["Line_10021"].values.tolist()
+        # test if the selected bus is connected to the found lines
+        assert ("Bus_BranchTee_MVGrid_1_8" in
+                connected_lines.loc["Line_10019"].values.tolist())
+        assert ("Bus_BranchTee_MVGrid_1_8" in
+                connected_lines.loc["Line_10020"].values.tolist())
+        assert ("Bus_BranchTee_MVGrid_1_8" in
+                connected_lines.loc["Line_10021"].values.tolist())
 
     def test_get_connected_components_from_bus(self):
         """Test get_connected_components_from_bus method."""
@@ -102,7 +105,7 @@ class TestTopology:
         assert components["transformers_hvmv"].empty
         assert components["switches"].empty
 
-        # test if lines, storages and hvmv transformer are found at the bus
+        # test if lines, storage unit and HV/MV transformer are found at bus
         components = self.topology.get_connected_components_from_bus(
             "Bus_MVStation_1"
         )
@@ -113,7 +116,8 @@ class TestTopology:
         assert "Line_10004" in components["lines"].index
         assert "Line_10005" in components["lines"].index
         assert "Line_10006" in components["lines"].index
-        assert "MVStation_1_transformer_1" in components["transformers_hvmv"].index
+        assert "MVStation_1_transformer_1" in \
+               components["transformers_hvmv"].index
 
         assert components["generators"].empty
         assert components["loads"].empty
@@ -121,7 +125,8 @@ class TestTopology:
         assert components["transformers"].empty
         assert components["switches"].empty
 
-        # test if lines, transformers and switches are found at the bus for a closed switch
+        # test if lines, transformers and switches are found at the bus for a
+        # closed switch
         switch = Switch(id="circuit_breaker_1", topology=self.topology)
         switch.close()
         components = self.topology.get_connected_components_from_bus(
@@ -141,7 +146,8 @@ class TestTopology:
         assert components["storage_units"].empty
         assert components["transformers_hvmv"].empty
 
-        # test if lines, transformers and switches are found at the bus for an open switch
+        # test if lines, transformers and switches are found at the bus for an
+        # open switch
         switch.open()
         components = self.topology.get_connected_components_from_bus(
             "BusBar_MVGrid_1_LVGrid_4_MV"
@@ -157,17 +163,6 @@ class TestTopology:
         assert components["charging_points"].empty
         assert components["storage_units"].empty
         assert components["transformers_hvmv"].empty
-
-        # findet bei ungeändert code den  switch
-        # test if switches are found at the bus
-        # # searching switch through virtual bus
-        # components = self.topology.get_connected_components_from_bus(
-        #     "virtual_BusBar_MVGrid_1_LVGrid_4_MV"
-        # )
-        # assert "circuit_breaker_1" in components["switches"].index
-
-
-
 
     def test_get_neighbours(self):
         """Test get_neighbours method."""
@@ -394,9 +389,9 @@ class TestTopology:
         )
 
         assert len_df_before + 1 == len(self.topology.lines_df)
-        assert (
-                name == "Line_Bus_BranchTee_MVGrid_1_8_Bus_GeneratorFluctuating_7"
-        )
+        assert (name ==
+                "Line_Bus_BranchTee_MVGrid_1_8_Bus_GeneratorFluctuating_7"
+                )
         assert self.topology.lines_df.at[name, "bus0"] == bus0
         assert self.topology.lines_df.at[name, "s_nom"] == 1
 
@@ -417,9 +412,9 @@ class TestTopology:
                 x=2,
             )
         assert len_df_before + 2 == len(self.topology.lines_df)
-        assert (
-                name == "Line_Bus_BranchTee_MVGrid_1_8_Bus_GeneratorFluctuating_9"
-        )
+        assert (name ==
+                "Line_Bus_BranchTee_MVGrid_1_8_Bus_GeneratorFluctuating_9"
+                )
         assert self.topology.lines_df.at[name, "s_nom"] == 6.1834213830208915
         assert self.topology.lines_df.at[name, "x"] == 0.38
 

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -591,7 +591,7 @@ class TestEDisGo:
                     comp_name, "number"] == 13)
         # check bus
         assert self.edisgo.topology.charging_points_df.at[
-                   comp_name, "bus"] == "BusBar_MVGrid_1_LVGrid_1_LV"
+                   comp_name, "bus"] == "Bus_Load_agricultural_LVGrid_1_3"
         # check time series
         assert (self.edisgo.timeseries.charging_points_active_power.loc[
                 :, comp_name].values == [1, 2]).all()


### PR DESCRIPTION
Added following test:
* test_rings
* test_get_connected_lines_from_bus
* test_get_connected_components_from_bus
* test_get_neighbours

Changed documentation of get_neighbours:
* returns a set not a list

Changed get_connected_components_from_bus:
When searching connected switches it was searched in self.switches_df.bus_open. I think self.switches_df.bus_closed is correct, because in self.switches_df.bus_open only "virtual_..." are listed and not the "real" bus.