### PR TITLE
Features/reinforcement catch convergence

### DIFF
--- a/doc/whatsnew/v0-2-1.rst
+++ b/doc/whatsnew/v0-2-1.rst
@@ -10,3 +10,5 @@ Changes
 * Added MV grid ID to logging output `#309 <https://github.com/openego/eDisGo/pull/309>`_
 * Added automatic link checking `#297 <https://github.com/openego/eDisGo/pull/297>`_
 * Bug fix `#346 <https://github.com/openego/eDisGo/pull/346>`_
+* Added method to scale timeseries `#353 <https://github.com/openego/eDisGo/pull/353>`_
+* Added method to aggregate lv grid buses to station bus secondary side `#353 <https://github.com/openego/eDisGo/pull/353>`_

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -1026,7 +1026,7 @@ class EDisGo:
 
                 if not fully_converged:
                     # Find non converging timesteps
-                    logger.debug("Find converging and non converging timesteps.")
+                    logger.info("Find converging and non converging timesteps.")
                     converging_timesteps, non_converging_timesteps = self.analyze(
                         timesteps=timesteps_pfa, raise_not_converged=False
                     )
@@ -1050,25 +1050,25 @@ class EDisGo:
                             without_generator_import=without_generator_import,
                         )
                         converged = True
-                        logger.debug(
+                        logger.info(
                             f"Reinforcement succeeded for {set_scaling_factor=} "
                             f"at {iteration=}"
                         )
                     except ValueError:
                         results = self.results
                         converged = False
-                        logger.debug(
+                        logger.info(
                             f"Reinforcement failed for {set_scaling_factor=} "
                             f"at {iteration=}"
                         )
                     return converged, results
 
                 if not converged:
-                    logger.debug("Reinforce only converged timesteps")
+                    logger.info("Reinforce only converged timesteps")
                     selected_timesteps = converging_timesteps
                     _, _ = reinforce()
 
-                    logger.debug("Reinforce only non converged timesteps")
+                    logger.info("Reinforce only non converged timesteps")
                     selected_timesteps = non_converging_timesteps
                     converged, results = reinforce()
 
@@ -1097,7 +1097,7 @@ class EDisGo:
                     self.timeseries = copy.deepcopy(initial_timerseries)
                     self.timeseries.scale_timeseries(
                         p_scaling_factor=set_scaling_factor,
-                        q_scaling_factor=0,
+                        q_scaling_factor=set_scaling_factor,
                     )
                     logger.info(
                         f"Try reinforce with {set_scaling_factor=} at {iteration=}"
@@ -1110,7 +1110,8 @@ class EDisGo:
                         )
 
                 self.timeseries = initial_timerseries
-
+                selected_timesteps = timesteps_pfa
+                converged, results = reinforce()
         # add measure to Results object
         if not copy_grid:
             self.results.measures = "grid_expansion"

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -932,6 +932,12 @@ class EDisGo:
             :attr:`edisgo.network.timeseries.TimeSeries.is_worst_case`. If True
             reinforcement is calculated for worst-case MV and LV cases separately.
 
+        catch_convergence_problems : bool
+            Uses reinforcement strategy to reinforce not converging grid.
+            Reinforces first with only converging timesteps. Reinforce again with at
+            start not converging timesteps. If still not converging, scale timeseries.
+            Default: False
+
         """
         if kwargs.get("is_worst_case", self.timeseries.is_worst_case):
 

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -939,7 +939,6 @@ class EDisGo:
             Uses reinforcement strategy to reinforce not converging grid.
             Reinforces first with only converging timesteps. Reinforce again with at
             start not converging timesteps. If still not converging, scale timeseries.
-            To use method "is_worst_case" must be "False".
             Default: False
 
         lv_grid_id : str or int

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -655,7 +655,7 @@ class EDisGo:
 
         Returns
         -------
-        :networkx:`networkx.Graph<>`
+        :networkx:`networkx.Graph<network.Graph>`
             Graph representation of the grid as networkx Ordered Graph,
             where lines are represented by edges in the graph, and buses and
             transformers are represented by nodes.
@@ -936,7 +936,11 @@ class EDisGo:
             Uses reinforcement strategy to reinforce not converging grid.
             Reinforces first with only converging timesteps. Reinforce again with at
             start not converging timesteps. If still not converging, scale timeseries.
+            To use method "is_worst_case" must be "False".
             Default: False
+
+        lv_grid_id : str or int
+            LV grid id to specify the grid to check, if mode is "lv".
 
         """
         if kwargs.get("is_worst_case", self.timeseries.is_worst_case):
@@ -968,6 +972,7 @@ class EDisGo:
                     combined_analysis=combined_analysis,
                     mode="mv",
                     without_generator_import=without_generator_import,
+                    **kwargs,
                 )
 
             if mode != "mv":
@@ -985,6 +990,7 @@ class EDisGo:
                     combined_analysis=combined_analysis,
                     mode=reinforce_mode,
                     without_generator_import=without_generator_import,
+                    **kwargs,
                 )
 
             if mode not in ["mv", "lv"]:
