### PR TITLE
Skip deprecated tests in generators import and examples that used oep mviews

### DIFF
--- a/tests/io/test_generators_import.py
+++ b/tests/io/test_generators_import.py
@@ -484,6 +484,7 @@ class TestGeneratorsImportOEDB:
     """
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_without_timeseries(self):
         edisgo = EDisGo(
             ding0_grid=pytest.ding0_test_network_2_path,
@@ -497,6 +498,7 @@ class TestGeneratorsImportOEDB:
         assert np.isclose(edisgo.topology.generators_df.p_nom.sum(), 20.18783)
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_with_worst_case_timeseries(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
         edisgo.set_time_series_worst_case_analysis()
@@ -568,6 +570,7 @@ class TestGeneratorsImportOEDB:
         #     :, new_solar_gen.name] / new_solar_gen.p_nom).all()
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_with_timeseries_by_technology(self):
         timeindex = pd.date_range("1/1/2012", periods=3, freq="H")
         ts_gen_dispatchable = pd.DataFrame(
@@ -647,6 +650,7 @@ class TestGeneratorsImportOEDB:
         #     :, new_solar_gen.name] / new_solar_gen.p_nom).all()
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_target_capacity(self):
         edisgo = EDisGo(
             ding0_grid=pytest.ding0_test_network_2_path,

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -381,6 +381,7 @@ class TestEDisGo:
         )
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_generator_import(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
         edisgo.import_generators("nep2035")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -39,6 +39,7 @@ class TestExamples:
         assert result.exec_error is None
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_edisgo_simple_example_ipynb(self):
         path = os.path.join(self.examples_dir_path, "edisgo_simple_example.ipynb")
         notebook = pytest_notebook.notebook.load_notebook(path=path)


### PR DESCRIPTION
Mark deprecated tests as skipped to prevent execution during testing. This needs to be done since the mviews are no longer supported in the oep

