### PR TITLE
Features/save flex bands

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -2074,7 +2074,7 @@ class EDisGo:
             Specifies which electromobility attributes to store. By default this is set
             to None, in which case all attributes are stored.
             See function docstring `attributes` parameter in
-            :func:`~.network.electromobility.Electromobility.to_csv` for more
+            :attr:`~.network.electromobility.Electromobility.to_csv` for more
             information.
         archive : bool, optional
             Save disk storage capacity by archiving the csv files. The

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -2070,6 +2070,12 @@ class EDisGo:
             To only store certain results provide a dictionary. See function docstring
             `parameters` parameter in :func:`~.network.results.Results.to_csv`
             for more information.
+        electromobility_attributes : None or list(str)
+            Specifies which electromobility attributes to store. By default this is set
+            to None, in which case all attributes are stored.
+            See function docstring `attributes` parameter in
+            :func:`~.network.electromobility.Electromobility.to_csv` for more
+            information.
         archive : bool, optional
             Save disk storage capacity by archiving the csv files. The
             archiving takes place after the generation of the CSVs and
@@ -2102,7 +2108,10 @@ class EDisGo:
             )
 
         if save_electromobility:
-            self.electromobility.to_csv(os.path.join(directory, "electromobility"))
+            self.electromobility.to_csv(
+                os.path.join(directory, "electromobility"),
+                attributes=kwargs.get("electromobility_attributes", None),
+            )
 
         # save configs
         self.config.to_json(directory)

--- a/edisgo/network/electromobility.py
+++ b/edisgo/network/electromobility.py
@@ -489,7 +489,7 @@ class Electromobility:
 
     def to_csv(self, directory):
         """
-        Exports electromobility to csv files.
+        Exports electromobility data to csv files.
 
         The following attributes are exported:
 
@@ -511,7 +511,7 @@ class Electromobility:
         Parameters
         ----------
         directory : str
-            Path to save electromobility to.
+            Path to save electromobility data to.
 
         """
         os.makedirs(directory, exist_ok=True)
@@ -683,7 +683,8 @@ def _get_matching_dict_of_attributes_and_file_names():
     restore and maps them to the file name.
 
     Is used in functions
-    :attr:`~.network.electromobility.Electromobility.from_csv`.
+    :attr:`~.network.electromobility.Electromobility.from_csv` and
+    attr:`~.network.electromobility.Electromobility.to_csv`.
 
     Returns
     -------

--- a/edisgo/network/electromobility.py
+++ b/edisgo/network/electromobility.py
@@ -503,6 +503,10 @@ class Electromobility:
           `integrated_charging_parks.csv`.
         * 'simbev_config_df' : Attribute :py:attr:`~simbev_config_df` is
           saved to `simbev_config.csv`.
+        * 'flexibility_bands' : The three flexibility bands in attribute
+          :py:attr:`~flexibility_bands` are saved to
+          `flexibility_band_upper_power.csv`, `flexibility_band_lower_energy.csv`, and
+          `flexibility_band_upper_energy.csv`.
 
         Parameters
         ----------
@@ -516,10 +520,15 @@ class Electromobility:
 
         for attr, file in attrs.items():
             df = getattr(self, attr)
-
-            if not df.empty:
-                path = os.path.join(directory, file)
-                df.to_csv(path)
+            if attr == "flexibility_bands":
+                for band in ["upper_power", "lower_energy", "upper_energy"]:
+                    if not df[band].empty:
+                        path = os.path.join(directory, file.format(band))
+                        df[band].to_csv(path)
+            else:
+                if not df.empty:
+                    path = os.path.join(directory, file)
+                    df.to_csv(path)
 
     def from_csv(self, data_path, edisgo_obj, from_zip_archive=False):
         """
@@ -688,6 +697,7 @@ def _get_matching_dict_of_attributes_and_file_names():
         "potential_charging_parks_gdf": "potential_charging_parks.csv",
         "integrated_charging_parks_df": "integrated_charging_parks.csv",
         "simbev_config_df": "metadata_simbev_run.csv",
+        "flexibility_bands": "flexibility_band_{}.csv",
     }
 
     return emob_dict

--- a/edisgo/network/electromobility.py
+++ b/edisgo/network/electromobility.py
@@ -487,11 +487,11 @@ class Electromobility:
         self.flexibility_bands = flex_band_dict
         return flex_band_dict
 
-    def to_csv(self, directory):
+    def to_csv(self, directory, attributes=None):
         """
         Exports electromobility data to csv files.
 