@@ -1001,6 +1007,7 @@ class EDisGo:
                     combined_analysis=combined_analysis,
                     mode=mode,
                     without_generator_import=without_generator_import,
+                    **kwargs,
                 )
             else:
                 # Initial try
@@ -1014,6 +1021,7 @@ class EDisGo:
                         combined_analysis=combined_analysis,
                         mode=mode,
                         without_generator_import=without_generator_import,
+                        **kwargs,
                     )
                     converged = True
                     fully_converged = True
@@ -1025,7 +1033,7 @@ class EDisGo:
                 # traceback.print_exc()
                 set_scaling_factor = 1
                 initial_timerseries = copy.deepcopy(self.timeseries)
-                minimal_scaling_factor = 0.01
+                minimal_scaling_factor = 0.05
                 max_iterations = 10
                 iteration = 0
                 highest_converged_scaling_factor = 0
@@ -1054,6 +1062,7 @@ class EDisGo:
                             combined_analysis=combined_analysis,
                             mode=mode,
                             without_generator_import=without_generator_import,
+                            **kwargs,
                         )
                         converged = True
                         logger.info(

--- a/edisgo/flex_opt/reinforce_grid.py
+++ b/edisgo/flex_opt/reinforce_grid.py
@@ -680,7 +680,7 @@ def catch_convergence_reinforce_grid(
     iteration = 0
     highest_converged_scaling_factor = 0
 
-    if not fully_converged:
+    if fully_converged is False:
         # Find non converging timesteps
         logger.info("Find converging and non converging timesteps.")
         converging_timesteps, non_converging_timesteps = edisgo.analyze(
@@ -691,10 +691,11 @@ def catch_convergence_reinforce_grid(
             f"Following timesteps {non_converging_timesteps} " f"doesnt't converged."
         )
 
-    if not converged:
-        logger.info("Reinforce only converged timesteps")
-        selected_timesteps = converging_timesteps
-        _, _ = reinforce()
+    if converged is False:
+        if not converging_timesteps.empty:
+            logger.info("Reinforce only converged timesteps")
+            selected_timesteps = converging_timesteps
+            _, _ = reinforce()
 
         logger.info("Reinforce only non converged timesteps")
         selected_timesteps = non_converging_timesteps

--- a/edisgo/flex_opt/reinforce_grid.py
+++ b/edisgo/flex_opt/reinforce_grid.py
@@ -826,12 +826,11 @@ def enhanced_reinforce_wrapper(
                                 lv_grid_id=lv_grid.id
                             )
                             logger.info(
-                                f"Aggregate to station mode 'lv' for {lv_grid} "
-                                f"successful."
+                                f"Aggregate to station for {lv_grid} successful."
                             )
                         except:  # noqa: E722
                             logger.info(
-                                f"Aggregate to station mode 'lv' for {lv_grid} failed."
+                                f"Aggregate to station for {lv_grid} failed."
                             )
 
         try:

--- a/edisgo/flex_opt/reinforce_grid.py
+++ b/edisgo/flex_opt/reinforce_grid.py
@@ -765,7 +765,7 @@ def enhanced_reinforce_wrapper(
     """
     try:
         logger.info("Try initial reinforcement.")
-        edisgo_obj.reinforce(mode=None, **kwargs)
+        edisgo_obj.reinforce(mode=None, catch_convergence_problems=True, **kwargs)
         logger.info("Initial succeeded.")
     except:  # noqa: E722
         logger.info("Initial failed.")
@@ -829,9 +829,7 @@ def enhanced_reinforce_wrapper(
                                 f"Aggregate to station for {lv_grid} successful."
                             )
                         except:  # noqa: E722
-                            logger.info(
-                                f"Aggregate to station for {lv_grid} failed."
-                            )
+                            logger.info(f"Aggregate to station for {lv_grid} failed.")
 
         try:
             edisgo_obj.reinforce(mode=None, catch_convergence_problems=True, **kwargs)

--- a/edisgo/flex_opt/reinforce_grid.py
+++ b/edisgo/flex_opt/reinforce_grid.py
@@ -825,12 +825,6 @@ def enhanced_reinforce_wrapper(
                             edisgo_obj.topology.aggregate_lv_grid_buses_on_station(
                                 lv_grid_id=lv_grid.id
                             )
-                            edisgo_obj.reinforce(
-                                mode="lv",
-                                lv_grid_id=lv_grid.id,
-                                catch_convergence_problems=True,
-                                **kwargs,
-                            )
                             logger.info(
                                 f"Aggregate to station mode 'lv' for {lv_grid} "
                                 f"successful."

--- a/edisgo/flex_opt/reinforce_grid.py
+++ b/edisgo/flex_opt/reinforce_grid.py
@@ -159,6 +159,8 @@ def reinforce_grid(
     else:
         edisgo_reinforce = edisgo
 
+    logger.info("Start reinforcement.")
+
     if timesteps_pfa is not None:
         if isinstance(timesteps_pfa, str) and timesteps_pfa == "snapshot_analysis":
             snapshots = tools.select_worstcase_snapshots(edisgo_reinforce)
@@ -620,3 +622,117 @@ def reinforce_grid(
     )
 
     return edisgo_reinforce.results
+
+
+def catch_convergence_reinforce_grid(
+    edisgo: EDisGo,
+    timesteps_pfa: str | pd.DatetimeIndex | pd.Timestamp | None = None,
+    copy_grid: bool = False,
+    max_while_iterations: int = 20,
+    combined_analysis: bool = False,
+    mode: str | None = None,
+    without_generator_import: bool = False,
+    **kwargs,
+) -> Results:
+    def reinforce():
+        try:
+            results = reinforce_grid(
+                edisgo,
+                max_while_iterations=max_while_iterations,
+                copy_grid=copy_grid,
+                timesteps_pfa=selected_timesteps,
+                combined_analysis=combined_analysis,
+                mode=mode,
+                without_generator_import=without_generator_import,
+                **kwargs,
+            )
+            converged = True
+            logger.info(
+                f"Reinforcement succeeded for {set_scaling_factor=} " f"at {iteration=}"
+            )
+        except ValueError:
+            results = edisgo.results
+            converged = False
+            logger.info(
+                f"Reinforcement failed for {set_scaling_factor=} " f"at {iteration=}"
+            )
+        return converged, results
+
+    # Initial try
+    logger.info("Start catch convergence reinforcement")
+    logger.info("Initial reinforcement try.")
+    selected_timesteps = timesteps_pfa
+    set_scaling_factor = 1.0
+    iteration = 0
+    converged = True
+    fully_converged = True
+
+    converged, results = reinforce()
+
+    if converged is False:
+        logger.info("Initial reinforcement doesn't converged.")
+        fully_converged = False
+
+    set_scaling_factor = 1
+    initial_timerseries = copy.deepcopy(edisgo.timeseries)
+    minimal_scaling_factor = 0.05
+    max_iterations = 10
+    iteration = 0
+    highest_converged_scaling_factor = 0
+
+    if not fully_converged:
+        # Find non converging timesteps
+        logger.info("Find converging and non converging timesteps.")
+        converging_timesteps, non_converging_timesteps = edisgo.analyze(
+            timesteps=timesteps_pfa, raise_not_converged=False
+        )
+        logger.debug(f"Following timesteps {converging_timesteps} converged.")
+        logger.debug(
+            f"Following timesteps {non_converging_timesteps} " f"doesnt't converged."
+        )
+
+    if not converged:
+        logger.info("Reinforce only converged timesteps")
+        selected_timesteps = converging_timesteps
+        _, _ = reinforce()
+
+        logger.info("Reinforce only non converged timesteps")
+        selected_timesteps = non_converging_timesteps
+        converged, results = reinforce()
+
+    while iteration < max_iterations:
+        iteration += 1
+        if converged:
+            if set_scaling_factor == 1:
+                # Initial iteration (0) worked
+                break
+            else:
+                highest_converged_scaling_factor = set_scaling_factor
+                set_scaling_factor = 1
+        else:
+            if set_scaling_factor == minimal_scaling_factor:
+                raise ValueError(f"Not reinforceable with {minimal_scaling_factor=}!")
+            elif iteration == 1:
+                set_scaling_factor = minimal_scaling_factor
+            else:
+                set_scaling_factor = (
+                    (set_scaling_factor - highest_converged_scaling_factor) * 0.25
+                ) + highest_converged_scaling_factor
+
+        edisgo.timeseries = copy.deepcopy(initial_timerseries)
+        edisgo.timeseries.scale_timeseries(
+            p_scaling_factor=set_scaling_factor,
+            q_scaling_factor=set_scaling_factor,
+        )
+        logger.info(f"Try reinforce with {set_scaling_factor=} at {iteration=}")
+        converged, results = reinforce()
+        if converged is False and iteration == max_iterations:
+            raise ValueError(
+                f"Not reinforceable, max iterations ({max_iterations}) " f"reached!"
+            )
+
+    edisgo.timeseries = initial_timerseries
+    selected_timesteps = timesteps_pfa
+    converged, results = reinforce()
+
+    return edisgo.results

--- a/edisgo/flex_opt/reinforce_grid.py
+++ b/edisgo/flex_opt/reinforce_grid.py
@@ -736,3 +736,115 @@ def catch_convergence_reinforce_grid(
     converged, results = reinforce()
 
     return edisgo.results
+
+
+def enhanced_reinforce_wrapper(
+    edisgo_obj: EDisGo, activate_cost_results_disturbing_mode: bool = False, **kwargs
+) -> EDisGo:
+    """
+    A Wrapper around the reinforce method, to catch exceptions and try to counter them
+    through reinforcing the grid in small portions:
+    Reinforcement mode mv, then mvlv mode, then lv powerflow per lv_grid.
+
+    Parameters
+    ----------
+    edisgo_obj : :class:`~.EDisGo`
+        The eDisGo object
+    activate_cost_results_disturbing_mode: :obj:`bool`
+        If this option is activated to methods are used to fix the problem. These
+        methods are currently not reinforcement costs increasing.
+        If the lv_reinforcement fails all branches of the lv_grid are replaced by the
+        standard type. Should this not work all lv nodes are aggregated to the station
+        node.
+
+    Returns
+    -------
+    :class:`~.EDisGo`
+        The reinforced eDisGo object
+
+    """
+    try:
+        logger.info("Try initial reinforcement.")
+        edisgo_obj.reinforce(mode=None, **kwargs)
+        logger.info("Initial succeeded.")
+    except:  # noqa: E722
+        logger.info("Initial failed.")
+
+        logger.info("Try mode 'mv' reinforcement.")
+        try:
+            edisgo_obj.reinforce(mode="mv", catch_convergence_problems=True, **kwargs)
+            logger.info("Mode 'mv' succeeded.")
+        except:  # noqa: E722
+            logger.info("Mode 'mv' failed.")
+
+        logger.info("Try mode 'mvlv' reinforcement.")
+        try:
+            edisgo_obj.reinforce(mode="mvlv", catch_convergence_problems=True, **kwargs)
+            logger.info("Mode 'mvlv' succeeded.")
+        except:  # noqa: E722
+            logger.info("Mode 'mvlv' failed.")
+
+        for lv_grid in list(edisgo_obj.topology.mv_grid.lv_grids):
+            try:
+                logger.info(f"Try mode 'lv' reinforcement for {lv_grid=}.")
+                edisgo_obj.reinforce(
+                    mode="lv",
+                    lv_grid_id=lv_grid.id,
+                    catch_convergence_problems=True,
+                    **kwargs,
+                )
+                logger.info(f"Mode 'lv' for {lv_grid} successful.")
+            except:  # noqa: E722
+                logger.info(f"Mode 'lv' for {lv_grid} failed.")
+                if activate_cost_results_disturbing_mode:
+                    try:
+                        logger.warning(
+                            f"Change all lines to standard type in {lv_grid=}."
+                        )
+                        lv_standard_line_type = edisgo_obj.config.from_cfg()[
+                            "grid_expansion_standard_equipment"
+                        ]["lv_line"]
+                        edisgo_obj.topology.change_line_type(
+                            lv_grid.lines_df.index.to_list(), lv_standard_line_type
+                        )
+                        edisgo_obj.reinforce(
+                            mode="lv",
+                            lv_grid_id=lv_grid.id,
+                            catch_convergence_problems=True,
+                            **kwargs,
+                        )
+                        logger.info(
+                            f"Changed lines mode 'lv' for {lv_grid} successful."
+                        )
+                    except:  # noqa: E722
+                        logger.info(f"Changed lines mode 'lv' for {lv_grid} failed.")
+                        logger.warning(
+                            f"Aggregate all lines to station bus in {lv_grid=}."
+                        )
+                        try:
+                            edisgo_obj.topology.aggregate_lv_grid_buses_on_station(
+                                lv_grid_id=lv_grid.id
+                            )
+                            edisgo_obj.reinforce(
+                                mode="lv",
+                                lv_grid_id=lv_grid.id,
+                                catch_convergence_problems=True,
+                                **kwargs,
+                            )
+                            logger.info(
+                                f"Aggregate to station mode 'lv' for {lv_grid} "
+                                f"successful."
+                            )
+                        except:  # noqa: E722
+                            logger.info(
+                                f"Aggregate to station mode 'lv' for {lv_grid} failed."
+                            )
+
+        try:
+            edisgo_obj.reinforce(mode=None, catch_convergence_problems=True, **kwargs)
+            logger.info("Enhanced reinforcement succeeded.")
+        except Exception as e:  # noqa: E722
+            logger.info("Enhanced reinforcement failed.")
+            raise e
+
+    return edisgo_obj

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -2189,7 +2189,7 @@ class TimeSeries:
     def scale_timeseries(
         self, p_scaling_factor: float = 1.0, q_scaling_factor: float = 1.0
     ):
-        attributes_type = ["generators", "storage_units", "storage_units"]
+        attributes_type = ["generators", "loads", "storage_units"]
         power_types = {
             "active_power": p_scaling_factor,
             "reactive_power": q_scaling_factor,

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -2186,6 +2186,19 @@ class TimeSeries:
         # set new timeindex
         self._timeindex = index
 
+    def scale_timeseries(
+        self, p_scaling_factor: float = 1.0, q_scaling_factor: float = 1.0
+    ):
+        attributes_type = ["generators", "storage_units", "storage_units"]
+        power_types = {
+            "active_power": p_scaling_factor,
+            "reactive_power": q_scaling_factor,
+        }
+        for suffix, scaling_factor in power_types.items():
+            for type in attributes_type:
+                attribute = f"{type}_{suffix}"
+                setattr(self, attribute, getattr(self, attribute) * scaling_factor)
+
 
 class TimeSeriesRaw:
     """

--- a/edisgo/network/topology.py
+++ b/edisgo/network/topology.py
@@ -2811,5 +2811,35 @@ class Topology:
                 f"are in a different reference system."
             )
 
+    def aggregate_lv_grid_buses_on_station(self, lv_grid_id: int | str) -> None:
+        """
+        Aggregates all lv grid buses on secondary station side bus. Drop all lines of
+        lv grid and replaces bus names in "loads_df", "storages_df",
+        "charging_points_df" and "storages_df".
+
+        Parameters
+        ----------
+        lv_grid_id : int or str
+        """
+        lv_grid = self.get_lv_grid(name=lv_grid_id)
+        lines_to_drop = lv_grid.lines_df.index.to_list()
+        station_bus = lv_grid.station.index[0]
+        buses_to_drop = lv_grid.buses_df.loc[
+            lv_grid.buses_df.index != station_bus
+        ].index.to_list()
+
+        self.buses_df = self.buses_df[~self.buses_df.index.isin(buses_to_drop)]
+        self.lines_df = self.lines_df[~self.lines_df.index.isin(lines_to_drop)]
+        self.loads_df.loc[self.loads_df.bus.isin(buses_to_drop), "bus"] = station_bus
+        self.generators_df.loc[
+            self.generators_df.bus.isin(buses_to_drop), "bus"
+        ] = station_bus
+        self.charging_points_df.loc[
+            self.charging_points_df.bus.isin(buses_to_drop), "bus"
+        ] = station_bus
+        self.storage_units_df.loc[
+            self.storage_units_df.bus.isin(buses_to_drop), "bus"
+        ] = station_bus
+
     def __repr__(self):
         return f"Network topology {self.id}"

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import shutil
@@ -2424,6 +2425,17 @@ class TestTimeSeries:
             )
             / 2,
             atol=1e-5,
+        )
+
+    def test_scale_timeseries(self):
+        self.edisgo.set_time_series_worst_case_analysis()
+        edisgo_scaled = copy.deepcopy(self.edisgo)
+        edisgo_scaled.timeseries.scale_timeseries(
+            p_scaling_factor=0.5, q_scaling_factor=0.5
+        )
+        assert_frame_equal(
+            edisgo_scaled.timeseries.generators_active_power,
+            self.edisgo.timeseries.generators_active_power * 0.5,
         )
 
 

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -2431,11 +2431,32 @@ class TestTimeSeries:
         self.edisgo.set_time_series_worst_case_analysis()
         edisgo_scaled = copy.deepcopy(self.edisgo)
         edisgo_scaled.timeseries.scale_timeseries(
-            p_scaling_factor=0.5, q_scaling_factor=0.5
+            p_scaling_factor=0.5, q_scaling_factor=0.4
         )
+
         assert_frame_equal(
             edisgo_scaled.timeseries.generators_active_power,
             self.edisgo.timeseries.generators_active_power * 0.5,
+        )
+        assert_frame_equal(
+            edisgo_scaled.timeseries.generators_reactive_power,
+            self.edisgo.timeseries.generators_reactive_power * 0.4,
+        )
+        assert_frame_equal(
+            edisgo_scaled.timeseries.loads_active_power,
+            self.edisgo.timeseries.loads_active_power * 0.5,
+        )
+        assert_frame_equal(
+            edisgo_scaled.timeseries.loads_reactive_power,
+            self.edisgo.timeseries.loads_reactive_power * 0.4,
+        )
+        assert_frame_equal(
+            edisgo_scaled.timeseries.storage_units_active_power,
+            self.edisgo.timeseries.storage_units_active_power * 0.5,
+        )
+        assert_frame_equal(
+            edisgo_scaled.timeseries.storage_units_reactive_power,
+            self.edisgo.timeseries.storage_units_reactive_power * 0.4,
         )
 
 

--- a/tests/network/test_topology.py
+++ b/tests/network/test_topology.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import shutil
@@ -848,6 +849,16 @@ class TestTopology:
         assert "generators.csv" in saved_files
 
         shutil.rmtree(dir)
+
+    def test_aggregate_lv_grid_buses_on_station(self):
+        """Test method aggregate_lv_grid_buses_on_station"""
+
+        lv_grid_id = str(list(self.topology.mv_grid.lv_grids)[1])
+        topology_obj = copy.deepcopy(self.topology)
+        topology_obj.aggregate_lv_grid_buses_on_station(lv_grid_id=lv_grid_id)
+
+        assert list(self.topology.mv_grid.lv_grids)[1].buses_df.shape[0] == 15
+        assert list(topology_obj.mv_grid.lv_grids)[1].buses_df.shape[0] == 1
 
 
 class TestTopologyWithEdisgoObject:

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -429,6 +429,20 @@ class TestEDisGo:
         assert len(results.equipment_changes) == 8
         assert results.v_res.shape == (4, 41)
 
+    def test_reinforce_catch_convergence(self):
+        # ###################### test with catch convergence ##########################
+        self.setup_worst_case_time_series()
+        self.edisgo.timeseries.scale_timeseries(
+            p_scaling_factor=10, q_scaling_factor=10
+        )
+        results = self.edisgo.reinforce(
+            catch_convergence_problems=True, is_worst_case=False
+        )
+        assert results.unresolved_issues.empty
+        assert len(results.grid_expansion_costs) == 109
+        assert len(results.equipment_changes) == 139
+        assert results.v_res.shape == (2, 142)
+
     def test_add_component(self, caplog):
         self.setup_worst_case_time_series()
         index = self.edisgo.timeseries.timeindex

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -494,11 +494,13 @@ class TestEDisGo:
             p_scaling_factor=10, q_scaling_factor=10
         )
         edisgo_obj = copy.deepcopy(self.edisgo)
