### PR TITLE
Implement flexible charging strategies for subset of charging parks

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -2065,7 +2065,7 @@ class EDisGo:
 
         integrate_charging_parks(self)
 
-    def apply_charging_strategy(self, strategy="dumb", **kwargs):
+    def apply_charging_strategy(self, strategy: str = "dumb", charging_park_ids: list[int] | None = None, **kwargs):
         """
         Applies charging strategy to set EV charging time series at charging parks.
 
@@ -2133,7 +2133,7 @@ class EDisGo:
         series resampled back to the original frequency.
 
         """
-        charging_strategy(self, strategy=strategy, **kwargs)
+        charging_strategy(self, strategy=strategy, charging_park_ids=charging_park_ids, **kwargs)
 
     def import_heat_pumps(self, scenario, engine, timeindex=None, import_types=None):
         """

--- a/edisgo/flex_opt/charging_strategies.py
+++ b/edisgo/flex_opt/charging_strategies.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from numbers import Number
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 import numpy as np
 import pandas as pd
@@ -52,6 +52,7 @@ def charging_strategy(
     strategy: str = "dumb",
     timestamp_share_threshold: Number = 0.2,
     minimum_charging_capacity_factor: Number = 0.1,
+    charging_park_ids: Iterable[int] | None = None,
 ):
     """
     Applies charging strategy to set EV charging time series at charging parks.