-        The following attributes are exported:
+        The following attributes can be exported:
 
         * 'charging_processes_df' : Attribute :py:attr:`~charging_processes_df`
           is saved to `charging_processes.csv`.
@@ -512,13 +512,20 @@ class Electromobility:
         ----------
         directory : str
             Path to save electromobility data to.
+        attributes : list(str) or None
+            List of attributes to export. See above for attributes that can be exported.
+            If None, all specified attributes are exported. Default: None.
 
         """
         os.makedirs(directory, exist_ok=True)
 
-        attrs = _get_matching_dict_of_attributes_and_file_names()
+        attrs_file_names = _get_matching_dict_of_attributes_and_file_names()
 
-        for attr, file in attrs.items():
+        if attributes is None:
+            attributes = list(attrs_file_names.keys())
+
+        for attr in attributes:
+            file = attrs_file_names[attr]
             df = getattr(self, attr)
             if attr == "flexibility_bands":
                 for band in file.keys():

--- a/edisgo/network/electromobility.py
+++ b/edisgo/network/electromobility.py
@@ -319,10 +319,46 @@ class Electromobility:
         except Exception:
             return None
 
+    @property
+    def flexibility_bands(self):
+        """
+        Dictionary with flexibility bands (lower and upper energy band as well as
+        upper power band).
+
+        Parameters
+        -----------
+        flex_dict : dict(str, :pandas:`pandas.DataFrame<DataFrame>`)
+            Keys are 'upper_power', 'lower_energy' and 'upper_energy'.
+            Values are dataframes containing the corresponding band per each charging
+            point. Columns of the dataframe are the charging point names as in
+            :attr:`~.network.topology.Topology.loads_df`. Index is a time index.
+
+        Returns
+        -------
+        dict(str, :pandas:`pandas.DataFrame<DataFrame>`)
+            See input parameter `flex_dict` for more information on the dictionary.
+
+        """
+        try:
+            return self._flexibility_bands
+        except Exception:
+            return {
+                "upper_power": pd.DataFrame(),
+                "lower_energy": pd.DataFrame(),
+                "upper_energy": pd.DataFrame(),
+            }
+
+    @flexibility_bands.setter
+    def flexibility_bands(self, flex_dict):
+        self._flexibility_bands = flex_dict
+
     def get_flexibility_bands(self, edisgo_obj, use_case):
         """
         Method to determine flexibility bands (lower and upper energy band as well as
         upper power band).
+
+        Besides being returned by this function, flexibility bands are written to
+        :attr:`flexibility_bands`.
 
         Parameters
         -----------
@@ -442,11 +478,14 @@ class Electromobility:
         upper_power = _shorten_and_set_index(upper_power)
         lower_energy = _shorten_and_set_index(lower_energy)
         upper_energy = _shorten_and_set_index(upper_energy)