-        results = enhanced_reinforce_wrapper(edisgo_obj)
+        edisgo_obj = enhanced_reinforce_wrapper(edisgo_obj)
+
+        results = edisgo_obj.results
 
         assert results.unresolved_issues.empty
-        assert len(results.grid_expansion_costs) == 6
-        assert len(results.equipment_changes) == 6
+        assert len(results.grid_expansion_costs) == 108
+        assert len(results.equipment_changes) == 162
         assert results.v_res.shape == (4, 142)
 
     def test_add_component(self, caplog):

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -440,8 +440,21 @@ class TestEDisGo:
         )
         assert results.unresolved_issues.empty
         assert len(results.grid_expansion_costs) == 109
-        assert len(results.equipment_changes) == 176
+        assert len(results.equipment_changes) == 186
         assert results.v_res.shape == (4, 142)
+
+    def test_reinforce_one_lv_grid(self):
+        # ###################### test with only one lv grid ##########################
+        self.setup_worst_case_time_series()
+        lv_grid_id = list(self.edisgo.topology.mv_grid.lv_grids)[0].id
+        results = self.edisgo.reinforce(
+            mode="lv", copy_grid=True, lv_grid_id=lv_grid_id
+        )
+
+        assert results.unresolved_issues.empty
+        assert len(results.grid_expansion_costs) == 6
+        assert len(results.equipment_changes) == 6
+        assert results.v_res.shape == (2, 142)
 
     def test_add_component(self, caplog):
         self.setup_worst_case_time_series()

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -452,22 +452,26 @@ class TestEDisGo:
     def test_reinforce_catch_convergence(self):
         # ###################### test with catch convergence ##########################
         self.setup_worst_case_time_series()
