### PR TITLE
Disable fail-fast in automated tests

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ '3.7', '3.8', '3.9' ]
     steps:


### PR DESCRIPTION
# Description

Disable fail-fast in automated tests. This gives the opportunity to check if tests fail for every version.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
