### PR TITLE
Refactor object copying in EDisGo class

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -1349,7 +1349,7 @@ class EDisGo:
 
         """
         if copy_grid:
-            edisgo_obj = copy.deepcopy(self)
+            edisgo_obj = self.copy()
         else:
             edisgo_obj = self
 
@@ -3121,7 +3121,7 @@ class EDisGo:
 
         """
         if copy_edisgo is True:
-            edisgo_obj = copy.deepcopy(self)
+            edisgo_obj = self.copy()
         else:
             edisgo_obj = self
         busmap_df, linemap_df = spatial_complexity_reduction(
@@ -3334,6 +3334,44 @@ class EDisGo:
         self.electromobility.resample(freq=freq)
         self.heat_pump.resample_timeseries(method=method, freq=freq)
         self.overlying_grid.resample(method=method, freq=freq)
+
+    def copy(self, deep=True):
+        """
+        Returns a copy of the object, with an option for a deep copy.
+
+        The SQLAlchemy engine is excluded from the copying process and restored
+        afterward.
+
+        Parameters
+        ----------
+        deep : bool
+            If True, performs a deep copy; otherwise, performs a shallow copy.
+
+        Returns
+        ---------
+        :class:`~.EDisGo`
+            Copied EDisGo object.
+
+        """
+        tmp_engine = (
+            getattr(self, "engine", None)
+            if isinstance(getattr(self, "engine", None), Engine)
+            else None
+        )
+
+        if tmp_engine:
+            logging.info("Temporarily removing the SQLAlchemy engine before copying.")
+            self.engine = self.config._engine = None
+
+        cpy = copy.deepcopy(self) if deep else copy.copy(self)
+
+        if tmp_engine:
+            logging.info("Restoring the SQLAlchemy engine after copying.")
+            self.engine = self.config._engine = cpy.engine = cpy.config._engine = (
+                tmp_engine
+            )
+
+        return cpy
 
 
 def import_edisgo_from_pickle(filename, path=""):


### PR DESCRIPTION
- Replaced direct use of copy.deepcopy with custom copy method in two places.
- Added a new `copy` method to the `EDisGo` class, supporting both shallow and deep copies while excluding the SQLAlchemy engine from being copied.
- Ensured proper restoration of the SQLAlchemy engine after copying.