-        self.edisgo.timeseries.scale_timeseries(p_scaling_factor=5, q_scaling_factor=5)
+        self.edisgo.timeseries.scale_timeseries(
+            p_scaling_factor=10, q_scaling_factor=10
+        )
         results = self.edisgo.reinforce(
             catch_convergence_problems=True, is_worst_case=False
         )
         assert results.unresolved_issues.empty
-        assert len(results.grid_expansion_costs) == 91
-        assert len(results.equipment_changes) == 116
+        assert len(results.grid_expansion_costs) == 134
+        assert len(results.equipment_changes) == 231
         assert results.v_res.shape == (4, 142)
 
         # ############### test with catch convergence worst case false ################
         self.setup_worst_case_time_series()
-        self.edisgo.timeseries.scale_timeseries(p_scaling_factor=5, q_scaling_factor=5)
+        self.edisgo.timeseries.scale_timeseries(
+            p_scaling_factor=10, q_scaling_factor=10
+        )
         results = self.edisgo.reinforce(catch_convergence_problems=True)
         assert results.unresolved_issues.empty
-        assert len(results.grid_expansion_costs) == 91
-        assert len(results.equipment_changes) == 116
+        assert len(results.grid_expansion_costs) == 134
+        assert len(results.equipment_changes) == 231
         assert results.v_res.shape == (4, 142)
 
     def test_reinforce_one_lv_grid(self):