@@ -78,21 +79,48 @@ def charging_strategy(
 
     """
     # get integrated charging parks
+    integrated_parks = edisgo_obj.electromobility.integrated_charging_parks_df
+
+    # Bestimmen, welche Ladeparks überhaupt angesprochen werden
+    if charging_park_ids is None:
+        target_park_ids = integrated_parks.index
+    else:
+        charging_park_ids = list(charging_park_ids)
+        target_park_ids = integrated_parks.index.intersection(charging_park_ids)
+
+        missing_ids = sorted(set(charging_park_ids) - set(target_park_ids))
+        if missing_ids:
+            logger.warning(
+                "The following charging park IDs are not integrated and will be "
+                "ignored in charging_strategy: %s",
+                missing_ids,
+            )
+
+    # PotentialChargingParks-Objekte auf diese Submenge filtern
     charging_parks = [
         cp
-        for cp in list(edisgo_obj.electromobility.potential_charging_parks)
-        if cp.grid is not None
+        for cp in edisgo_obj.electromobility.potential_charging_parks
+        if cp.grid is not None and cp.id in target_park_ids
     ]
 
-    # Delete possible old time series as these influence "residual" charging
+    if len(charging_parks) == 0:
+        logger.info(
+            "No charging parks selected for charging strategy '%s'. Nothing to do.",
+            strategy,
+        )
+        return
+
+    # EDisGo-IDs der betroffenen Ladeparks
+    edisgo_ids_to_update = integrated_parks.loc[target_park_ids, "edisgo_id"].values
+
+    # Nur für diese Ladeparks alte Zeitreihen löschen
     edisgo_obj.timeseries.drop_component_time_series(
         "loads_active_power",
-        edisgo_obj.electromobility.integrated_charging_parks_df.edisgo_id.values,
+        edisgo_ids_to_update,
     )
-
     edisgo_obj.timeseries.drop_component_time_series(
         "loads_reactive_power",
-        edisgo_obj.electromobility.integrated_charging_parks_df.edisgo_id.values,
+        edisgo_ids_to_update,
     )
 
     eta_cp = edisgo_obj.electromobility.eta_charging_points
@@ -196,8 +224,8 @@ def charging_strategy(
         # "residual" charging
         # only use charging processes from integrated charging parks
         charging_processes_df = edisgo_obj.electromobility.charging_processes_df[
-            edisgo_obj.electromobility.charging_processes_df.charging_park_id.isin(
-                edisgo_obj.electromobility.integrated_charging_parks_df.index
+        edisgo_obj.electromobility.charging_processes_df.charging_park_id.isin(
+        target_park_ids
             )
         ]
 
@@ -318,8 +346,7 @@ def charging_strategy(
         pd.DataFrame(
             data=0.0,
             index=edisgo_obj.timeseries.timeindex,
-            columns=edisgo_obj.electromobility.integrated_charging_parks_df
-            .edisgo_id.values,
+            columns=edisgo_ids_to_update,
         ),
     )
     # fmt: on

--- a/tests/flex_opt/test_charging_strategy.py
+++ b/tests/flex_opt/test_charging_strategy.py
@@ -102,9 +102,12 @@ class TestChargingStrategy:
         Charging strategies can be applied to different subsets of charging parks
         without overwriting each other's results.
         """
+        #edisgo = self.edisgo_obj
+        timeindex = pd.date_range("1/1/2011", periods=24 * 7, freq="H")
         edisgo = self.edisgo_obj
-        ts = edisgo.timeseries
+        edisgo.set_timeindex(timeindex)
 
+        ts = edisgo.timeseries
         # Baseline: apply a strategy to all integrated charging parks
         # so that we have non-zero time series for all of them.
         edisgo.apply_charging_strategy(strategy="dumb")

--- a/tests/flex_opt/test_charging_strategy.py
+++ b/tests/flex_opt/test_charging_strategy.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-
+import numpy as np
 from edisgo.edisgo import EDisGo
 from edisgo.flex_opt.charging_strategies import charging_strategy
 
@@ -96,3 +96,64 @@ class TestChargingStrategy:
         self.edisgo_obj.set_timeindex(timeindex)
         charging_strategy(self.edisgo_obj, strategy="dumb")
         assert ts._loads_active_power.index.freqstr == "15T"
+
+    def test_charging_strategy_with_subset_of_parks(self):
+        """
+        Charging strategies can be applied to different subsets of charging parks
+        without overwriting each other's results.
+        """
+        edisgo = self.edisgo_obj
+        ts = edisgo.timeseries
+
+        # Baseline: apply a strategy to all integrated charging parks
+        # so that we have non-zero time series for all of them.
+        edisgo.apply_charging_strategy(strategy="dumb")
+
+        integrated = edisgo.electromobility.integrated_charging_parks_df
+        all_park_ids = list(integrated.index)
+
+        # If the test network had less than two charging parks, this test would
+        # not make sense.
+        if len(all_park_ids) < 2:
+            pytest.skip("Not enough charging parks for subset test.")
+
+        park_a = all_park_ids[0]
+        park_b = all_park_ids[1]
+
+        edisgo_id_a = integrated.loc[park_a, "edisgo_id"]
+        edisgo_id_b = integrated.loc[park_b, "edisgo_id"]
+
+        # store baseline time series for both parks
+        loads_before = ts._loads_active_power.copy()
+        ts_a_before = loads_before[edisgo_id_a].copy()
+        ts_b_before = loads_before[edisgo_id_b].copy()
+
+        # 1) apply a strategy only to park A
+        edisgo.apply_charging_strategy(
+            strategy="reduced",
+            charging_park_ids=[park_a],
+        )
+
+        loads_after_first = ts._loads_active_power
+        ts_a_after_first = loads_after_first[edisgo_id_a].copy()
+        ts_b_after_first = loads_after_first[edisgo_id_b].copy()
+
+        
+        # park B should be unchanged by a call that only targets park A
+        pd.testing.assert_series_equal(ts_b_before, ts_b_after_first, check_names=True)
+
+        # 2) apply a different strategy only to park B
+        edisgo.apply_charging_strategy(
+            strategy="residual",
+            charging_park_ids=[park_b],
+        )
+
+        loads_after_second = ts._loads_active_power
+        ts_a_after_second = loads_after_second[edisgo_id_a].copy()
+        ts_b_after_second = loads_after_second[edisgo_id_b].copy()
+
+        
+        # park A must not be changed by the second call that targets only park B
+        pd.testing.assert_series_equal(
+            ts_a_after_first, ts_a_after_second, check_names=True
+        )    


### PR DESCRIPTION
Fixes #330

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Summary

This PR allows charging strategies to be applied to a subset of charging parks instead of always to all integrated charging parks. This makes it possible to combine different charging strategies within the same EDisGo instance (e.g. some charging parks using `residual`, others using `dumb`).

## Changes

- Extend `EDisGo.apply_charging_strategy` to accept an optional argument  
  `charging_park_ids: Iterable[int] | None`.
  - If `charging_park_ids` is `None` (default), behaviour is unchanged: the strategy is applied to all integrated charging parks.
  - If a list/iterable of IDs is provided, the strategy is applied only to those charging parks.
- Update `flex_opt.charging_strategies.charging_strategy` to:
  - Take the same `charging_park_ids` argument.
  - Determine `target_park_ids` as the intersection of the provided IDs with the indices of `integrated_charging_parks_df`.
  - Filter `charging_parks` and `charging_processes_df` to `target_park_ids`.
  - Drop existing active and reactive power time series only for the selected charging parks instead of all integrated charging parks.
  - Add/update active and reactive power time series only for the selected charging parks.
  - Log a warning if non-integrated charging park IDs are passed.
- Keep the existing strategies `"dumb"`, `"reduced"` and `"residual"` working as before, but applied to the filtered subset when `charging_park_ids` is set, preserving backward compatibility when it is not provided.

## Implementation details

- `EDisGo.apply_charging_strategy` remains a thin wrapper around `charging_strategy`, now forwarding the optional `charging_park_ids` argument.
- In `charging_strategy`:
  - `integrated_parks` is derived from `edisgo_obj.electromobility.integrated_charging_parks_df`.
  - `target_park_ids` is computed from `charging_park_ids` (or all integrated parks if `None`).
  - `edisgo_ids_to_update` is taken from `integrated_parks.loc[target_park_ids, "edisgo_id"]`.
- For the `"residual"` strategy, `charging_processes_df` is restricted to `target_park_ids` instead of all integrated charging parks.
- Reactive power time series to 0 Mvar are added only for `edisgo_ids_to_update`, so multiple calls with different subsets do not overwrite each other’s results.


# Checklist:

- [ ] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works  
      (existing test suite still passes; no new tests added)
- [x] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them to the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
