### PR TITLE
Change requirements

### DIFF
--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -13,8 +13,7 @@ pypower
 scikit-learn
 beautifulsoup4
 plotly
-dash == 2.6.0
-werkzeug==2.2.0
+dash
 jupyter_dash
 docutils == 0.16.0
 sphinx >= 4.3.0, < 5.1.0

--- a/setup.py
+++ b/setup.py
@@ -53,12 +53,10 @@ requirements = [
     "beautifulsoup4",
     "contextily",
     "descartes",
-    "jupyter",
     "jupyterlab",
     "plotly",
-    "dash==2.6.0",
+    "dash",
     "jupyter_dash",
-    "werkzeug==2.2.0",
 ]
 
 dev_requirements = [


### PR DESCRIPTION
# Description

- Make only jupyterlab as requirement (Installing jupyter notebooks with pip leads to problems)
- Remove pinning dash version (The problems why the version was pinned have been fixed.)
- Remove Werkzeug as requirement, it is installed when dash or jupyter_dash is installed

## Type of change

Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] New and adjusted code includes type hinting now
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The Read the Docs documentation is compiling correctly
- [x] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [x] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