@@ -483,6 +487,7 @@ class TestEDisGo:
         assert len(results.equipment_changes) == 6
         assert results.v_res.shape == (4, 142)
 
+    @pytest.mark.slow
     def test_enhanced_reinforce(self):
         self.setup_edisgo_object()
         self.setup_worst_case_time_series()
@@ -496,8 +501,8 @@ class TestEDisGo:
 
         results = edisgo_obj.results
 
-        assert len(results.grid_expansion_costs) == 154
-        assert len(results.equipment_changes) == 338
+        assert len(results.grid_expansion_costs) == 843
+        assert len(results.equipment_changes) == 1802
         assert results.v_res.shape == (4, 142)
 
     def test_add_component(self, caplog):

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -491,16 +491,17 @@ class TestEDisGo:
         self.setup_edisgo_object()
         self.setup_worst_case_time_series()
         self.edisgo.timeseries.scale_timeseries(
-            p_scaling_factor=10, q_scaling_factor=10
+            p_scaling_factor=100, q_scaling_factor=100
         )
         edisgo_obj = copy.deepcopy(self.edisgo)
-        edisgo_obj = enhanced_reinforce_wrapper(edisgo_obj)
+        edisgo_obj = enhanced_reinforce_wrapper(
+            edisgo_obj, activate_cost_results_disturbing_mode=True
+        )
 
         results = edisgo_obj.results
 
