### PR TITLE
fix: read Sphinx version dynamically from package metadata

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,6 +27,7 @@ __author__ = "nesnoj, gplssm"
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import importlib.metadata
 import os
 import sys
 
@@ -234,7 +235,10 @@ author = "open_eGo-Team"
 # built documents.
 #
 # The short X.Y version.
-version = "0.2.1"
+try:
+    version = importlib.metadata.version("eDisGo")
+except importlib.metadata.PackageNotFoundError:
+    version = "unknown"
 # The full version, including alpha/beta/rc tags.
 release = version
 


### PR DESCRIPTION
The version in doc/conf.py was hardcoded to "0.2.1" while setup.py already declares "0.3.0dev". This caused ReadTheDocs to build the docs under the wrong version, resulting in a broken index that only resolved when manually switching to "stable".

Replace the hardcoded version string with importlib.metadata.version() so conf.py always reflects the installed package version without requiring manual updates on each release.