### PR TITLE
Refactor TOEP references to OEP

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -89,7 +89,7 @@ jobs:
           python -m pip install pytest pytest-notebook
           python -m pytest --runslow --runonlinux --disable-warnings --color=yes -v
         env:
-          TOEP_TOKEN_KH: ${{ secrets.TOEP_TOKEN_KH }}
+          OEP_TOKEN_KH: ${{ secrets.OEP_TOKEN_KH }}
 
       # Run standard tests on Windows
       - name: Run tests (Windows)
@@ -98,7 +98,7 @@ jobs:
           python -m pip install pytest pytest-notebook
           python -m pytest --runslow --disable-warnings --color=yes -v
         env:
-          TOEP_TOKEN_KH: ${{ secrets.TOEP_TOKEN_KH }}
+          OEP_TOKEN_KH: ${{ secrets.OEP_TOKEN_KH }}
 
       # Run coverage job and upload to Coveralls (only on Linux, Python 3.9)
       - name: Run tests with coverage and submit to Coveralls
@@ -108,6 +108,6 @@ jobs:
           coverage run --source=edisgo -m pytest --runslow --runonlinux --disable-warnings --color=yes -v
           coveralls
         env:
-          TOEP_TOKEN_KH: ${{ secrets.TOEP_TOKEN_KH }}
+          OEP_TOKEN_KH: ${{ secrets.OEP_TOKEN_KH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: github

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ eDisGo.egg-info/
 /edisgo/opf/eDisGo_OPF.jl/.vscode
 .vscode/settings.json
 
-*TOEP_TOKEN.*
+*OEP_TOKEN.*

--- a/doc/usage_details.rst
+++ b/doc/usage_details.rst
@@ -173,14 +173,14 @@ Database Connection for Loading Data from egon-data
 This section describes how to connect to and load data from **egon-data**.
 There are two supported connection methods:
 
-1. Using the TOEP database (standard)
+1. Using the OEP database (standard)
 2. Using a custom PostgreSQL database
 
 
-TOEP Database (Standard)
+OEP Database (Standard)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The TOEP database provides the egon-data interface and is the default data source.
+The OEP database provides the egon-data interface and is the default data source.
 
 Example
 ^^^^^^^
@@ -190,26 +190,26 @@ Example
     from edisgo.io.timeseries import set_time_series_active_power_predefined
 
     edisgo_obj.set_time_series_active_power_predefined(
-        fluctuating_generators_ts="oedb"  # use "oedb" to load data from TOEP,
+        fluctuating_generators_ts="oedb"  # use "oedb" to load data from OEP,
     )
 
-TOEP Token Setup
+OEP Token Setup
 ^^^^^^^^^^^^^^^^
 
-To authenticate with TOEP, place a file named ``TOEP_TOKEN.txt`` in the directory ``edisgo/config/``.
-The file should contain your personal TOEP access token.
+To authenticate with OEP, place a file named ``OEP_TOKEN.txt`` in the directory ``edisgo/config/``.
+The file should contain your personal OEP access token.
 
 A token can be requested at:
 
-    https://toep.iks.cs.ovgu.de/
+    https://openenergyplatform.org/
 
-Using a TOEP token is optional but recommended to avoid issues related to connection limits for anonymous users.
+Using a OEP token is optional but recommended to avoid issues related to connection limits for anonymous users.
 
 
 Using a Custom PostgreSQL Database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to connect to a custom PostgreSQL database instead of TOEP.
+It is possible to connect to a custom PostgreSQL database instead of OEP.
 This requires a configuration file and database engine initialization.
 
 Step 1: Create a Database Configuration File
@@ -252,7 +252,7 @@ The database engine can be initialized using the :func:`~edisgo.io.db.engine` fu
 Step 3: Load Data from the Custom Database
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once the engine is initialized, data can be loaded using the same functions as for TOEP.
+Once the engine is initialized, data can be loaded using the same functions as for OEP.
 Pass the ``engine`` argument to specify your connection.
 
 .. code-block:: python
@@ -277,9 +277,9 @@ Summary
    * - **Access Type**
      - **Description**
      - **Authentication**
-   * - TOEP
+   * - OEP
      - Load official egon-data source
-     - TOEP token (recommended)
+     - OEP token (recommended)
    * - Custom PostgreSQL database
      - Connect to user-defined database
      - YAML config file with credentials

--- a/edisgo/io/db.py
+++ b/edisgo/io/db.py
@@ -167,7 +167,7 @@ def engine(
         configuration YAML. If False try to connect to local database.
     token : str or pathlib.Path, optional (default=None)
         Token for database connection or path to text file containing token.
-        If empty the default token file in the config folder TOEP_TOKEN.txt
+        If empty the default token file in the config folder OEP_TOKEN.txt
         will be used. If the default token file is not found, no token
         will be used and the connection will be established without token.
 
@@ -180,8 +180,8 @@ def engine(
 
     if not ssh:
         # Github Actions KHs token
-        if "TOEP_TOKEN_KH" in os.environ:
-            token = os.environ["TOEP_TOKEN_KH"]
+        if "OEP_TOKEN_KH" in os.environ:
+            token = os.environ["OEP_TOKEN_KH"]
 
             read = True
         else:
@@ -189,7 +189,7 @@ def engine(
 
             if token is None:
                 spec = importlib.util.find_spec("edisgo")
-                token = Path(spec.origin).resolve().parent / "config" / "TOEP_TOKEN.txt"
+                token = Path(spec.origin).resolve().parent / "config" / "OEP_TOKEN.txt"
 
             if token.is_file():
                 logger.info(f"Getting OEP token from file {token}.")
@@ -199,7 +199,7 @@ def engine(
 
                 read = True
 
-        database_url = "toep.iks.cs.ovgu.de"
+        database_url = "openenergyplatform.org"
 
         msg = ""
 

--- a/edisgo/tools/config.py
+++ b/edisgo/tools/config.py
@@ -268,7 +268,7 @@ class Config:
         list of sqlalchemy.Table
             A list of SQLAlchemy Table objects corresponding to the imported tables.
         """
-        if "toep" in str(engine.url):
+        if "openenergyplatform" in str(engine.url):
             self._ensure_db_mappings_loaded()
             schema = self.db_schema_mapping.get(schema_name)
             if not schema:


### PR DESCRIPTION
Update all references from TOEP to OEP in configuration and documentation to reflect the correct naming and improve clarity. This change ensures consistency across the codebase and documentation.