-        assert results.unresolved_issues.empty
-        assert len(results.grid_expansion_costs) == 108
-        assert len(results.equipment_changes) == 162
+        assert len(results.grid_expansion_costs) == 840
+        assert len(results.equipment_changes) == 1388
         assert results.v_res.shape == (4, 142)
 
     def test_add_component(self, caplog):

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -16,6 +16,7 @@ from shapely.geometry import Point
 
 from edisgo import EDisGo
 from edisgo.edisgo import import_edisgo_from_files
+from edisgo.flex_opt.reinforce_grid import enhanced_reinforce_wrapper
 
 
 class TestEDisGo:
@@ -480,6 +481,20 @@ class TestEDisGo:
         results = self.edisgo.reinforce(
             mode="lv", copy_grid=True, lv_grid_id=lv_grid_id
         )
+
+        assert results.unresolved_issues.empty
+        assert len(results.grid_expansion_costs) == 6
+        assert len(results.equipment_changes) == 6
+        assert results.v_res.shape == (4, 142)
+
+    def test_enhanced_reinforce(self):
+        self.setup_edisgo_object()
+        self.setup_worst_case_time_series()
+        self.edisgo.timeseries.scale_timeseries(
+            p_scaling_factor=10, q_scaling_factor=10
+        )
+        edisgo_obj = copy.deepcopy(self.edisgo)
+        results = enhanced_reinforce_wrapper(edisgo_obj)
 
         assert results.unresolved_issues.empty
         assert len(results.grid_expansion_costs) == 6

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -440,8 +440,8 @@ class TestEDisGo:
         )
         assert results.unresolved_issues.empty
         assert len(results.grid_expansion_costs) == 109
