### PR TITLE
Fix missing timeindex in set_time_series_active_power_predefined

### DIFF
--- a/doc/whatsnew/v0-3-0.rst
+++ b/doc/whatsnew/v0-3-0.rst
@@ -29,3 +29,4 @@ Changes
 * Added a storage operation strategy where the storage is charged when PV feed-in is higher than electricity demand of the household and discharged when electricity demand exceeds PV generation `#386 <https://github.com/openego/eDisGo/pull/386>`_
 * Added an estimation of the voltage deviation over a cable when selecting a suitable cable to connect a new component `#411 <https://github.com/openego/eDisGo/pull/411>`_
 * Added clipping of heat pump electrical power at its maximum value #428 <https://github.com/openego/eDisGo/pull/428>
+* Loading predefined time series now automatically sets the timeindex to the default year of the database if it is empty. `#457 <https://github.com/openego/eDisGo/pull/457>`_

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -591,13 +591,17 @@ class EDisGo:
 
             self.set_timeindex(timeindex)
 
+        logger.info(
+            f"Trying to set predefined timeseries for {self.timeseries.timeindex}"
+        )
+
         if fluctuating_generators_ts is not None:
             self.timeseries.predefined_fluctuating_generators_by_technology(
                 self,
                 fluctuating_generators_ts,
                 fluctuating_generators_names,
                 engine=kwargs.get("engine", toep_engine()),
-                timeindex=kwargs.get("timeindex", None),
+                timeindex=timeindex,
             )
         if dispatchable_generators_ts is not None:
             self.timeseries.predefined_dispatchable_generators_by_technology(
@@ -612,7 +616,7 @@ class EDisGo:
                     edisgo_obj=self,
                     scenario=kwargs.get("scenario"),
                     engine=kwargs.get("engine", toep_engine()),
-                    timeindex=kwargs.get("timeindex", None),
+                    timeindex=timeindex,
                     load_names=conventional_loads_names,
                 )
                 # concat new time series with existing ones and drop any duplicate

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -41,6 +41,7 @@ from edisgo.io.electromobility_import import (
 )
 from edisgo.io.heat_pump_import import oedb as import_heat_pumps_oedb
 from edisgo.io.storage_import import home_batteries_oedb
+from edisgo.io.timeseries_import import _timeindex_helper_func
 from edisgo.network import timeseries
 from edisgo.network.dsm import DSM
 from edisgo.network.electromobility import Electromobility
@@ -558,12 +559,22 @@ class EDisGo:
         """
         if self.timeseries.timeindex.empty:
             logger.warning(
-                "When setting time series using predefined profiles it is better to "
-                "set a time index as all data in TimeSeries class is indexed by the"
-                "time index. You can set the time index upon initialisation of "
-                "the EDisGo object by providing the input parameter 'timeindex' or by "
-                "using the function EDisGo.set_timeindex()."
+                "The EDisGo.TimeSeries.timeindex is empty. By default, this function "
+                "will set the timeindex to the default year of the provided database "
+                "connection or, if specified, to the given timeindex. To ensure "
+                "expected behavior, consider setting the timeindex explicitly before "
+                "running this function using EDisGo.set_timeindex()."
             )
+
+            timeindex = kwargs.get("timeindex", None)
+
+            if timeindex is None:
+                timeindex, _ = _timeindex_helper_func(
+                    self, timeindex, allow_leap_year=True
+                )
+
+            self.set_timeindex(timeindex)
+
         if fluctuating_generators_ts is not None:
             self.timeseries.predefined_fluctuating_generators_by_technology(
                 self,
@@ -1846,9 +1857,11 @@ class EDisGo:
                 [
                     pd.DataFrame(
                         {
-                            naming.format("_".join(k))
-                            if isinstance(k, tuple)
-                            else naming.format(k): getattr(self.timeseries, attribute)
+                            (
+                                naming.format("_".join(k))
+                                if isinstance(k, tuple)
+                                else naming.format(k)
+                            ): getattr(self.timeseries, attribute)
                             .loc[:, v]
                             .sum(axis=1)
                         }

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -557,21 +557,37 @@ class EDisGo:
             is indexed using a default year and set for the whole year.
 
         """
