### PR TITLE
Bugfix relative loading scale and dashplot

### DIFF
--- a/edisgo/tools/plots.py
+++ b/edisgo/tools/plots.py
@@ -1220,7 +1220,7 @@ def plot_plotly(
                 loading = s_res.loc[branch_name]
                 s_nom = edisgo_obj.topology.lines_df.s_nom.loc[branch_name]
                 color = color_map_color(
-                    loading / s_nom,
+                    loading / s_nom * 0.9,
                     vmin=color_min,
                     vmax=color_max,
                     cmap_name=colorscale,
@@ -2085,7 +2085,7 @@ def plot_dash_app(
                         ].index
                     selected_timesteps = list(map(str, selected_timesteps))
             elif timestep_mode == "All":
-                selected_timesteps = False
+                selected_timesteps = None
 
             app.logger.debug(f"selected_timesteps={selected_timesteps}")
 


### PR DESCRIPTION
# Description

I fixed a bug in the plotly_plot relative loading coloring and in the dash plot when a single edisgo object and all time steps are selected.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
