### PR TITLE
fix(plot_plotly): remove conflicting xaxis/yaxis layout when using ma…

### DIFF
--- a/edisgo/tools/plots.py
+++ b/edisgo/tools/plots.py
@@ -1258,6 +1258,7 @@ def plot_plotly(
 
             data_line_plot.append(edge_scatter)
 
+        # Add colorbar for line colors (works for both map and non-map plots)
         if line_color:
             line_color_title = {
                 "loading": "Loading in MVA",
@@ -1265,24 +1266,47 @@ def plot_plotly(
                 "reinforce": "Reinforce",
             }
 
-            colorbar_edge_scatter = go.Scatter(
-                mode="markers",
-                x=[None],
-                y=[None],
-                marker=dict(
-                    colorbar=dict(
-                        title=line_color_title[line_color],
-                        xanchor="left",
-                        titleside="right",
-                        x=1.19,
-                        thickness=15,
+            # Create invisible scatter plot for colorbar
+            if plot_map:
+                colorbar_edge_scatter = go.Scattermapbox(
+                    mode="markers",
+                    lon=[None],
+                    lat=[None],
+                    marker=dict(
+                        colorbar=dict(
+                            title=line_color_title[line_color],
+                            xanchor="left",
+                            titleside="right",
+                            x=1.02,
+                            thickness=15,
+                        ),
+                        colorscale=colorscale,
+                        cmax=color_max,
+                        cmin=color_min,
+                        showscale=showscale,
+                        opacity=0,  # Make invisible
                     ),
-                    colorscale=colorscale,
-                    cmax=color_max,
-                    cmin=color_min,
-                    showscale=showscale,
-                ),
-            )
+                    showlegend=False,
+                )
+            else:
+                colorbar_edge_scatter = go.Scatter(
+                    mode="markers",
+                    x=[None],
+                    y=[None],
+                    marker=dict(
+                        colorbar=dict(
+                            title=line_color_title[line_color],
+                            xanchor="left",
+                            titleside="right",
+                            x=1.19,
+                            thickness=15,
+                        ),
+                        colorscale=colorscale,
+                        cmax=color_max,
+                        cmin=color_min,
+                        showscale=showscale,
+                    ),
+                )
 
             if line_color == "reinforce":
                 colorbar_edge_scatter.marker.colorbar.tickmode = "array"
@@ -1381,6 +1405,9 @@ def plot_plotly(
                 text += "<br>" + str(index) + " = " + str(value)
 
             node_text.append(text)
+        # Create node scatter plots
+        node_scatter_plots = []
+
         if plot_map:
             node_scatter = go.Scattermapbox(
                 lon=node_x,
@@ -1389,12 +1416,11 @@ def plot_plotly(
                 hoverinfo="text",
                 text=node_text,
                 marker=dict(
-                    showscale=showscale,
+                    showscale=False,  # Disable colorbar for mapbox, added it separately
                     colorscale=colorscale,
                     color=node_colors,
                     size=8,
                     cmid=cmid,
-                    colorbar=colorbar,
                 ),
             )
         else:
@@ -1415,11 +1441,103 @@ def plot_plotly(
                 ),
             )
 
-        return [node_scatter]
+        node_scatter_plots.append(node_scatter)
 
-    fig = go.Figure(
-        data=plot_lines() + plot_buses() + plot_line_text(),
-        layout=go.Layout(
+        # Add separate colorbar for nodes in mapbox plots
+        if plot_map and node_color and showscale:
+            if plot_map:
+                node_colorbar_scatter = go.Scattermapbox(
+                    mode="markers",
+                    lon=[None],
+                    lat=[None],
+                    marker=dict(
+                        colorbar=dict(
+                            title=colorbar["title"] if colorbar else "Node values",
+                            xanchor="left",
+                            titleside="right",
+                            x=1.12,  # Position it next to line colorbar
+                            thickness=15,
+                        ),
+                        colorscale=colorscale,
+                        color=[0, 1],  # Dummy values for colorbar range
+                        cmax=max(node_colors) if isinstance(node_colors, list) else 1,
+                        cmin=min(node_colors) if isinstance(node_colors, list) else 0,
+                        cmid=cmid,
+                        showscale=True,
+                        opacity=0,  # Make invisible
+                    ),
+                    showlegend=False,
+                )
+                node_scatter_plots.append(node_colorbar_scatter)
+
+        return node_scatter_plots
+
+    # Calculate optimal zoom level for map based on network extent
+    def calculate_zoom_level():
+        if not plot_map:
+            return 11  # Default zoom for non-map plots
+
+        # Get all node coordinates
+        lats = []
+        lons = []
+        for node in G.nodes():
+            x, y = G.nodes[node]["pos"]
+            lons.append(x)
+            lats.append(y)
+
+        if not lats or not lons:
+            return 11  # Default if no coordinates
+
+        # Calculate bounds
+        lat_min, lat_max = min(lats), max(lats)
+        lon_min, lon_max = min(lons), max(lons)
+
+        # Calculate the extent in degrees
+        lat_range = lat_max - lat_min
+        lon_range = lon_max - lon_min
+        max_range = max(lat_range, lon_range)
+
+        # Simple zoom level calculation based on coordinate range
+        # These values are empirically determined for good fit
+        if max_range > 0.5:
+            zoom = 9
+        elif max_range > 0.2:
+            zoom = 10
+        elif max_range > 0.1:
+            zoom = 11
+        elif max_range > 0.05:
+            zoom = 12
+        elif max_range > 0.02:
+            zoom = 13
+        elif max_range > 0.01:
+            zoom = 14
+        elif max_range > 0.005:
+            zoom = 15
+        else:
+            zoom = 16
+
+        return min(zoom, 18)  # Cap at maximum zoom level
+
+    zoom_level = calculate_zoom_level()
+
+    # Create layout based on whether map is enabled
+    if plot_map:
+        layout = go.Layout(
+            height=height,
+            showlegend=False,
+            hovermode="closest",
+            margin=dict(b=20, l=5, r=5, t=40),
+            mapbox=dict(
+                center=dict(
+                    lat=y_center,
+                    lon=x_center,
+                ),
+                zoom=zoom_level,
+                style="open-street-map",
+            ),
+        )
+    else:
+        layout = go.Layout(
             height=height,
             showlegend=False,
             hovermode="closest",
@@ -1436,17 +1554,11 @@ def plot_plotly(
                 scaleanchor="x",
                 scaleratio=1,
             ),
-            mapbox=dict(
-                # bearing=0,
-                center=dict(
-                    lat=y_center,
-                    lon=x_center,
-                ),
-                # pitch=0,
-                zoom=11,
-                style="open-street-map",
-            ),
-        ),
+        )
+
+    fig = go.Figure(
+        data=plot_lines() + plot_buses() + plot_line_text(),
+        layout=layout,
     )
     if warning_message:
         fig.add_annotation(


### PR DESCRIPTION
…pbox

When plot_map=True and power flow data is present, the layout incorrectly included both mapbox and classic x/y axis settings. This caused Plotly to fall back to default axes, disabling zoom and displaying unintended axis labels.

The fix ensures that xaxis/yaxis settings are only applied when plot_map=False, preventing layout conflicts and restoring full interactivity.

# Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
