### PR TITLE
Maintanance/GitHub tests for python 3.10

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -20,13 +20,13 @@ jobs:
         include:
           - name-suffix: "coverage"
             os: ubuntu-latest
-            python-version: 3.8
-          - name-suffix: "basic"
-            os: ubuntu-latest
             python-version: 3.9
           - name-suffix: "basic"
+            os: ubuntu-latest
+            python-version: 3.10
+          - name-suffix: "basic"
             os: windows-latest
-            python-version: 3.8
+            python-version: 3.9
 
     steps:
       - name: Checkout repo
@@ -71,7 +71,7 @@ jobs:
           python -m pytest --runslow --disable-warnings --color=yes -v
 
       - name: Run tests, coverage and send to coveralls
-        if: runner.os == 'Linux' && matrix.python-version == 3.8 && matrix.name-suffix == 'coverage'
+        if: runner.os == 'Linux' && matrix.python-version == 3.9 && matrix.name-suffix == 'coverage'
         run: |
           pip install pytest pytest-notebook coveralls
           coverage run --source=edisgo -m pytest --runslow --runonlinux --disable-warnings --color=yes -v

--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -23,7 +23,7 @@ jobs:
             python-version: 3.9
           - name-suffix: "basic"
             os: ubuntu-latest
-            python-version: 3.10
+            python-version: "3.10"
           - name-suffix: "basic"
             os: windows-latest
             python-version: 3.9

--- a/doc/dev_notes.rst
+++ b/doc/dev_notes.rst
@@ -18,8 +18,7 @@ Installation using Linux
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 To set up a source installation using linux simply use a virtual environment and install
-the source code with pip. Make sure to use python3.7 or higher (recommended
-python3.8). **After** setting up your virtual environment and activating it run the
+the source code with pip. Make sure to use python3.9 or higher. **After** setting up your virtual environment and activating it run the
 following commands within your eDisGo directory:
 
 .. code-block:: bash

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -3,7 +3,7 @@
 Getting started
 ================
 
-.. warning:: Make sure to use python 3.8 or higher!
+.. warning:: Make sure to use python 3.9 or higher!
 
 Installation using Linux
 -------------------------

--- a/eDisGo_env.yml
+++ b/eDisGo_env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python >= 3.8, < 3.10
+  - python >= 3.9, < 3.11
   - pip
   - pandas >= 1.4, < 2.2.0
   - conda-forge::fiona

--- a/eDisGo_env_dev.yml
+++ b/eDisGo_env_dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python >= 3.8, < 3.10
+  - python >= 3.9, < 3.11
   - pip
   - pandas >= 1.4, < 2.2.0
   - conda-forge::fiona

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import sys
 
 from setuptools import find_packages, setup
 
-if sys.version_info[:2] < (3, 8):
+if sys.version_info[:2] < (3, 9):
     error = (
-        "eDisGo requires Python 3.8 or later (%d.%d detected)." % sys.version_info[:2]
+        "eDisGo requires Python 3.9 or later (%d.%d detected)." % sys.version_info[:2]
     )
     sys.stderr.write(error + "\n")
     sys.exit(1)


### PR DESCRIPTION
# Description

Changed the github workflow to python versions 3.9 and 3.10. The Tests for python 3.8 are not longer provided

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The Read the Docs documentation is compiling correctly
- [x] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [x] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
