### PR TITLE
Bugfix/contextily provider

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up julia
+        if: runner.os == 'Linux' && matrix.python-version == 3.8 && matrix.name-suffix == 'coverage'
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.6"
+
       - name: Install packages (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -60,9 +66,6 @@ jobs:
 
       - name: Run tests, coverage and send to coveralls
         if: runner.os == 'Linux' && matrix.python-version == 3.8 && matrix.name-suffix == 'coverage'
-        uses: julia-actions/setup-julia@v1
-        with:
-          version: "1.6"
         run: |
           pip install pytest pytest-notebook coveralls
           coverage run --source=edisgo -m pytest --runslow --runonlinux --disable-warnings --color=yes -v

--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -60,6 +60,9 @@ jobs:
 
       - name: Run tests, coverage and send to coveralls
         if: runner.os == 'Linux' && matrix.python-version == 3.8 && matrix.name-suffix == 'coverage'
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.6"
         run: |
           pip install pytest pytest-notebook coveralls
           coverage run --source=edisgo -m pytest --runslow --runonlinux --disable-warnings --color=yes -v

--- a/edisgo/io/generators_import.py
+++ b/edisgo/io/generators_import.py
@@ -796,7 +796,7 @@ def oedb(
     * Removes decommissioned power and CHP plants (all plants that do not have a source
       ID or whose source ID can not be matched to a new plant and are not of subtype
       pv_rooftop, as these are handled in a separate function)
-    * Updates existing power plants (plants whose source ID is in
+    * Updates existing power plants (plants whose source ID
       can be matched; solar, wind and CHP plants never have a source ID in
       the future scenarios and are therefore never updated). The following two cases
       are distinguished:

--- a/edisgo/tools/plots.py
+++ b/edisgo/tools/plots.py
@@ -172,7 +172,7 @@ def add_basemap(ax, zoom=12):
     Adds map to a plot.
 
     """
-    url = ctx.providers.Stamen.TonerLite
+    url = ctx.providers.CartoDB.Positron
     xmin, xmax, ymin, ymax = ax.axis()
     basemap, extent = ctx.bounds2img(xmin, ymin, xmax, ymax, zoom=zoom, source=url)
     ax.imshow(basemap, extent=extent, interpolation="bilinear")


### PR DESCRIPTION
# Description

This PR fixes a problem with the per default used background map. Up to now, Stamen was used as a provider. As Stamen is not supported anymore, this needed to be changed. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
