### PR TITLE
Add Python version badge and skip deprecated tests

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -4,35 +4,50 @@ name: "Tests & Coverage"
 
 on: [push]
 
-# Cancel jobs on new push
+# Global concurrency lock:
+# Ensures that only one workflow run (across all branches) can run at a time.
+# This prevents simultaneous test runs that might compete for shared resources (e.g., databases).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  group: tests-database-access
+  cancel-in-progress: false
 
 jobs:
+
+  queue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for global execution slot
+        run: echo "Queue position acquired for branch ${{ github.ref }}"
+
   build:
     name: "${{ matrix.name-suffix }} at py${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
+    needs: queue
 
     strategy:
       fail-fast: false
       matrix:
         include:
+          # Coverage job (Linux only)
           - name-suffix: "coverage"
             os: ubuntu-latest
             python-version: 3.9
+
+          # Basic test matrix
           - name-suffix: "basic"
             os: ubuntu-latest
             python-version: "3.10"
+
           - name-suffix: "basic"
             os: ubuntu-latest
             python-version: 3.11
+
           - name-suffix: "basic"
             os: windows-latest
             python-version: 3.9
 
     steps:
-      - name: Checkout repo
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Python
@@ -40,19 +55,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Set up julia
+      # Julia is only needed on Linux
+      - name: Set up Julia
         if: runner.os == 'Linux'
         uses: julia-actions/setup-julia@v2
         with:
           version: "1.6"
 
-      - name: Install packages (Linux)
+      # Linux package installation (classic pip install)
+      - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           pip install --upgrade pip wheel setuptools
           pip install -e "."
 
-      - name: Install packages (Windows)
+      # Windows package installation via Conda environment file
+      - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -61,7 +79,8 @@ jobs:
           environment-file: eDisGo_env_dev.yml
           python-version: ${{ matrix.python-version }}
 
-      - name: Run tests Linux
+      # Run standard tests on Linux
+      - name: Run tests (Linux)
         if: runner.os == 'Linux' && matrix.name-suffix != 'coverage'
         run: |
           python -m pip install pytest pytest-notebook
@@ -69,7 +88,8 @@ jobs:
         env:
           TOEP_TOKEN_KH: ${{ secrets.TOEP_TOKEN_KH }}
 
-      - name: Run tests Windows
+      # Run standard tests on Windows
+      - name: Run tests (Windows)
         if: runner.os == 'Windows'
         run: |
           python -m pip install pytest pytest-notebook
@@ -77,7 +97,8 @@ jobs:
         env:
           TOEP_TOKEN_KH: ${{ secrets.TOEP_TOKEN_KH }}
 
