### PR TITLE
Bugfix/dingo annual demand nans

### DIFF
--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -1450,9 +1450,8 @@ class TimeSeries:
 
         # check if loads contain annual demand
         if not all(loads_df.annual_consumption.notnull()):
-            raise Warning(
-                "Not all affected loads have information on annual consumption. Please "
-                "check and adapt if necessary."
+            raise AttributeError(
+                "The annual consumption of some loads is missing. Please provide "
             )
 
         # scale time series by annual consumption

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -1450,9 +1450,9 @@ class TimeSeries:
 
         # check if loads contain annual demand
         if not all(loads_df.annual_consumption.notnull()):
-            raise AttributeError(
-                "The following loads have missing information on annual consumption: "
-                f"{loads_df[~loads_df.annual_consumption.notnull()].index.values}."
+            raise Warning(
+                "Not all affected loads have information on annual consumption. Please "
+                "check and adapt if necessary."
             )
 
         # scale time series by annual consumption

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -1448,6 +1448,13 @@ class TimeSeries:
         load_names = self._check_if_components_exist(edisgo_object, load_names, "loads")
         loads_df = edisgo_object.topology.loads_df.loc[load_names, :]
 
+        # check if loads contain annual demand
+        if not all(loads_df.annual_consumption.notnull()):
+            raise AttributeError(
+                "The following loads have missing information on annual consumption: "
+                f"{loads_df[~loads_df.annual_consumption.notnull()].index.values}."
+            )
+
         # scale time series by annual consumption
         ts_scaled = loads_df.apply(
             lambda x: ts_loads[x.sector] * x.annual_consumption,

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -1451,7 +1451,7 @@ class TimeSeries:
         # check if loads contain annual demand
         if not all(loads_df.annual_consumption.notnull()):
             raise AttributeError(
-                "The annual consumption of some loads is missing. Please provide "
+                "The annual consumption of some loads is missing. Please provide"
             )
 
         # scale time series by annual consumption

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -1793,6 +1793,26 @@ class TestTimeSeries:
             ).values,
         ).all()
 
+        # test Error if 'annual_consumption' is missing
+        # Save the original 'annual_consumption' values
+        original_annual_consumption = self.edisgo.topology.loads_df[
+            "annual_consumption"
+        ].copy()
+        # Set 'annual_consumption' to None for the test
+        self.edisgo.topology.loads_df["annual_consumption"] = None
+        with pytest.raises(AttributeError) as exc_info:
+            self.edisgo.timeseries.predefined_conventional_loads_by_sector(
+                self.edisgo, "demandlib"
+            )
+        assert (
+            exc_info.value.args[0]
+            == "The annual consumption of some loads is missing. Please provide"
+        )
+        # Restore the original 'annual_consumption' values
+        self.edisgo.topology.loads_df[
+            "annual_consumption"
+        ] = original_annual_consumption
+
     def test_predefined_charging_points_by_use_case(self, caplog):
         index = pd.date_range("1/1/2018", periods=3, freq="H")
         self.edisgo.timeseries.timeindex = index


### PR DESCRIPTION
# Description

This pull request introduces a check for missing annual consumption data in the loads dataframe. This check is necessary because the ding0 network no longer provides the annual demand, which can lead to issues in subsequent processes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] New and adjusted code includes type hinting now
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The Read the Docs documentation is compiling correctly
- [x] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [x] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file

### Detailed Changes

1. **Added Check for Missing Annual Consumption Data:**
    - Implemented a check to raise an `AttributeError` if the annual consumption data is missing in the loads dataframe, ensuring data completeness and preventing downstream errors.
    ```python
    if not all(loads_df.annual_consumption.notnull()):
        raise AttributeError(
            "The annual consumption of some loads is missing. Please provide "
        )
    ```


These changes ensure data validation processes function correctly, enhancing the stability and reliability of the code.
