### PR TITLE
Oedb connection issue disable test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,10 @@ requirements = [
     "plotly",
     "pydot",
     "pygeos",
-    "pyomo <= 6.4.2",  # Problem with PyPSA 20.1 fixed in newest PyPSA release
+    # "pyomo <= 6.4.2",  # Problem with PyPSA 20.1 fixed in newest PyPSA release
     "pypower",
     "pyproj >= 3.0.0",
-    "pypsa >= 0.17.0, <= 0.20.1",
+    "pypsa",
     "pyyaml",
     "saio",
     "scikit-learn <= 1.1.1",

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,10 @@ requirements = [
     "plotly",
     "pydot",
     "pygeos",
-    # "pyomo <= 6.4.2",  # Problem with PyPSA 20.1 fixed in newest PyPSA release
+    "pyomo <= 6.4.2",  # Problem with PyPSA 20.1 fixed in newest PyPSA release
     "pypower",
     "pyproj >= 3.0.0",
-    "pypsa",
+    "pypsa >= 0.17.0, <= 0.20.1",
     "pyyaml",
     "saio",
     "scikit-learn <= 1.1.1",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def read(fname):
 requirements = [
     "contextily",
     "dash < 2.9.0",
-    "demandlib",
+    "demandlib < 0.2.0",
     "descartes",
     "egoio >= 0.4.7",
     "geoalchemy2 < 0.7.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,9 @@ def pytest_addoption(parser):
         default=False,
         help="run tests that only work locally",
     )
+    parser.addoption(
+        "--runoedbtest", action="store_true", default=False, help="Run OEDB tests"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -75,3 +78,10 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "runonlinux" in item.keywords:
                 item.add_marker(skip_windows)
+    if config.getoption("--runoedbtest"):
+        # If the --runoedbtest option is specified, do not skip any tests
+        return
+    skip_oedbtest = pytest.mark.skip(reason="Need --runoedbtest option to run")
+    for item in items:
+        if "oedbtest" in item.keywords:
+            item.add_marker(skip_oedbtest)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,10 +78,8 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "runonlinux" in item.keywords:
                 item.add_marker(skip_windows)
-    if config.getoption("--runoedbtest"):
-        # If the --runoedbtest option is specified, do not skip any tests
-        return
-    skip_oedbtest = pytest.mark.skip(reason="Need --runoedbtest option to run")
-    for item in items:
-        if "oedbtest" in item.keywords:
-            item.add_marker(skip_oedbtest)
+    if not config.getoption("--runoedbtest"):
+        skip_oedbtest = pytest.mark.skip(reason="need --runoedbtest option to run")
+        for item in items:
+            if "oedbtest" in item.keywords:
+                item.add_marker(skip_oedbtest)

--- a/tests/io/test_generators_import.py
+++ b/tests/io/test_generators_import.py
@@ -484,6 +484,7 @@ class TestGeneratorsImportOEDB:
     """
 
     @pytest.mark.slow
+    @pytest.mark.oedbtest
     def test_oedb_legacy_without_timeseries(self):
         edisgo = EDisGo(
             ding0_grid=pytest.ding0_test_network_2_path,
@@ -497,6 +498,7 @@ class TestGeneratorsImportOEDB:
         assert np.isclose(edisgo.topology.generators_df.p_nom.sum(), 20.18783)
 
     @pytest.mark.slow
+    @pytest.mark.oedbtest
     def test_oedb_legacy_with_worst_case_timeseries(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
         edisgo.set_time_series_worst_case_analysis()
@@ -568,6 +570,7 @@ class TestGeneratorsImportOEDB:
         #     :, new_solar_gen.name] / new_solar_gen.p_nom).all()
 
     @pytest.mark.slow
+    @pytest.mark.oedbtest
     def test_oedb_legacy_with_timeseries_by_technology(self):
         timeindex = pd.date_range("1/1/2012", periods=3, freq="H")
         ts_gen_dispatchable = pd.DataFrame(
@@ -647,6 +650,7 @@ class TestGeneratorsImportOEDB:
         #     :, new_solar_gen.name] / new_solar_gen.p_nom).all()
 
     @pytest.mark.slow
+    @pytest.mark.oedbtest
     def test_target_capacity(self):
         edisgo = EDisGo(
             ding0_grid=pytest.ding0_test_network_2_path,

--- a/tests/io/test_timeseries_import.py
+++ b/tests/io/test_timeseries_import.py
@@ -87,7 +87,6 @@ class TestTimeseriesImport:
         assert feedin_df.shape == (6, 4)
         assert_index_equal(feedin_df.index, timeindex)
 
-    @pytest.mark.oedbtest
     def test_load_time_series_demandlib(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
         timeindex = pd.date_range("1/1/2018", periods=7000, freq="H")

--- a/tests/io/test_timeseries_import.py
+++ b/tests/io/test_timeseries_import.py
@@ -59,6 +59,7 @@ class TestTimeseriesImport:
         assert_index_equal(ind, given_index)
         assert_index_equal(ind_full, timeindex)
 
+    @pytest.mark.oedbtest
     def test_feedin_oedb_legacy(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
         timeindex = pd.date_range("1/1/2010", periods=3000, freq="H")
@@ -86,6 +87,7 @@ class TestTimeseriesImport:
         assert feedin_df.shape == (6, 4)
         assert_index_equal(feedin_df.index, timeindex)
 
+    @pytest.mark.oedbtest
     def test_load_time_series_demandlib(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
         timeindex = pd.date_range("1/1/2018", periods=7000, freq="H")

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -1235,6 +1235,7 @@ class TestTimeSeries:
             )
 
     @pytest.mark.slow
+    @pytest.mark.oedbtest
     def test_predefined_fluctuating_generators_by_technology(self):
         timeindex = pd.date_range("1/1/2011 12:00", periods=2, freq="H")
         self.edisgo.timeseries.timeindex = timeindex

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -1550,6 +1550,7 @@ class TestTimeSeries:
         )
         # fmt: on
 
+    @pytest.mark.oedbtest  # WARNING: This is NO oedb error, but a demandlib error
     def test_predefined_conventional_loads_by_sector(self, caplog):
         index = pd.date_range("1/1/2018", periods=3, freq="H")
         self.edisgo.timeseries.timeindex = index

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -1550,7 +1550,6 @@ class TestTimeSeries:
         )
         # fmt: on
 
-    @pytest.mark.oedbtest  # WARNING: This is NO oedb error, but a demandlib error
     def test_predefined_conventional_loads_by_sector(self, caplog):
         index = pd.date_range("1/1/2018", periods=3, freq="H")
         self.edisgo.timeseries.timeindex = index

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -382,6 +382,7 @@ class TestEDisGo:
         )
 
     @pytest.mark.slow
+    @pytest.mark.oedbtest
     def test_generator_import(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
         edisgo.import_generators("nep2035")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -26,6 +26,7 @@ class TestExamples:
         assert result.exec_error is None
 
     @pytest.mark.slow
+    @pytest.mark.oedbtest
     def test_electromobility_example_ipynb(self):
         path = os.path.join(self.examples_dir_path, "electromobility_example.ipynb")
         notebook = pytest_notebook.notebook.load_notebook(path=path)
@@ -39,6 +40,7 @@ class TestExamples:
         assert result.exec_error is None
 
     @pytest.mark.slow
+    @pytest.mark.oedbtest
     def test_edisgo_simple_example_ipynb(self):
         path = os.path.join(self.examples_dir_path, "edisgo_simple_example.ipynb")
         notebook = pytest_notebook.notebook.load_notebook(path=path)

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -168,6 +168,7 @@ class TestTools:
         assert tools.determine_bus_voltage_level(self.edisgo, bus_voltage_level_6) == 6
         assert tools.determine_bus_voltage_level(self.edisgo, bus_voltage_level_7) == 7
 
+    @pytest.mark.oedbtest
     def test_get_weather_cells_intersecting_with_grid_district(self):
         weather_cells = tools.get_weather_cells_intersecting_with_grid_district(
             self.edisgo


### PR DESCRIPTION
# Description

This pull request addresses current issues with the oedb database by adding `pytest.mark.oedbtest` to comment out tests that fail. These tests can be run specifically by using the argument `--runoedbtest`. Additionally, the demandlib version has been restricted to `< 0.2.0` because version 0.2.0 keeps failing one test.
Both changes should be reverted, as soon as the issues with the oedialect and demandlib are fixed (see issues #405 and #406).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- ~~New and adjusted code includes type hinting now~~
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] The Read the Docs documentation is compiling correctly
- ~~If new packages are needed, I added them to the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).~~
- ~~I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file~~