### PR TITLE
Fixes failing windows tests

### DIFF
--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -1294,6 +1294,7 @@ class TestEDisGo:
 
         zip = ZipFile(zip_file)
         files = zip.namelist()
+        zip.close()
         assert len(files) == 24
 
         os.remove(zip_file)


### PR DESCRIPTION
# Description

Fixes failing windows tests which were inflicted by not properly closing a zip file.

- Solved through: Close file before removing to prevent permission error under windows