### PR TITLE
Add concurrency settings to prevent overlapping workflows

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -1,6 +1,12 @@
+
 # Tests with pytest the package and monitors the covarage and sends it to coveralls.io
 # Coverage is only send to coveralls.io when no pytest tests fail
 name: "Tests & Coverage"
+
+# Abbrechen laufender Workflows bei neuem Push auf denselben Branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on: [push]
 


### PR DESCRIPTION
Introduce concurrency settings to cancel in-progress workflows when a new push occurs on the same branch. This change enhances workflow management and prevents overlapping executions.

