### PR TITLE
Add Python version badge and skip deprecated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/openego/eDisGo/badge.svg?branch=dev)](https://coveralls.io/github/openego/eDisGo?branch=dev)
 [![Tests & coverage](https://github.com/openego/eDisGo/actions/workflows/tests-coverage.yml/badge.svg)](https://github.com/openego/eDisGo/actions/workflows/tests-coverage.yml)
+![Python Versions](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11-blue)
+
 
 
 # eDisGo

--- a/tests/io/test_generators_import.py
+++ b/tests/io/test_generators_import.py
@@ -484,6 +484,7 @@ class TestGeneratorsImportOEDB:
     """
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_without_timeseries(self):
         edisgo = EDisGo(
             ding0_grid=pytest.ding0_test_network_2_path,
@@ -497,6 +498,7 @@ class TestGeneratorsImportOEDB:
         assert np.isclose(edisgo.topology.generators_df.p_nom.sum(), 20.18783)
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_with_worst_case_timeseries(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
         edisgo.set_time_series_worst_case_analysis()
@@ -568,6 +570,7 @@ class TestGeneratorsImportOEDB:
         #     :, new_solar_gen.name] / new_solar_gen.p_nom).all()
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_with_timeseries_by_technology(self):
         timeindex = pd.date_range("1/1/2012", periods=3, freq="H")
         ts_gen_dispatchable = pd.DataFrame(
@@ -647,6 +650,7 @@ class TestGeneratorsImportOEDB:
         #     :, new_solar_gen.name] / new_solar_gen.p_nom).all()
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_target_capacity(self):
         edisgo = EDisGo(
             ding0_grid=pytest.ding0_test_network_2_path,

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -381,6 +381,7 @@ class TestEDisGo:
         )
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_generator_import(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
         edisgo.import_generators("nep2035")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -39,6 +39,7 @@ class TestExamples:
         assert result.exec_error is None
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_edisgo_simple_example_ipynb(self):
         path = os.path.join(self.examples_dir_path, "edisgo_simple_example.ipynb")
         notebook = pytest_notebook.notebook.load_notebook(path=path)


### PR DESCRIPTION
Update the README to include a badge for supported Python versions. Skip deprecated tests in the generators import and examples to address ongoing issues.