-        return {
+
+        flex_band_dict = {
             "upper_power": upper_power,
             "lower_energy": lower_energy,
             "upper_energy": upper_energy,
         }
+        self.flexibility_bands = flex_band_dict
+        return flex_band_dict
 
     def to_csv(self, directory):
         """

--- a/edisgo/network/electromobility.py
+++ b/edisgo/network/electromobility.py
@@ -521,9 +521,9 @@ class Electromobility:
         for attr, file in attrs.items():
             df = getattr(self, attr)
             if attr == "flexibility_bands":
-                for band in ["upper_power", "lower_energy", "upper_energy"]:
-                    if not df[band].empty:
-                        path = os.path.join(directory, file.format(band))
+                for band in file.keys():
+                    if band in df.keys() and not df[band].empty:
+                        path = os.path.join(directory, file[band])
                         df[band].to_csv(path)
             else:
                 if not df.empty:
@@ -698,7 +698,11 @@ def _get_matching_dict_of_attributes_and_file_names():
         "potential_charging_parks_gdf": "potential_charging_parks.csv",
         "integrated_charging_parks_df": "integrated_charging_parks.csv",
         "simbev_config_df": "metadata_simbev_run.csv",
-        "flexibility_bands": "flexibility_band_{}.csv",
+        "flexibility_bands": {
+            "upper_power": "flexibility_band_upper_power.csv",
+            "lower_energy": "flexibility_band_lower_energy.csv",
+            "upper_energy": "flexibility_band_upper_energy.csv",
+        },
     }
 
     return emob_dict

--- a/tests/network/test_electromobility.py
+++ b/tests/network/test_electromobility.py
@@ -70,12 +70,25 @@ class TestElectromobility:
             "lower_energy": pd.DataFrame({"cp_1": [1, 2]}, index=timeindex),
         }
         self.edisgo_obj.electromobility.flexibility_bands = flex_bands
+
+        # ############ test with default values #####################
         self.edisgo_obj.electromobility.to_csv(dir)
 
         saved_files = os.listdir(dir)
         assert len(saved_files) == 6
         assert "charging_processes.csv" in saved_files
         assert "flexibility_band_upper_power.csv" in saved_files
+
+        shutil.rmtree(dir)
+
+        # ############ test specifying attributes #####################
+        self.edisgo_obj.electromobility.to_csv(
+            dir, attributes=["potential_charging_parks_gdf"]
+        )
+
+        saved_files = os.listdir(dir)
+        assert len(saved_files) == 1
+        assert "potential_charging_parks.csv" in saved_files
 
         shutil.rmtree(dir)
 

--- a/tests/network/test_electromobility.py
+++ b/tests/network/test_electromobility.py
@@ -5,6 +5,8 @@ import geopandas as gpd
 import pandas as pd
 import pytest
 
+from pandas.util.testing import assert_frame_equal
+
 from edisgo.edisgo import EDisGo
 from edisgo.io.electromobility_import import (
     import_electromobility,
@@ -61,11 +63,19 @@ class TestElectromobility:
     def test_to_csv(self):
         """Test for method to_csv."""
         dir = os.path.join(os.getcwd(), "electromobility")
+        timeindex = pd.date_range("1/1/1970", periods=2, freq="H")
+        flex_bands = {
+            "upper_energy": pd.DataFrame({"cp_1": [1, 2]}, index=timeindex),
+            "upper_power": pd.DataFrame({"cp_1": [1, 2]}, index=timeindex),
+            "lower_energy": pd.DataFrame({"cp_1": [1, 2]}, index=timeindex),
+        }
+        self.edisgo_obj.electromobility.flexibility_bands = flex_bands
         self.edisgo_obj.electromobility.to_csv(dir)
 
         saved_files = os.listdir(dir)
-        assert len(saved_files) == 3
+        assert len(saved_files) == 6
         assert "charging_processes.csv" in saved_files
+        assert "flexibility_band_upper_power.csv" in saved_files
 
         shutil.rmtree(dir)
 
@@ -75,9 +85,16 @@ class TestElectromobility:
 
         """
         dir = os.path.join(os.getcwd(), "electromobility")
+        timeindex = pd.date_range("1/1/1970", periods=2, freq="H")
+        flex_bands = {
+            "upper_energy": pd.DataFrame({"cp_1": [1, 2]}, index=timeindex),
+            "upper_power": pd.DataFrame({"cp_1": [1, 2]}, index=timeindex),
+            "lower_energy": pd.DataFrame({"cp_1": [1, 2]}, index=timeindex),
+        }
+        self.edisgo_obj.electromobility.flexibility_bands = flex_bands
         self.edisgo_obj.electromobility.to_csv(dir)
 
-        # reset self.topology
+        # reset Electromobility
         self.edisgo_obj.electromobility = Electromobility()
 
         self.edisgo_obj.electromobility.from_csv(dir, self.edisgo_obj)
@@ -85,5 +102,21 @@ class TestElectromobility:
         assert len(self.edisgo_obj.electromobility.charging_processes_df) == 48
         assert len(self.edisgo_obj.electromobility.potential_charging_parks_gdf) == 1621
         assert self.edisgo_obj.electromobility.integrated_charging_parks_df.empty
+
+        assert_frame_equal(
+            self.edisgo_obj.electromobility.flexibility_bands["upper_energy"],
+            flex_bands["upper_energy"],
+            check_freq=False,
+        )
+        assert_frame_equal(
+            self.edisgo_obj.electromobility.flexibility_bands["lower_energy"],
+            flex_bands["lower_energy"],
+            check_freq=False,
+        )
+        assert_frame_equal(
+            self.edisgo_obj.electromobility.flexibility_bands["upper_power"],
+            flex_bands["upper_power"],
+            check_freq=False,
+        )
 
         shutil.rmtree(dir)

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -1502,6 +1502,15 @@ class TestEDisGoFunc:
             },
             index=[0, 1],
         )
