### PR TITLE
Fix: Correct Matplotlib Attribute Error

### DIFF
--- a/edisgo/tools/plots.py
+++ b/edisgo/tools/plots.py
@@ -6,7 +6,6 @@ import os
 from typing import TYPE_CHECKING
 
 import matplotlib
-import matplotlib.cm as cm
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
@@ -604,7 +603,7 @@ def mv_grid_topology(
         bus_sizes, bus_colors = nodes_by_costs(
             pypsa_plot.buses.index, grid_expansion_costs, edisgo_obj
         )
-        bus_cmap = plt.cm.get_cmap(lines_cmap)
+        bus_cmap = matplotlib.pyplot.colormaps.get_cmap(lines_cmap)
     elif node_color == "curtailment":
         bus_sizes = nodes_curtailment(pypsa_plot.buses.index, curtailment_df)
         bus_colors = "orangered"
@@ -681,7 +680,8 @@ def mv_grid_topology(
         line_width = pypsa_plot.lines.s_nom * scaling_factor_line_width
     else:
         line_width = 2
-    cmap = plt.cm.get_cmap(lines_cmap)
+    cmap = matplotlib.pyplot.colormaps.get_cmap(lines_cmap)
+
     ll = pypsa_plot.plot(
         line_colors=line_colors,
         line_cmap=cmap,
@@ -888,7 +888,7 @@ def color_map_color(
     """
     norm = matplotlib.colors.Normalize(vmin=vmin, vmax=vmax)
     if isinstance(cmap_name, str):
-        cmap = cm.get_cmap(cmap_name)
+        cmap = matplotlib.pyplot.colormaps.get_cmap(cmap_name)
     else:
         cmap = matplotlib.colors.LinearSegmentedColormap.from_list("mycmap", cmap_name)
     rgb = cmap(norm(abs(value)))[:3]


### PR DESCRIPTION
# Description

This pull request addresses an issue in the plots.py module where an AttributeError is raised due to the use of a non-existent get_cmap attribute in the matplotlib.cm module.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