-        assert len(results.equipment_changes) == 139
-        assert results.v_res.shape == (2, 142)
+        assert len(results.equipment_changes) == 176
+        assert results.v_res.shape == (4, 142)
 
     def test_add_component(self, caplog):
         self.setup_worst_case_time_series()

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -452,26 +452,22 @@ class TestEDisGo:
     def test_reinforce_catch_convergence(self):
         # ###################### test with catch convergence ##########################
         self.setup_worst_case_time_series()
-        self.edisgo.timeseries.scale_timeseries(
-            p_scaling_factor=10, q_scaling_factor=10
-        )
+        self.edisgo.timeseries.scale_timeseries(p_scaling_factor=5, q_scaling_factor=5)
         results = self.edisgo.reinforce(
             catch_convergence_problems=True, is_worst_case=False
         )
         assert results.unresolved_issues.empty
-        assert len(results.grid_expansion_costs) == 109
-        assert len(results.equipment_changes) == 186
+        assert len(results.grid_expansion_costs) == 91
+        assert len(results.equipment_changes) == 116
         assert results.v_res.shape == (4, 142)
 
         # ############### test with catch convergence worst case false ################
         self.setup_worst_case_time_series()
-        self.edisgo.timeseries.scale_timeseries(
-            p_scaling_factor=10, q_scaling_factor=10
-        )
+        self.edisgo.timeseries.scale_timeseries(p_scaling_factor=5, q_scaling_factor=5)
         results = self.edisgo.reinforce(catch_convergence_problems=True)
         assert results.unresolved_issues.empty