+        flex_bands = {
+            "upper_energy": pd.DataFrame(
+                {"cp_1": [1, 2]}, index=edisgo_obj.timeseries.timeindex[0:2]
+            ),
+            "upper_power": pd.DataFrame(
+                {"cp_1": [1, 2]}, index=edisgo_obj.timeseries.timeindex[0:2]
+            ),
+        }
+        edisgo_obj.electromobility.flexibility_bands = flex_bands
 
         # ######################## test with default ########################
         edisgo_obj.save(
@@ -1540,11 +1549,15 @@ class TestEDisGoFunc:
         # delete directory
         shutil.rmtree(save_dir)
 
-        # ############ test with loading time series and results from zip ############
-        edisgo_obj.save(save_dir, archive=True)
+        # ########### test with loading time series, results, emob from zip ###########
+        edisgo_obj.save(save_dir, archive=True, save_electromobility=True)
         zip_file = f"{save_dir}.zip"
         edisgo_obj_loaded = import_edisgo_from_files(
-            zip_file, import_results=True, import_timeseries=True, from_zip_archive=True
+            zip_file,
+            import_results=True,
+            import_timeseries=True,
+            import_electromobility=True,
+            from_zip_archive=True,
         )
 
         # check topology
@@ -1562,6 +1575,16 @@ class TestEDisGoFunc:
         # check results
         assert_frame_equal(
             edisgo_obj_loaded.results.i_res, edisgo_obj.results.i_res, check_freq=False
+        )
+        # check electromobility
+        assert_frame_equal(
+            edisgo_obj_loaded.electromobility.flexibility_bands["upper_energy"],
+            edisgo_obj.electromobility.flexibility_bands["upper_energy"],
+            check_freq=False,
+        )
+        assert_frame_equal(
+            edisgo_obj_loaded.electromobility.charging_processes_df,
+            edisgo_obj.electromobility.charging_processes_df,
         )
 
         # delete zip file

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -1266,6 +1266,13 @@ class TestEDisGo:
             },
             index=[0, 1],
         )
+        self.edisgo.electromobility.potential_charging_parks_gdf = pd.DataFrame(
+            data={
+                "ags": [5.0, 6.0],
+                "car_id": [7.0, 8.0],
+            },
+            index=[0, 1],
+        )
 
         # ################### test with default parameters ###################
         self.edisgo.save(save_dir)
@@ -1278,7 +1285,12 @@ class TestEDisGo:
         shutil.rmtree(save_dir)
 
         # ############## test with saving heat pump and electromobility #############
-        self.edisgo.save(save_dir, save_electromobility=True, save_heatpump=True)
+        self.edisgo.save(
+            save_dir,
+            save_electromobility=True,
+            save_heatpump=True,
+            electromobility_attributes=["charging_processes_df"],
+        )
 
         # check that sub-directory are created
         dirs_in_save_dir = os.listdir(save_dir)
@@ -1295,7 +1307,7 @@ class TestEDisGo:
         zip = ZipFile(zip_file)
         files = zip.namelist()
         zip.close()
-        assert len(files) == 24
+        assert len(files) == 25
 
         os.remove(zip_file)
 
@@ -1533,7 +1545,9 @@ class TestEDisGoFunc:
         # ############ test with loading electromobility and heat pump data ###########
 
         edisgo_obj_loaded = import_edisgo_from_files(
-            save_dir, import_electromobility=True, import_heat_pump=True
+            save_dir,
+            import_electromobility=True,
+            import_heat_pump=True,
         )
 
         # check electromobility


### PR DESCRIPTION
# Description

Adds flexibility bands as property to the Electromobility class to allow csv im- and export. 

The following still needs to be done:

- [x] Implement csv import of flexibility bands.
- [x] Allow choosing which Electromobility attributes to export.
- [x] Add tests.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
