### PR TITLE
Fix doc links check

### DIFF
--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -13,7 +13,7 @@ pyproj >= 3.0.0
 pypsa == 0.26.2
 pyyaml
 saio
-scikit-learn < 1.3.0
+scikit-learn == 1.5
 sphinx
 sphinx_rtd_theme >=0.5.2
 sphinx-autodoc-typehints

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -13,7 +13,7 @@ pyproj >= 3.0.0
 pypsa == 0.26.2
 pyyaml
 saio
-scikit-learn == 1.5
+scikit-learn < 1.6 # Workaround: Pin scikit-learn to version 1.5 to fix failing doc check on GitHub
 sphinx
 sphinx_rtd_theme >=0.5.2
 sphinx-autodoc-typehints

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ requirements = [
     # newer pandas versions don't work with specified sqlalchemy versions, but upgrading
     # sqlalchemy leads to new errors.. should be fixed at some point
     "pandas >= 1.4.0, < 2.2.0",
-    "plotly",
+    "plotly < 6.0",
     "pydot",
     "pygeos",
     "pypower",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ requirements = [
     "pypsa == 0.26.2",
     "pyyaml",
     "saio",
-    "scikit-learn < 1.3.0",
+    "scikit-learn == 1.5",
     "shapely >= 1.7.0",
     "sqlalchemy < 1.4.0",
     "sshtunnel",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ requirements = [
     "pypsa == 0.26.2",
     "pyyaml",
     "saio",
-    "scikit-learn == 1.5",
+    "scikit-learn < 1.3.0",
     "shapely >= 1.7.0",
     "sqlalchemy < 1.4.0",
     "sshtunnel",


### PR DESCRIPTION
# Description

the scikit-learn version is updated to <1.6  for the rtd-requirements so that the doc check is not failing anymore

Fixes #431 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- ~[ ] New feature (non-breaking change which adds functionality)~
- ~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~

# Checklist:

- ~[ ] New and adjusted code is formatted using the `pre-commit` hooks~
- ~[ ] New and adjusted code includes type hinting now~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] New and existing unit tests pass locally with my changes~
- [x] The Read the Docs documentation is compiling correctly
- [x] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- ~[ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file~