-        assert len(results.grid_expansion_costs) == 109
-        assert len(results.equipment_changes) == 186
+        assert len(results.grid_expansion_costs) == 91
+        assert len(results.equipment_changes) == 116
         assert results.v_res.shape == (4, 142)
 
     def test_reinforce_one_lv_grid(self):
@@ -500,8 +496,8 @@ class TestEDisGo:
 
         results = edisgo_obj.results
 
-        assert len(results.grid_expansion_costs) == 840
-        assert len(results.equipment_changes) == 1388
+        assert len(results.grid_expansion_costs) == 154
+        assert len(results.equipment_changes) == 338
         assert results.v_res.shape == (4, 142)
 
     def test_add_component(self, caplog):

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -410,14 +410,33 @@ class TestEDisGo:
         assert results.v_res.shape == (4, 142)
         assert self.edisgo.results.v_res.shape == (4, 142)
 
-        # ###################### test mode lv and copy grid ##########################
+        # ###################### test without worst case settings ####################
+        self.setup_worst_case_time_series()
+        results = self.edisgo.reinforce(is_worst_case=False)
+        assert results.unresolved_issues.empty
+        assert len(results.grid_expansion_costs) == 10
+        assert len(results.equipment_changes) == 10
+        assert results.v_res.shape == (4, 142)
+        assert self.edisgo.results.v_res.shape == (4, 142)
+
+        # ###################### test mode mv and copy grid ##########################
         self.setup_edisgo_object()
         self.setup_worst_case_time_series()
+        results = self.edisgo.reinforce(mode="mv", copy_grid=True)
+        assert results.unresolved_issues.empty
+        assert len(results.grid_expansion_costs) == 4
+        assert len(results.equipment_changes) == 4
+        assert results.v_res.shape == (4, 142)
+        assert self.edisgo.results.v_res.empty
+
+        # ###################### test mode lv and copy grid ##########################
+        # self.setup_edisgo_object()
+        # self.setup_worst_case_time_series()
         results = self.edisgo.reinforce(mode="lv", copy_grid=True)
         assert results.unresolved_issues.empty
         assert len(results.grid_expansion_costs) == 6
         assert len(results.equipment_changes) == 6
-        assert results.v_res.shape == (2, 142)
+        assert results.v_res.shape == (4, 142)
         assert self.edisgo.results.v_res.empty
 
         # ################# test mode mvlv and combined analysis ####################
@@ -427,7 +446,7 @@ class TestEDisGo:
         assert results.unresolved_issues.empty
         assert len(results.grid_expansion_costs) == 8
         assert len(results.equipment_changes) == 8
-        assert results.v_res.shape == (4, 41)
+        assert results.v_res.shape == (4, 142)
 
     def test_reinforce_catch_convergence(self):
         # ###################### test with catch convergence ##########################
@@ -438,6 +457,17 @@ class TestEDisGo:
         results = self.edisgo.reinforce(
             catch_convergence_problems=True, is_worst_case=False
         )
+        assert results.unresolved_issues.empty
+        assert len(results.grid_expansion_costs) == 109
+        assert len(results.equipment_changes) == 186
+        assert results.v_res.shape == (4, 142)
+
+        # ############### test with catch convergence worst case false ################
+        self.setup_worst_case_time_series()
+        self.edisgo.timeseries.scale_timeseries(
+            p_scaling_factor=10, q_scaling_factor=10
+        )
+        results = self.edisgo.reinforce(catch_convergence_problems=True)
         assert results.unresolved_issues.empty
         assert len(results.grid_expansion_costs) == 109
         assert len(results.equipment_changes) == 186
@@ -454,7 +484,7 @@ class TestEDisGo:
         assert results.unresolved_issues.empty
         assert len(results.grid_expansion_costs) == 6
         assert len(results.equipment_changes) == 6
-        assert results.v_res.shape == (2, 142)
+        assert results.v_res.shape == (4, 142)
 
     def test_add_component(self, caplog):
         self.setup_worst_case_time_series()


### PR DESCRIPTION
# Description

Adds a reinforcement strategy, to reinforce not converging grids.

## Type of change

New feature (non-breaking change which adds functionality)
Fixes  a bit of #356 

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] New and adjusted code includes type hinting now
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The Read the Docs documentation is compiling correctly
- [x] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [x] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
