### PR TITLE
Fix failing plotly tests

### DIFF
--- a/edisgo/tools/plots.py
+++ b/edisgo/tools/plots.py
@@ -1543,7 +1543,6 @@ def plot_dash_app(
 
     app = JupyterDash(__name__)
     # Workaround to use standard python logging with plotly dash
-    logger.handlers.pop()
     if debug:
         app.logger.disabled = False
         app.logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
# Description

Plotly test were failing. Because trying remove from an empty logger handler list. The handler was removed before because plotly/dash put there a handler I don't want to be there. Now it's gone, why? I don't know, but it is probably okay.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