-        if self.timeseries.timeindex.empty:
+
+        timeindex = kwargs.get("timeindex", None)
+        set_timeindex = False
+
+        if (timeindex is not None) and not timeindex.equals(self.timeseries.timeindex):
+            logger.warning(
+                "The given timeindex is different from the EDisGo.TimeSeries.timeindex."
+                " Therefore the EDisGo.TimeSeries.timeindex will be overwritten by the "
+                "given timeindex."
+            )
+
+            set_timeindex = True
+
+        elif self.timeseries.timeindex.empty:
             logger.warning(
                 "The EDisGo.TimeSeries.timeindex is empty. By default, this function "
                 "will set the timeindex to the default year of the provided database "
-                "connection or, if specified, to the given timeindex. To ensure "
-                "expected behavior, consider setting the timeindex explicitly before "
-                "running this function using EDisGo.set_timeindex()."
+                "connection. To ensure expected behavior, consider setting the "
+                "timeindex explicitly before running this function using "
+                "EDisGo.set_timeindex()."
             )
 
-            timeindex = kwargs.get("timeindex", None)
+            set_timeindex = True
 
+        if set_timeindex:
             if timeindex is None:
                 timeindex, _ = _timeindex_helper_func(
                     self, timeindex, allow_leap_year=True
                 )
+
+            logger.warning(f"Setting EDisGo.TimeSeries.timeindex to {timeindex}.")
 
             self.set_timeindex(timeindex)
 

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -207,7 +207,7 @@ class TestEDisGo:
         # check warning
         self.edisgo.set_time_series_active_power_predefined()
         assert (
-            "When setting time series using predefined profiles it is better"
+            "The EDisGo.TimeSeries.timeindex is empty. By default, this function"
             in caplog.text
         )
 

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -934,9 +934,9 @@ class TestEDisGo:
 
         # ##### test without any aggregation
 
-        self.edisgo.topology._loads_df.at[
-            "Load_residential_LVGrid_1_4", "bus"
-        ] = "Bus_BranchTee_LVGrid_1_10"
+        self.edisgo.topology._loads_df.at["Load_residential_LVGrid_1_4", "bus"] = (
+            "Bus_BranchTee_LVGrid_1_10"
+        )
 
         # save original values
         number_gens_before = len(self.edisgo.topology.generators_df)
@@ -1054,9 +1054,9 @@ class TestEDisGo:
         )
         # manipulate grid so that more than one load of the same sector is
         # connected at the same bus
-        self.edisgo.topology._loads_df.at[
-            "Load_residential_LVGrid_1_4", "bus"
-        ] = "Bus_BranchTee_LVGrid_1_10"
+        self.edisgo.topology._loads_df.at["Load_residential_LVGrid_1_4", "bus"] = (
+            "Bus_BranchTee_LVGrid_1_10"
+        )
 
         # save original values (only loads, as generators did not change)
         loads_p_set_before = self.edisgo.topology.loads_df.p_set.sum()
@@ -1136,9 +1136,9 @@ class TestEDisGo:
 
         # manipulate grid so that two generators of different types are
         # connected at the same bus
-        self.edisgo.topology._generators_df.at[
-            "GeneratorFluctuating_13", "type"
-        ] = "misc"
+        self.edisgo.topology._generators_df.at["GeneratorFluctuating_13", "type"] = (
+            "misc"
+        )
 
         # save original values (values of loads were changed in previous aggregation)
         loads_p_set_before = self.edisgo.topology.loads_df.p_set.sum()


### PR DESCRIPTION
# Description

- Automatically set `EDisGo.TimeSeries.timeindex` to the default year of the database if it is empty.  
- Added a logger warning to inform users about the default behavior and recommend setting the `timeindex` explicitly using `EDisGo.set_timeindex()`.

Fixes #456 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] ~New and adjusted code includes type hinting now~
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] ~If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).~
- [x] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