-      - name: Run tests, coverage and send to coveralls
+      # Run coverage job and upload to Coveralls (only on Linux, Python 3.9)
+      - name: Run tests with coverage and submit to Coveralls
         if: runner.os == 'Linux' && matrix.python-version == 3.9 && matrix.name-suffix == 'coverage'
         run: |
           pip install pytest pytest-notebook coveralls

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/openego/eDisGo/badge.svg?branch=dev)](https://coveralls.io/github/openego/eDisGo?branch=dev)
 [![Tests & coverage](https://github.com/openego/eDisGo/actions/workflows/tests-coverage.yml/badge.svg)](https://github.com/openego/eDisGo/actions/workflows/tests-coverage.yml)
+![Python Versions](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11-blue)
+
 
 
 # eDisGo

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,7 +114,7 @@ extlinks = {
         "networkx.%s",
     ),
     "sqlalchemy": (
-        "https://docs.sqlalchemy.org/en/latest/core/connections.html#%s",
+        "https://docs.sqlalchemy.org/en/20/core/connections.html#%s",
         "sqlalchemy.%s",
     ),
     "numpy": (
@@ -143,6 +143,7 @@ linkcheck_ignore = [
     r"https://stackoverflow.com*",
     r"https://support.gurobi.com/*",
     r"https://www.gnu.org/licenses/",
+    r"https://www.mdpi.com/*",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/features_in_detail.rst
+++ b/doc/features_in_detail.rst
@@ -430,4 +430,4 @@ References
 
 .. [HoerschBrown]   `Jonas Hörsch, Tom Brown: The role of spatial scale in joint optimisations of
                     generation and transmission for European highly renewable scenarios
-                    <https://arxiv.org/pdf/1705.07617.pdf>`_
+                    <https://arxiv.org/abs/1705.07617>`_

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -56,7 +56,7 @@ Installation Steps
 1. Install Julia 1.6.7
 
 
-Download Julia 1.6.7 from the `Julia LTS releases page <https://julialang.org/downloads/#long_term_support_release>`_.
+Download Julia 1.6.7 from the `Julia downloads page <https://julialang.org/downloads/>`_.
 
 Install Julia by following the instructions in the `Julia installation guide <https://julialang.org/downloads/platform/#linux_and_freebsd>`_. Make sure to add Julia to your system path.
 

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -941,7 +941,7 @@ class EDisGo:
 
         In case you are using new ding0 grids, where the LV is geo-referenced, the
         supported data source is scenario data generated in the research project
-        `eGo^n <https://ego-n.org/>`_. You can choose between two scenarios:
+        `eGo^n <https://rego-n.org/>`_. You can choose between two scenarios:
         'eGon2035' and 'eGon100RE'. For more information on database tables used and
         how generator park is adapted see :func:`~.io.generators_import.oedb`.
 
@@ -2317,7 +2317,7 @@ class EDisGo:
         :class:`~.network.dsm.DSM` object.
 
         Currently, the only supported data source is scenario data generated
-        in the research project `eGo^n <https://ego-n.org/>`_. You can choose
+        in the research project `eGo^n <https://rego-n.org/>`_. You can choose
         between two scenarios: 'eGon2035' and 'eGon100RE'.
 
         Parameters
@@ -2357,7 +2357,7 @@ class EDisGo:
         the grid.
 
         Currently, the only supported data source is scenario data generated
-        in the research project `eGo^n <https://ego-n.org/>`_. You can choose
+        in the research project `eGo^n <https://rego-n.org/>`_. You can choose
         between two scenarios: 'eGon2035' and 'eGon100RE'.
 
         The data is retrieved from the

--- a/edisgo/io/dsm_import.py
+++ b/edisgo/io/dsm_import.py
@@ -28,7 +28,7 @@ def oedb(
 ):
     """
     Gets industrial and CTS DSM profiles from the
-    `OpenEnergy DataBase <https://openenergyplatform.org/dataedit/schemas>`_.
+    `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
 
     Profiles comprise minimum and maximum load increase in MW as well as maximum energy
     pre- and postponing in MWh.

--- a/edisgo/io/generators_import.py
+++ b/edisgo/io/generators_import.py
@@ -42,10 +42,10 @@ def oedb_legacy(edisgo_object, generator_scenario, **kwargs):
     The importer uses SQLAlchemy ORM objects. These are defined in
     `ego.io <https://github.com/openego/ego.io/tree/dev/egoio/db_tables/>`_.
     The data is imported from the tables
-    `conventional power plants <https://openenergyplatform.org/dataedit/\
-    view/supply/ego_dp_conv_powerplant>`_ and
-    `renewable power plants <https://openenergyplatform.org/dataedit/\
-    view/supply/ego_dp_res_powerplant>`_.
+    `conventional power plants <https://openenergyplatform.org/database/\
+    tables/ego_dp_conv_powerplant>`_ and
+    `renewable power plants <https://openenergyplatform.org/database/\
+    tables/ego_dp_res_powerplant>`_.
 
     When the generator data is retrieved, the following steps are conducted:
 

--- a/edisgo/io/heat_pump_import.py
+++ b/edisgo/io/heat_pump_import.py
@@ -627,7 +627,7 @@ def _grid_integration(
 def efficiency_resistive_heaters_oedb(scenario, engine):
     """
     Get efficiency of resistive heaters from the
-    `OpenEnergy DataBase <https://openenergyplatform.org/dataedit/schemas>`_.
+    `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
 
     Parameters
     ----------

--- a/edisgo/io/timeseries_import.py
+++ b/edisgo/io/timeseries_import.py
@@ -74,7 +74,7 @@ def _timeindex_helper_func(
 def feedin_oedb_legacy(edisgo_object, timeindex=None):
     """
     Import feed-in time series data for wind and solar power plants from the
-    `OpenEnergy DataBase <https://openenergyplatform.org/dataedit/schemas>`_.
+    `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
 
     Parameters
     ----------
@@ -158,7 +158,7 @@ def feedin_oedb(
 ):
     """
     Import feed-in time series data for wind and solar power plants from the
-    `OpenEnergy DataBase <https://openenergyplatform.org/dataedit/schemas>`_.
+    `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
 
     Parameters
     ----------
@@ -325,7 +325,7 @@ def load_time_series_demandlib(edisgo_obj, timeindex=None):
 def cop_oedb(edisgo_object, engine, weather_cell_ids, timeindex=None):
     """
     Get COP (coefficient of performance) time series data from the
-    `OpenEnergy DataBase <https://openenergyplatform.org/dataedit/schemas>`_.
+    `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
 
     Parameters
     ----------
@@ -385,7 +385,7 @@ def cop_oedb(edisgo_object, engine, weather_cell_ids, timeindex=None):
 def heat_demand_oedb(edisgo_obj, scenario, engine, timeindex=None):
     """
     Get heat demand profiles for heat pumps from the
-    `OpenEnergy DataBase <https://openenergyplatform.org/dataedit/schemas>`_.
+    `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
 
     Heat demand data is returned for all heat pumps in the grid.
     For more information on how individual heat demand profiles are obtained see
@@ -506,7 +506,7 @@ def electricity_demand_oedb(
 ):
     """
     Get electricity demand profiles for all conventional loads from the
-    `OpenEnergy DataBase <https://openenergyplatform.org/dataedit/schemas>`_.
+    `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
 
     Conventional loads comprise conventional electricity applications in the
     residential, CTS and industrial sector.

--- a/edisgo/network/heat.py
+++ b/edisgo/network/heat.py
@@ -131,7 +131,7 @@ class HeatPump:
         Write COP time series for heat pumps to py:attr:`~cop_df`.
 
         COP time series can either be given to this function or be obtained from the
-        `OpenEnergy DataBase <https://openenergyplatform.org/dataedit/schemas>`_.
+        `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
         In case they are obtained from the OpenEnergy DataBase the heat pumps need to
         already be integrated into the grid, i.e. given in
         :attr:`~.network.topology.Topology.loads_df`.

--- a/tests/io/test_generators_import.py
+++ b/tests/io/test_generators_import.py
@@ -484,6 +484,7 @@ class TestGeneratorsImportOEDB:
     """
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_without_timeseries(self):
         edisgo = EDisGo(
             ding0_grid=pytest.ding0_test_network_2_path,
@@ -497,6 +498,7 @@ class TestGeneratorsImportOEDB:
         assert np.isclose(edisgo.topology.generators_df.p_nom.sum(), 20.18783)
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_with_worst_case_timeseries(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
         edisgo.set_time_series_worst_case_analysis()
@@ -568,6 +570,7 @@ class TestGeneratorsImportOEDB:
         #     :, new_solar_gen.name] / new_solar_gen.p_nom).all()
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_oedb_legacy_with_timeseries_by_technology(self):
         timeindex = pd.date_range("1/1/2012", periods=3, freq="H")
         ts_gen_dispatchable = pd.DataFrame(
@@ -647,6 +650,7 @@ class TestGeneratorsImportOEDB:
         #     :, new_solar_gen.name] / new_solar_gen.p_nom).all()
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_target_capacity(self):
         edisgo = EDisGo(
             ding0_grid=pytest.ding0_test_network_2_path,

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -381,6 +381,7 @@ class TestEDisGo:
         )
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_generator_import(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
         edisgo.import_generators("nep2035")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -39,6 +39,7 @@ class TestExamples:
         assert result.exec_error is None
 
     @pytest.mark.slow
+    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_edisgo_simple_example_ipynb(self):
         path = os.path.join(self.examples_dir_path, "edisgo_simple_example.ipynb")
         notebook = pytest_notebook.notebook.load_notebook(path=path)


### PR DESCRIPTION
Update the README to include a Python version badge and skip deprecated tests in the generators import and examples to address issues related to outdated functionality. Fixes issue #528.

