### PR TITLE
fix: add standardized SPDX license headers to all Python source files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,18 @@ repos:
 #  rev: pylint-2.6.0
 #  hooks:
 #    - id: pylint
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.5.5
+  hooks:
+    - id: insert-license
+      files: \.py$
+      exclude: ^tests/
+      args:
+        - --license-filepath
+        - .license-header.txt
+        - --comment-style
+        - "#"
+        - --no-extra-eol
 - repo: https://github.com/kynan/nbstripout
   rev: 0.8.1
   hooks:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 # Overview
 
+
 [![Coverage Status](https://coveralls.io/repos/github/openego/eDisGo/badge.svg?branch=dev)](https://coveralls.io/github/openego/eDisGo?branch=dev)
 [![Tests & coverage](https://github.com/openego/eDisGo/actions/workflows/tests-coverage.yml/badge.svg)](https://github.com/openego/eDisGo/actions/workflows/tests-coverage.yml)
 ![Python Versions](https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12-blue)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,17 +1,13 @@
-"""This file is part of DINGO, the DIstribution Network GeneratOr.
-DINGO is a tool to generate synthetic medium and low voltage power
-distribution grids based on open data.
-
-It is developed in the project open_eGo: https://openegoproject.wordpress.com
-
-DINGO lives at github: https://github.com/openego/dingo/
-The documentation is available on RTD: https://edisgo.readthedocs.io/en/dev/"""
-
-__copyright__ = "Reiner Lemoine Institut gGmbH"
-__license__ = "GNU Affero General Public License Version 3 (AGPL-3.0)"
-__url__ = "https://github.com/openego/eDisGo/blob/dev/LICENSE"
-__author__ = "nesnoj, gplssm"
-
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 # -*- coding: utf-8 -*-
 #

--- a/edisgo/__init__.py
+++ b/edisgo/__init__.py
@@ -1,1 +1,12 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from edisgo.edisgo import EDisGo  # noqa: F401

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import copy
@@ -14,7 +25,6 @@ import numpy as np
 import pandas as pd
 
 from sqlalchemy.engine.base import Engine
-from edisgo.tools.tools import get_path_length_to_station
 
 from edisgo.flex_opt.charging_strategies import charging_strategy
 from edisgo.flex_opt.check_tech_constraints import lines_relative_load
@@ -55,7 +65,10 @@ from edisgo.tools import plots, tools
 from edisgo.tools.config import Config
 from edisgo.tools.geo import find_nearest_bus
 from edisgo.tools.spatial_complexity_reduction import spatial_complexity_reduction
-from edisgo.tools.tools import determine_grid_integration_voltage_level
+from edisgo.tools.tools import (
+    determine_grid_integration_voltage_level,
+    get_path_length_to_station,
+)
 
 if "READTHEDOCS" not in os.environ:
     from shapely.geometry import Point
@@ -2066,7 +2079,12 @@ class EDisGo:
 
         integrate_charging_parks(self)
 
-    def apply_charging_strategy(self, strategy: str = "dumb", charging_park_ids: list[int] | None = None, **kwargs):
+    def apply_charging_strategy(
+        self,
+        strategy: str = "dumb",
+        charging_park_ids: list[int] | None = None,
+        **kwargs,
+    ):
         """
         Applies charging strategy to set EV charging time series at charging parks.
 
@@ -2134,7 +2152,9 @@ class EDisGo:
         series resampled back to the original frequency.
 
         """
-        charging_strategy(self, strategy=strategy, charging_park_ids=charging_park_ids, **kwargs)
+        charging_strategy(
+            self, strategy=strategy, charging_park_ids=charging_park_ids, **kwargs
+        )
 
     def import_heat_pumps(self, scenario, engine, timeindex=None, import_types=None):
         """
@@ -2596,8 +2616,15 @@ class EDisGo:
             title = None
         plots.histogram(data=data, title=title, timeindex=timestep, **kwargs)
 
-    def plot_voltage_over_dist(self, mv_id, lv_id, save_as=False, split_branches=False, return_data=False, other=None):
-
+    def plot_voltage_over_dist(
+        self,
+        mv_id,
+        lv_id,
+        save_as=False,
+        split_branches=False,
+        return_data=False,
+        other=None,
+    ):
         """
         Plot LV voltage over distance to the MV/LV transformer for one LV grid,
 
@@ -2630,7 +2657,8 @@ class EDisGo:
         if getattr(v_a, "empty", True) or getattr(v_b, "empty", True):
             raise RuntimeError(
                 "Voltage results (results.v_res) are empty. "
-                "Run analyze() with timesteps/snapshots so voltage results are generated."
+                "Run analyze() with timesteps/snapshots so voltage "
+                "results are generated."
             )
         # Resolve LV grids (index-based resolution)
         lv_grids_a = list(self.topology.mv_grid.lv_grids)
@@ -2641,20 +2669,30 @@ class EDisGo:
                 lv_grid_a = lv_grids_a[lv_id]
                 lv_grid_b = lv_grids_b[lv_id]
             except IndexError as e:
-                raise ValueError(f"lv_id={lv_id} out of range. base has {len(lv_grids_a)} LV grids.") from e
+                raise ValueError(
+                    f"lv_id={lv_id} out of range. base has {len(lv_grids_a)} LV grids."
+                ) from e
         else:
             # String matching fallback
             target = str(lv_id)
+
             def _match(lvs):
                 for g in lvs:
-                    for cand in (getattr(g, "id", None), getattr(g, "name", None), str(g)):
+                    for cand in (
+                        getattr(g, "id", None),
+                        getattr(g, "name", None),
+                        str(g),
+                    ):
                         if cand is not None and str(cand) == target:
                             return g
                 return None
+
             lv_grid_a = _match(lv_grids_a)
             lv_grid_b = _match(lv_grids_b)
             if lv_grid_a is None or lv_grid_b is None:
-                raise ValueError(f"Could not resolve lv_id='{lv_id}' in one of the EDisGo objects.")
+                raise ValueError(
+                    f"Could not resolve lv_id='{lv_id}' in one of the EDisGo objects."
+                )
 
         # Determine LV transformer (source) bus
         # Prefer station-like attributes; fallback to first bus if not found.
@@ -2671,9 +2709,9 @@ class EDisGo:
         source_a = _lv_source_bus(lv_grid_a)
         source_b = _lv_source_bus(lv_grid_b)
 
-
         # Distances (Dijkstra)
-        # Edge weight attribute commonly is 'length' in eDisGo graphs; adjust if your graph uses 'length_km'
+        # Edge weight attribute commonly is 'length' in eDisGo graphs;
+        # adjust if your graph uses 'length_km'
         pl_a = get_path_length_to_station(self)
         pl_b = get_path_length_to_station(other)
 
@@ -2686,17 +2724,24 @@ class EDisGo:
 
         # Import networkx once
         import networkx as nx
-        
-        # If LV station bus is not in pl_a (external bus), set its distance to 0 and compute other buses relative to it
+
+        # If LV station bus is not in pl_a (external bus), set its distance to 0
+        # and compute other buses relative to it
         if str(source_a) in dist_a.index and pd.isna(dist_a.loc[str(source_a)]):
             # Use LV grid graph to compute path lengths
             try:
                 lv_graph = lv_grid_a.graph
-                lv_station = str(lv_grid_a.station.index[0])  if hasattr(lv_grid_a, 'station') else str(source_a)
-                
+                lv_station = (
+                    str(lv_grid_a.station.index[0])
+                    if hasattr(lv_grid_a, "station")
+                    else str(source_a)
+                )
+
                 # Compute all path lengths from station at once using BFS
                 try:
-                    path_lengths = nx.single_source_shortest_path_length(lv_graph, source=lv_station)
+                    path_lengths = nx.single_source_shortest_path_length(
+                        lv_graph, source=lv_station
+                    )
                     for bus in lv_buses_a:
                         dist_a.loc[bus] = path_lengths.get(bus, 0)
                 except (nx.NetworkXError, nx.NodeNotFound):
@@ -2705,16 +2750,22 @@ class EDisGo:
             except Exception:
                 # Fallback: set all LV buses to 0
                 dist_a.loc[:] = 0
-        
+
         if str(source_b) in dist_b.index and pd.isna(dist_b.loc[str(source_b)]):
             # Use LV grid graph to compute path lengths
             try:
                 lv_graph = lv_grid_b.graph
-                lv_station = str(lv_grid_b.station.index[0]) if hasattr(lv_grid_b, 'station') else str(source_b)
-                
+                lv_station = (
+                    str(lv_grid_b.station.index[0])
+                    if hasattr(lv_grid_b, "station")
+                    else str(source_b)
+                )
+
                 # Compute all path lengths from station at once using BFS
                 try:
-                    path_lengths = nx.single_source_shortest_path_length(lv_graph, source=lv_station)
+                    path_lengths = nx.single_source_shortest_path_length(
+                        lv_graph, source=lv_station
+                    )
                     for bus in lv_buses_b:
                         dist_b.loc[bus] = path_lengths.get(bus, 0)
                 except (nx.NetworkXError, nx.NodeNotFound):
@@ -2723,14 +2774,12 @@ class EDisGo:
             except Exception:
                 # Fallback: set all LV buses to 0
                 dist_b.loc[:] = 0
- 
+
         # Shift to LV station reference (station bus distance -> 0)
         if str(source_a) in pl_a.index and not pd.isna(pl_a.loc[str(source_a)]):
             dist_a = dist_a - float(pl_a.loc[str(source_a)])
         if str(source_b) in pl_b.index and not pd.isna(pl_b.loc[str(source_b)]):
             dist_b = dist_b - float(pl_b.loc[str(source_b)])
-
-
 
         # Worst-case timesteps
         t_load_a, t_feed_a = _infer_load_and_feedin_timesteps(self, v_a)
@@ -2739,9 +2788,6 @@ class EDisGo:
         # Voltages at those timesteps
         v_a_load = _series_at_t(v_a, t_load_a)
         v_a_feed = _series_at_t(v_a, t_feed_a)
-        v_b_load = _series_at_t(v_b, t_load_b)
-        v_b_feed = _series_at_t(v_b, t_feed_b)
-
         # Use all buses (grids are identical), no intersection needed
         buses = pd.Index([str(b) for b in lv_grid_a.buses_df.index])
         if buses.empty:
@@ -2753,7 +2799,7 @@ class EDisGo:
             v_a_load=v_a_load,
             v_a_feed=v_a_feed,
         )
- 
+
         fig = make_voltage_over_distance_figure(
             title=f"LV voltage over distance (lv_id={lv_id})",
             buses=buses,
@@ -2765,7 +2811,6 @@ class EDisGo:
             x_label="Path length to LV station [-]",
             df=df,
         )
-
 
         if save_as:
             if isinstance(save_as, str):
@@ -2782,7 +2827,8 @@ class EDisGo:
 
     def plot_voltage_over_dist_mv(self, mv_id, other, save_as=False, return_data=False):
         """
-        Plot MV voltage over distance to the HV/MV transformer, comparing two EDisGo objects.
+        Plot MV voltage over distance to the HV/MV transformer,
+        comparing two EDisGo objects.
 
         Parameters
         ----------
@@ -2804,7 +2850,8 @@ class EDisGo:
         if getattr(v_a, "empty", True) or getattr(v_b, "empty", True):
             raise RuntimeError(
                 "Voltage results (results.v_res) are empty. "
-                "Run analyze() with timesteps/snapshots so voltage results are generated."
+                "Run analyze() with timesteps/snapshots so voltage "
+                "results are generated."
             )
         mv_a = self.topology.mv_grid
         mv_b = other.topology.mv_grid
@@ -2817,7 +2864,11 @@ class EDisGo:
 
             # 1) Try transformer buses, but only accept if they exist in graph nodes
             trafos = getattr(edisgo_obj.topology, "transformers_hvmv_df", None)
-            if trafos is not None and hasattr(trafos, "columns") and {"bus0", "bus1"}.issubset(trafos.columns):
+            if (
+                trafos is not None
+                and hasattr(trafos, "columns")
+                and {"bus0", "bus1"}.issubset(trafos.columns)
+            ):
                 for col in ("bus0", "bus1"):
                     b = str(trafos.iloc[0][col])
                     if b in G:
@@ -2830,9 +2881,8 @@ class EDisGo:
                     bus = getattr(st, "bus", None)
                     if bus is not None and str(bus) in G:
                         return str(bus)
-                 # Fallback: first graph node (guaranteed)
+                # Fallback: first graph node (guaranteed)
             return str(next(iter(G.nodes)))
-
 
         source_a = _mv_source_bus(self)
         source_b = _mv_source_bus(other)
@@ -2850,27 +2900,32 @@ class EDisGo:
         # Handle cases where MV buses are not in pl_a (e.g., external buses)
         # Use MV grid graph to compute path lengths if needed
         import networkx as nx
+
         if dist_a.isna().any():
             try:
                 mv_graph = mv_a.graph
                 for bus in mv_buses_a:
                     if pd.isna(dist_a.loc[bus]):
                         try:
-                            path = nx.shortest_path(mv_graph, source=source_a, target=bus)
+                            path = nx.shortest_path(
+                                mv_graph, source=source_a, target=bus
+                            )
                             dist_a.loc[bus] = len(path) - 1  # number of edges
                         except (nx.NetworkXNoPath, nx.NodeNotFound):
                             dist_a.loc[bus] = 0
             except Exception:
                 # Fallback: set all NaN values to 0
                 dist_a = dist_a.fillna(0)
-        
+
         if dist_b.isna().any():
             try:
                 mv_graph = mv_b.graph
                 for bus in mv_buses_b:
                     if pd.isna(dist_b.loc[bus]):
                         try:
-                            path = nx.shortest_path(mv_graph, source=source_b, target=bus)
+                            path = nx.shortest_path(
+                                mv_graph, source=source_b, target=bus
+                            )
                             dist_b.loc[bus] = len(path) - 1  # number of edges
                         except (nx.NetworkXNoPath, nx.NodeNotFound):
                             dist_b.loc[bus] = 0
@@ -2889,7 +2944,6 @@ class EDisGo:
         buses = pd.Index([str(b) for b in mv_a.buses_df.index])
         if buses.empty:
             raise RuntimeError("No MV buses found in MV grid.")
-
 
         df = build_voltage_over_distance_df(
             buses=buses,
@@ -2913,8 +2967,7 @@ class EDisGo:
             band_high=1.06,
             x_label="Path length to HV/MV station [-]",
             df=df,
-    )
-
+        )
 
         if save_as:
             if isinstance(save_as, str):

--- a/edisgo/flex_opt/__init__.py
+++ b/edisgo/flex_opt/__init__.py
@@ -1,0 +1,10 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/edisgo/flex_opt/battery_storage_operation.py
+++ b/edisgo/flex_opt/battery_storage_operation.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 import math
 

--- a/edisgo/flex_opt/charging_strategies.py
+++ b/edisgo/flex_opt/charging_strategies.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging
@@ -224,8 +235,8 @@ def charging_strategy(
         # "residual" charging
         # only use charging processes from integrated charging parks
         charging_processes_df = edisgo_obj.electromobility.charging_processes_df[
-        edisgo_obj.electromobility.charging_processes_df.charging_park_id.isin(
-        target_park_ids
+            edisgo_obj.electromobility.charging_processes_df.charging_park_id.isin(
+                target_park_ids
             )
         ]
 

--- a/edisgo/flex_opt/check_tech_constraints.py
+++ b/edisgo/flex_opt/check_tech_constraints.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 
 import numpy as np

--- a/edisgo/flex_opt/costs.py
+++ b/edisgo/flex_opt/costs.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 import os
 
@@ -162,9 +173,7 @@ def grid_expansion_costs(edisgo_obj, without_generator_import=False):
         ]["quantity"].to_frame()
         lines_added_unique = lines_added.index.unique()
         lines_added = (
-            lines_added.groupby(level=0)
-            .sum()
-            .loc[lines_added_unique, ["quantity"]]
+            lines_added.groupby(level=0).sum().loc[lines_added_unique, ["quantity"]]
         )
         # use the minimum of quantity and num_parallel, as sometimes lines are added
         # and in a next reinforcement step removed again, e.g. when feeder is split

--- a/edisgo/flex_opt/exceptions.py
+++ b/edisgo/flex_opt/exceptions.py
@@ -1,3 +1,15 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+
 class Error(Exception):
     """Base class for exceptions in this module."""
 

--- a/edisgo/flex_opt/heat_pump_operation.py
+++ b/edisgo/flex_opt/heat_pump_operation.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 
 import pandas as pd

--- a/edisgo/flex_opt/q_control.py
+++ b/edisgo/flex_opt/q_control.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import numpy as np
 import pandas as pd
 

--- a/edisgo/flex_opt/reinforce_grid.py
+++ b/edisgo/flex_opt/reinforce_grid.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import datetime

--- a/edisgo/flex_opt/reinforce_measures.py
+++ b/edisgo/flex_opt/reinforce_measures.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging
@@ -506,9 +517,9 @@ def reinforce_lines_voltage_issues(edisgo_obj, grid, crit_nodes):
             else:
                 raise ValueError("Bus not in line buses. Please check.")
             # change line length and type
-            edisgo_obj.topology._lines_df.at[
-                crit_line_name, "length"
-            ] = path_length_dict[node_2_3]
+            edisgo_obj.topology._lines_df.at[crit_line_name, "length"] = (
+                path_length_dict[node_2_3]
+            )
             edisgo_obj.topology.change_line_type([crit_line_name], standard_line)
             lines_changes[crit_line_name] = 1
             # TODO: Include switch disconnector

--- a/edisgo/io/__init__.py
+++ b/edisgo/io/__init__.py
@@ -1,0 +1,10 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/edisgo/io/db.py
+++ b/edisgo/io/db.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import importlib.util

--- a/edisgo/io/ding0_import.py
+++ b/edisgo/io/ding0_import.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 
 import pandas as pd
@@ -45,9 +56,9 @@ def import_ding0_grid(path, edisgo_obj, legacy_ding0_grids=True):
         voltage_bus1 = edisgo_obj.topology.buses_df.loc[
             transformers_df.bus1
         ].v_nom.values
-        transformers_df.loc[
-            voltage_bus1 > voltage_bus0, ["bus0", "bus1"]
-        ] = transformers_df.loc[voltage_bus1 > voltage_bus0, ["bus1", "bus0"]].values
+        transformers_df.loc[voltage_bus1 > voltage_bus0, ["bus0", "bus1"]] = (
+            transformers_df.loc[voltage_bus1 > voltage_bus0, ["bus1", "bus0"]].values
+        )
         return transformers_df
 
     def sort_hvmv_transformer_buses(transformers_df):

--- a/edisgo/io/dsm_import.py
+++ b/edisgo/io/dsm_import.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/io/electromobility_import.py
+++ b/edisgo/io/electromobility_import.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import json
@@ -1079,11 +1090,11 @@ def distribute_public_charging_demand(edisgo_obj, **kwargs):
                 idx, "charging_point_id"
             ] = charging_point_id
 
-            available_charging_points_df.loc[
-                charging_point_id
-            ] = edisgo_obj.electromobility.charging_processes_df.loc[
-                idx, available_charging_points_df.columns
-            ].tolist()
+            available_charging_points_df.loc[charging_point_id] = (
+                edisgo_obj.electromobility.charging_processes_df.loc[
+                    idx, available_charging_points_df.columns
+                ].tolist()
+            )
 
             designated_charging_point_capacity_df.at[
                 charging_park_id, "designated_charging_point_capacity"

--- a/edisgo/io/generators_import.py
+++ b/edisgo/io/generators_import.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging
@@ -25,9 +36,13 @@ if "READTHEDOCS" not in os.environ:
     import geopandas as gpd
 
     from egoio.db_tables import model_draft, supply
-    from edisgo.io.mviews_filters import build_conv_scenario_filter, build_res_scenario_filter
     from shapely.ops import transform
     from shapely.wkt import loads as wkt_loads
+
+    from edisgo.io.mviews_filters import (
+        build_conv_scenario_filter,
+        build_res_scenario_filter,
+    )
 
 if TYPE_CHECKING:
     from edisgo import EDisGo
@@ -125,14 +140,11 @@ def oedb_legacy(edisgo_object, generator_scenario, **kwargs):
                 orm_conv_generators.capacity.label("p_nom"),
                 orm_conv_generators.voltage_level,
                 orm_conv_generators.fuel.label("generator_type"),
-                func.ST_AsText(
-                    func.ST_Transform(orm_conv_generators.geom, srid)
-                ).label("geom"),
+                func.ST_AsText(func.ST_Transform(orm_conv_generators.geom, srid)).label(
+                    "geom"
+                ),
             )
-            .filter(
-                orm_conv_generators.subst_id
-                == edisgo_object.topology.mv_grid.id
-            )
+            .filter(orm_conv_generators.subst_id == edisgo_object.topology.mv_grid.id)
             .filter(orm_conv_generators.voltage_level.in_([4, 5]))
             .filter(orm_conv_generators_version)
         )
@@ -175,13 +187,11 @@ def oedb_legacy(edisgo_object, generator_scenario, **kwargs):
                 func.ST_AsText(
                     func.ST_Transform(orm_re_generators.rea_geom_new, srid)
                 ).label("geom"),
-                func.ST_AsText(
-                    func.ST_Transform(orm_re_generators.geom, srid)
-                ).label("geom_em"),
+                func.ST_AsText(func.ST_Transform(orm_re_generators.geom, srid)).label(
+                    "geom_em"
+                ),
             )
-            .filter(
-                orm_re_generators.subst_id == edisgo_object.topology.mv_grid.id
-            )
+            .filter(orm_re_generators.subst_id == edisgo_object.topology.mv_grid.id)
             .filter(orm_re_generators_version)
         )
 
@@ -305,18 +315,16 @@ def oedb_legacy(edisgo_object, generator_scenario, **kwargs):
 
     # Map generator_scenario to full scenario names for mview filter logic
     scenario_mapping = {
-        'nep2035': 'NEP 2035',
-        'ego100': 'eGo 100',
-        'status_quo': 'Status Quo',
-        'sq': 'Status Quo'
+        "nep2035": "NEP 2035",
+        "ego100": "eGo 100",
+        "status_quo": "Status Quo",
+        "sq": "Status Quo",
     }
-    scenario_name = scenario_mapping.get(
-        generator_scenario.lower(),
-        generator_scenario
-    )
+    scenario_name = scenario_mapping.get(generator_scenario.lower(), generator_scenario)
 
     if oedb_data_source == "model_draft":
-        # Use base tables from model_draft schema (CamelCase ORM names, without _mview suffix)
+        # Use base tables from model_draft schema
+        # (CamelCase ORM names, without _mview suffix)
         orm_conv_generators = model_draft.__getattribute__("EgoDpSupplyConvPowerplant")
         orm_re_generators = model_draft.__getattribute__("EgoDpSupplyResPowerplant")
 
@@ -331,7 +339,8 @@ def oedb_legacy(edisgo_object, generator_scenario, **kwargs):
     elif oedb_data_source == "versioned":
         data_version = edisgo_object.config["versioned"]["version"]
 
-        # Use base tables from supply schema (CamelCase ORM names, without _mview suffix)
+        # Use base tables from supply schema
+        # (CamelCase ORM names, without _mview suffix)
         orm_conv_generators = supply.__getattribute__("EgoDpConvPowerplant")
         orm_re_generators = supply.__getattribute__("EgoDpResPowerplant")
 

--- a/edisgo/io/heat_pump_import.py
+++ b/edisgo/io/heat_pump_import.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 import os
 import random

--- a/edisgo/io/mviews_filters.py
+++ b/edisgo/io/mviews_filters.py
@@ -1,15 +1,16 @@
-"""
-Helper functions to build scenario filters that replicate mview logic.
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
-These functions create SQLAlchemy filter conditions that match the original
-materialized view definitions, allowing direct queries on base tables.
 
-Author: Generated for mviews replacement
-Date: 2025-12-17
-"""
-
-
-def build_conv_scenario_filter(orm_table, scenario, version=None, preversion='v0.3.0'):
+def build_conv_scenario_filter(orm_table, scenario, version=None, preversion="v0.3.0"):
     """
     Build filter conditions for conventional power plants matching mview logic.
 
@@ -31,10 +32,10 @@ def build_conv_scenario_filter(orm_table, scenario, version=None, preversion='v0
     """
     # Set default versions
     if version is None:
-        if scenario in ['NEP 2035', 'eGo 100']:
-            versions = ['v0.4.2', 'v0.4.4', 'v0.4.5']
+        if scenario in ["NEP 2035", "eGo 100"]:
+            versions = ["v0.4.2", "v0.4.4", "v0.4.5"]
         else:
-            versions = ['v0.4.5']
+            versions = ["v0.4.5"]
     else:
         versions = [version] if isinstance(version, str) else version
 
@@ -45,39 +46,44 @@ def build_conv_scenario_filter(orm_table, scenario, version=None, preversion='v0
     ]
 
     # Version filter
-    if hasattr(orm_table, 'version'):
+    if hasattr(orm_table, "version"):
         filters.append(orm_table.version.in_(versions))
 
     # Scenario-specific filters
-    if scenario == 'eGo 100':
+    if scenario == "eGo 100":
         # eGo 100: only pumped storage from NEP 2035
-        filters.extend([
-            orm_table.scenario == 'NEP 2035',
-            orm_table.fuel == 'pumped_storage',
-            (orm_table.shutdown == None) |
-            (orm_table.shutdown >= 2049)
-        ])
-    elif scenario == 'NEP 2035':
+        filters.extend(
+            [
+                orm_table.scenario == "NEP 2035",
+                orm_table.fuel == "pumped_storage",
+                (orm_table.shutdown == None)  # noqa: E711
+                | (orm_table.shutdown >= 2049),
+            ]
+        )
+    elif scenario == "NEP 2035":
         # NEP 2035: exclude hydro, filter by shutdown
         # Note: OEP doesn't support NOT IN, so we use individual != filters
-        filters.extend([
-            orm_table.scenario == 'NEP 2035',
-            orm_table.fuel != 'hydro',
-            orm_table.fuel != 'run_of_river',
-            orm_table.fuel != 'reservoir',
-            (orm_table.shutdown == None) |
-            (orm_table.shutdown >= 2034)
-        ])
+        filters.extend(
+            [
+                orm_table.scenario == "NEP 2035",
+                orm_table.fuel != "hydro",
+                orm_table.fuel != "run_of_river",
+                orm_table.fuel != "reservoir",
+                (orm_table.shutdown == None)  # noqa: E711
+                | (orm_table.shutdown >= 2034),
+            ]
+        )
     else:
         # Generic scenario filter
         filters.append(orm_table.scenario == scenario)
 
     # Combine all filters with AND
     from sqlalchemy import and_
+
     return and_(*filters)
 
 
-def build_res_scenario_filter(orm_table, scenario, version=None, preversion='v0.3.0'):
+def build_res_scenario_filter(orm_table, scenario, version=None, preversion="v0.3.0"):
     """
     Build filter conditions for renewable power plants matching mview logic.
 
@@ -105,11 +111,11 @@ def build_res_scenario_filter(orm_table, scenario, version=None, preversion='v0.
 
     # Set default versions
     if version is None:
-        if scenario == 'Status Quo':
-            versions = ['v0.4.4', 'v0.4.5']
+        if scenario == "Status Quo":
+            versions = ["v0.4.4", "v0.4.5"]
         else:
             # NEP 2035 uses v0.4.4 and v0.4.5
-            versions = ['v0.4.4', 'v0.4.5']
+            versions = ["v0.4.4", "v0.4.5"]
     else:
         versions = [version] if isinstance(version, str) else version
 
@@ -120,37 +126,34 @@ def build_res_scenario_filter(orm_table, scenario, version=None, preversion='v0.
     ]
 
     # Version filter
-    if hasattr(orm_table, 'version'):
+    if hasattr(orm_table, "version"):
         base_filters.append(orm_table.version.in_(versions))
 
     # Scenario-specific filters
-    if scenario == 'NEP 2035':
+    if scenario == "NEP 2035":
         # NEP 2035 mview is UNION of:
         # 1. Status Quo generators (solar/wind only, no offshore)
         # 2. NEP 2035 generators (all types)
         status_quo_filters = [
-            orm_table.scenario == 'Status Quo',
-            orm_table.generation_type.in_(['solar', 'wind']),
-            orm_table.generation_subtype != 'wind_offshore'
+            orm_table.scenario == "Status Quo",
+            orm_table.generation_type.in_(["solar", "wind"]),
+            orm_table.generation_subtype != "wind_offshore",
         ]
-        nep2035_filters = [
-            orm_table.scenario == 'NEP 2035'
-        ]
+        nep2035_filters = [orm_table.scenario == "NEP 2035"]
 
         # Combine: (Status Quo conditions) OR (NEP 2035 conditions)
-        scenario_filter = or_(
-            and_(*status_quo_filters),
-            and_(*nep2035_filters)
-        )
+        scenario_filter = or_(and_(*status_quo_filters), and_(*nep2035_filters))
         base_filters.append(scenario_filter)
 
-    elif scenario == 'Status Quo':
+    elif scenario == "Status Quo":
         # Status Quo: only solar and wind (excluding offshore)
-        base_filters.extend([
-            orm_table.scenario == 'Status Quo',
-            orm_table.generation_type.in_(['solar', 'wind']),
-            orm_table.generation_subtype != 'wind_offshore'
-        ])
+        base_filters.extend(
+            [
+                orm_table.scenario == "Status Quo",
+                orm_table.generation_type.in_(["solar", "wind"]),
+                orm_table.generation_subtype != "wind_offshore",
+            ]
+        )
     else:
         # Generic scenario filter for other scenarios (like eGo 100)
         base_filters.append(orm_table.scenario == scenario)

--- a/edisgo/io/mviews_replacement.py
+++ b/edisgo/io/mviews_replacement.py
@@ -1,17 +1,19 @@
-"""
-Replacement functions for deprecated materialized views (mviews) in eDisGo/oedb.
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
-This module provides functions to replace the deprecated mviews by directly querying
-the underlying base tables with appropriate filters. The filter logic is extracted
-from the original mview definitions in mviews_definitions.sql.
-
-Author: Generated for mviews replacement
-Date: 2025-12-17
-"""
+from typing import Literal, Optional
 
 import pandas as pd
+
 from sqlalchemy import text
-from typing import Optional, Literal
 
 
 class MviewsReplacement:
@@ -38,9 +40,9 @@ class MviewsReplacement:
         self,
         scenario: str,
         version: Optional[str] = None,
-        preversion: str = 'v0.3.0',
-        schema: Literal['model_draft', 'data'] = 'data',
-        table_name: str = 'ego_dp_conv_powerplant'
+        preversion: str = "v0.3.0",
+        schema: Literal["model_draft", "data"] = "data",
+        table_name: str = "ego_dp_conv_powerplant",
     ) -> pd.DataFrame:
         """
         Load conventional power plant data (replaces ego_dp_conv_powerplant_*_mview).
@@ -71,10 +73,10 @@ class MviewsReplacement:
         """
         # Set default versions based on scenario
         if version is None:
-            if scenario in ['NEP 2035', 'eGo 100']:
-                version_list = ['v0.4.2', 'v0.4.4', 'v0.4.5']
+            if scenario in ["NEP 2035", "eGo 100"]:
+                version_list = ["v0.4.2", "v0.4.4", "v0.4.5"]
             else:
-                version_list = ['v0.4.5']
+                version_list = ["v0.4.5"]
         else:
             version_list = [version] if isinstance(version, str) else version
 
@@ -82,7 +84,7 @@ class MviewsReplacement:
         version_filter = "', '".join(version_list)
 
         # Base query - selecting all columns from the table
-        if scenario == 'eGo 100':
+        if scenario == "eGo 100":
             # Special case for eGo 100: only pumped storage from NEP 2035
             query = f"""
             SELECT DISTINCT
@@ -104,7 +106,7 @@ class MviewsReplacement:
                 AND preversion = '{preversion}'
                 AND version IN ('{version_filter}')
             """
-        elif scenario == 'NEP 2035':
+        elif scenario == "NEP 2035":
             # NEP 2035: exclude hydro plants, filter by shutdown date
             query = f"""
             SELECT DISTINCT
@@ -132,7 +134,7 @@ class MviewsReplacement:
                 shutdown, status, fuel, technology, type, eeg, chp, capacity,
                 capacity_uba, chp_capacity_uba, efficiency_data, efficiency_estimate,
                 network_node, voltage, network_operator, name_uba, lat, lon, comment,
-                geom, voltage_level, subst_id, otg_id, un_id, la_id, scenario, flag, nuts
+                geom, voltage_level, subst_id, otg_id, un_id, la_id, scenario, flag, nuts  # noqa: E501
             FROM {schema}.{table_name}
             WHERE scenario = '{scenario}'
                 AND capacity > 0
@@ -147,9 +149,9 @@ class MviewsReplacement:
         self,
         scenario: str,
         version: Optional[str] = None,
-        preversion: str = 'v0.3.0',
-        schema: Literal['model_draft', 'data'] = 'data',
-        table_name: str = 'ego_dp_res_powerplant'
+        preversion: str = "v0.3.0",
+        schema: Literal["model_draft", "data"] = "data",
+        table_name: str = "ego_dp_res_powerplant",
     ) -> pd.DataFrame:
         """
         Load renewable power plant data (replaces ego_dp_res_powerplant_*_mview).
@@ -180,24 +182,24 @@ class MviewsReplacement:
         """
         # Set default versions based on scenario
         if version is None:
-            if scenario == 'Status Quo':
-                version_list = ['v0.4.4', 'v0.4.5']
+            if scenario == "Status Quo":
+                version_list = ["v0.4.4", "v0.4.5"]
             else:
-                version_list = ['v0.4.5']
+                version_list = ["v0.4.5"]
         else:
             version_list = [version] if isinstance(version, str) else version
 
         version_filter = "', '".join(version_list)
 
         # Base query with duplicate filtering logic from the mview
-        if table_name == 'ego_dp_res_powerplant':
+        if table_name == "ego_dp_res_powerplant":
             # For ego_dp_res_powerplant: complex duplicate filtering
             id_column = "id || version"
         else:
             # For ego_dp_supply_res_powerplant: simpler duplicate filtering
             id_column = "id"
 
-        if scenario == 'Status Quo':
+        if scenario == "Status Quo":
             # Status Quo scenario: only solar and wind (excluding offshore)
             query = f"""
             WITH filtered_data AS (
@@ -254,9 +256,9 @@ class MviewsReplacement:
 
     def get_loadarea(
         self,
-        version: str = 'v0.4.5',
-        schema: Literal['model_draft', 'data'] = 'data',
-        table_name: str = 'ego_dp_loadarea'
+        version: str = "v0.4.5",
+        schema: Literal["model_draft", "data"] = "data",
+        table_name: str = "ego_dp_loadarea",
     ) -> pd.DataFrame:
         """
         Load load area data (replaces ego_dp_loadarea_*_mview).
@@ -302,9 +304,9 @@ class MviewsReplacement:
 
     def get_mv_griddistrict(
         self,
-        version: str = 'v0.4.5',
-        schema: Literal['model_draft', 'data'] = 'data',
-        table_name: str = 'ego_dp_mv_griddistrict'
+        version: str = "v0.4.5",
+        schema: Literal["model_draft", "data"] = "data",
+        table_name: str = "ego_dp_mv_griddistrict",
     ) -> pd.DataFrame:
         """
         Load MV grid district data (replaces ego_dp_mv_griddistrict_*_mview).
@@ -340,7 +342,7 @@ class MviewsReplacement:
         mview_name: str,
         scenario: Optional[str] = None,
         version: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ) -> pd.DataFrame:
         """
         Generic mview replacement loader based on mview name.
@@ -372,105 +374,98 @@ class MviewsReplacement:
         Examples
         --------
         >>> replacer = MviewsReplacement(engine)
-        >>> data = replacer.load_mview_replacement('ego_dp_conv_powerplant_nep2035_mview')
-        >>> data = replacer.load_mview_replacement('ego_supply_res_powerplant_ego100_mview')
+        >>> data = replacer.load_mview_replacement(
+        ...     'ego_dp_conv_powerplant_nep2035_mview')
+        >>> data = replacer.load_mview_replacement(
+        ...     'ego_supply_res_powerplant_ego100_mview')
         """
         # Remove 'mviews.' prefix if present
-        mview_name = mview_name.replace('mviews.', '')
+        mview_name = mview_name.replace("mviews.", "")
 
         # Determine schema from mview name
-        if mview_name.startswith('ego_supply_'):
-            schema = kwargs.get('schema', 'data')
-            base_prefix = 'ego_dp_supply_'
-        else:
-            schema = kwargs.get('schema', 'data')
-            base_prefix = 'ego_dp_'
+        schema = kwargs.get("schema", "data")
 
         # Parse conventional power plants
-        if 'conv_powerplant' in mview_name:
+        if "conv_powerplant" in mview_name:
             # Extract scenario from name if not provided
             if scenario is None:
-                if 'ego100' in mview_name or 'ego_100' in mview_name:
-                    scenario = 'eGo 100'
-                elif 'nep2035' in mview_name:
-                    scenario = 'NEP 2035'
-                elif 'sq' in mview_name or 'status' in mview_name:
-                    scenario = 'Status Quo'
+                if "ego100" in mview_name or "ego_100" in mview_name:
+                    scenario = "eGo 100"
+                elif "nep2035" in mview_name:
+                    scenario = "NEP 2035"
+                elif "sq" in mview_name or "status" in mview_name:
+                    scenario = "Status Quo"
                 else:
-                    raise ValueError(f"Cannot determine scenario from mview name: {mview_name}")
+                    raise ValueError(
+                        f"Cannot determine scenario from mview name: {mview_name}"
+                    )
 
             # Determine table name
-            if mview_name.startswith('ego_supply_'):
-                table_name = 'ego_dp_supply_conv_powerplant'
+            if mview_name.startswith("ego_supply_"):
+                table_name = "ego_dp_supply_conv_powerplant"
             else:
-                table_name = 'ego_dp_conv_powerplant'
+                table_name = "ego_dp_conv_powerplant"
 
             return self.get_conv_powerplant(
                 scenario=scenario,
                 version=version,
                 schema=schema,
                 table_name=table_name,
-                **kwargs
+                **kwargs,
             )
 
         # Parse renewable power plants
-        elif 'res_powerplant' in mview_name:
+        elif "res_powerplant" in mview_name:
             if scenario is None:
-                if 'ego100' in mview_name or 'ego_100' in mview_name:
-                    scenario = 'eGo 100'
-                elif 'nep2035' in mview_name:
-                    scenario = 'NEP 2035'
-                elif 'sq' in mview_name or 'status' in mview_name:
-                    scenario = 'Status Quo'
+                if "ego100" in mview_name or "ego_100" in mview_name:
+                    scenario = "eGo 100"
+                elif "nep2035" in mview_name:
+                    scenario = "NEP 2035"
+                elif "sq" in mview_name or "status" in mview_name:
+                    scenario = "Status Quo"
                 else:
-                    raise ValueError(f"Cannot determine scenario from mview name: {mview_name}")
+                    raise ValueError(
+                        f"Cannot determine scenario from mview name: {mview_name}"
+                    )
 
             # Determine table name
-            if mview_name.startswith('ego_supply_'):
-                table_name = 'ego_dp_supply_res_powerplant'
+            if mview_name.startswith("ego_supply_"):
+                table_name = "ego_dp_supply_res_powerplant"
             else:
-                table_name = 'ego_dp_res_powerplant'
+                table_name = "ego_dp_res_powerplant"
 
             return self.get_res_powerplant(
                 scenario=scenario,
                 version=version,
                 schema=schema,
                 table_name=table_name,
-                **kwargs
+                **kwargs,
             )
 
         # Parse load areas
-        elif 'loadarea' in mview_name:
+        elif "loadarea" in mview_name:
             # Extract version from name if not provided
             if version is None:
-                if 'v0_4_5' in mview_name or 'v0.4.5' in mview_name:
-                    version = 'v0.4.5'
-                elif 'v0_4_3' in mview_name or 'v0.4.3' in mview_name:
-                    version = 'v0.4.3'
+                if "v0_4_5" in mview_name or "v0.4.5" in mview_name:
+                    version = "v0.4.5"
+                elif "v0_4_3" in mview_name or "v0.4.3" in mview_name:
+                    version = "v0.4.3"
                 else:
-                    version = 'v0.4.5'  # default
+                    version = "v0.4.5"  # default
 
-            return self.get_loadarea(
-                version=version,
-                schema=schema,
-                **kwargs
-            )
+            return self.get_loadarea(version=version, schema=schema, **kwargs)
 
         # Parse MV grid districts
-        elif 'mv_griddistrict' in mview_name:
+        elif "mv_griddistrict" in mview_name:
             if version is None:
-                if 'v0_4_5' in mview_name or 'v0.4.5' in mview_name:
-                    version = 'v0.4.5'
-                elif 'v0_4_3' in mview_name or 'v0.4.3' in mview_name:
-                    version = 'v0.4.3'
+                if "v0_4_5" in mview_name or "v0.4.5" in mview_name:
+                    version = "v0.4.5"
+                elif "v0_4_3" in mview_name or "v0.4.3" in mview_name:
+                    version = "v0.4.3"
                 else:
-                    version = 'v0.4.5'  # default
+                    version = "v0.4.5"  # default
 
-            return self.get_mv_griddistrict(
-                version=version,
-                schema=schema,
-                **kwargs
-            )
+            return self.get_mv_griddistrict(version=version, schema=schema, **kwargs)
 
         else:
             raise ValueError(f"Unsupported mview name pattern: {mview_name}")

--- a/edisgo/io/powermodels_io.py
+++ b/edisgo/io/powermodels_io.py
@@ -1,10 +1,13 @@
-"""
-This module provides tools to convert eDisGo representation of the network
-topology and timeseries to PowerModels network data format and to retrieve results from
-PowerModels OPF in PowerModels network data format to eDisGo representation.
-Call :func:`to_powermodels` to retrieve the PowerModels network container and
-:func:`from_powermodels` to write OPF results to edisgo object.
-"""
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 import json
 import logging
@@ -250,10 +253,10 @@ def from_powermodels(
         Base value of apparent power for per unit system.
         Default: 1 MVA.
     """
-    if type(pm_results) == str:
+    if isinstance(pm_results, str):
         with open(pm_results) as f:
             pm = json.loads(json.load(f))
-    elif type(pm_results) == dict:
+    elif isinstance(pm_results, dict):
         pm = pm_results
     else:
         raise ValueError(
@@ -363,9 +366,11 @@ def from_powermodels(
         for flex in df2.columns:
             abs_error = abs(df2[flex].values - hv_flex_dict[flex].values)
             rel_error = [
-                abs_error[i] / hv_flex_dict[flex].iloc[i]
-                if ((abs_error > 0.01)[i] & (hv_flex_dict[flex].iloc[i] != 0))
-                else 0
+                (
+                    abs_error[i] / hv_flex_dict[flex].iloc[i]
+                    if ((abs_error > 0.01)[i] & (hv_flex_dict[flex].iloc[i] != 0))
+                    else 0
+                )
                 for i in range(len(abs_error))
             ]
             df2[flex] = rel_error
@@ -707,13 +712,17 @@ def _build_gen(edisgo_obj, psa_net, pm, flexible_storage_units, s_base):
             pf, sign = _get_pf(edisgo_obj, pm, idx_bus, "storage_unit")
             p_g = max(
                 [
-                    psa_net.storage_units_t.p_set[inflexible_storage_units[stor_i]].iloc[0],
+                    psa_net.storage_units_t.p_set[
+                        inflexible_storage_units[stor_i]
+                    ].iloc[0],
                     0.0,
                 ]
             )
             q_g = min(
                 [
-                    psa_net.storage_units_t.q_set[inflexible_storage_units[stor_i]].iloc[0],
+                    psa_net.storage_units_t.q_set[
+                        inflexible_storage_units[stor_i]
+                    ].iloc[0],
                     0.0,
                 ]
             )
@@ -841,9 +850,9 @@ def _build_branch(edisgo_obj, psa_net, pm, flexible_storage_units, s_base):
 
         pm["branch"][str(stor_i + len(branches.index) + 1)] = {
             "name": "bss_branch_" + str(stor_i + 1),
-            "br_r": (0.017 * s_base / (psa_net.buses.v_nom.iloc[idx_bus - 1] ** 2)).round(
-                10
-            ),
+            "br_r": (
+                0.017 * s_base / (psa_net.buses.v_nom.iloc[idx_bus - 1] ** 2)
+            ).round(10),
             "r": 0.017,
             "br_x": 0,
             "f_bus": idx_bus,
@@ -958,13 +967,17 @@ def _build_load(
             pf, sign = _get_pf(edisgo_obj, pm, idx_bus, "storage_unit")
             p_d = -min(
                 [
-                    psa_net.storage_units_t.p_set[inflexible_storage_units[stor_i]].iloc[0],
+                    psa_net.storage_units_t.p_set[
+                        inflexible_storage_units[stor_i]
+                    ].iloc[0],
                     np.float64(0.0),
                 ]
             )
             q_d = -max(
                 [
-                    psa_net.storage_units_t.q_set[inflexible_storage_units[stor_i]].iloc[0],
+                    psa_net.storage_units_t.q_set[
+                        inflexible_storage_units[stor_i]
+                    ].iloc[0],
                     np.float64(0.0),
                 ]
             )
@@ -1049,9 +1062,13 @@ def _build_battery_storage(
             "pf": pf,
             "sign": sign,
             "virtual_branch": str(stor_i + len(branches.index) + 1),
-            "ps": psa_net.storage_units.p_set.loc[flexible_storage_units[stor_i]].round(20)
+            "ps": psa_net.storage_units.p_set.loc[flexible_storage_units[stor_i]].round(
+                20
+            )
             / s_base,
-            "qs": psa_net.storage_units.q_set.loc[flexible_storage_units[stor_i]].round(20)
+            "qs": psa_net.storage_units.q_set.loc[flexible_storage_units[stor_i]].round(
+                20
+            )
             / s_base,
             "pmax": psa_net.storage_units.p_nom.loc[
                 flexible_storage_units[stor_i]

--- a/edisgo/io/pypsa_io.py
+++ b/edisgo/io/pypsa_io.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 This module provides tools to convert eDisGo representation of the network
 topology to PyPSA data model. Call :func:`to_pypsa` to retrieve the PyPSA network

--- a/edisgo/io/storage_import.py
+++ b/edisgo/io/storage_import.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/io/timeseries_import.py
+++ b/edisgo/io/timeseries_import.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import datetime

--- a/edisgo/network/__init__.py
+++ b/edisgo/network/__init__.py
@@ -1,0 +1,10 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/edisgo/network/components.py
+++ b/edisgo/network/components.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 import math
 import os

--- a/edisgo/network/dsm.py
+++ b/edisgo/network/dsm.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/network/electromobility.py
+++ b/edisgo/network/electromobility.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 import os
 
@@ -913,9 +924,7 @@ class Electromobility:
                 df = df.assign(geometry=gpd.GeoSeries.from_wkt(df["geometry"]))
 
                 try:
-                    df = gpd.GeoDataFrame(
-                        df, geometry="geometry", crs=f"epsg:{epsg}"
-                    )
+                    df = gpd.GeoDataFrame(df, geometry="geometry", crs=f"epsg:{epsg}")
 
                 except Exception:
                     logger.warning(
@@ -923,9 +932,7 @@ class Electromobility:
                         f"EPSG {epsg}. Trying with EPSG 4326 as fallback."
                     )
 
-                    df = gpd.GeoDataFrame(
-                        df, geometry="geometry", crs="epsg:4326"
-                    )
+                    df = gpd.GeoDataFrame(df, geometry="geometry", crs="epsg:4326")
 
             if attr == "simbev_config_df":
                 for col in ["start_date", "end_date"]:

--- a/edisgo/network/grids.py
+++ b/edisgo/network/grids.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/edisgo/network/heat.py
+++ b/edisgo/network/heat.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging
@@ -238,9 +249,9 @@ class HeatPump:
                     random_weather_cell_id = hp_df.weather_cell_id.dropna().unique()[0]
                     hp_without_weather_cell = hp_df[hp_df.weather_cell_id.isna()].index
                     # random weather cell ID is not written to loads_df!
-                    hp_df.loc[
-                        hp_without_weather_cell, "weather_cell_id"
-                    ] = random_weather_cell_id
+                    hp_df.loc[hp_without_weather_cell, "weather_cell_id"] = (
+                        random_weather_cell_id
+                    )
                 weather_cells = hp_df.weather_cell_id.dropna().unique()
 
                 # get COP per weather cell

--- a/edisgo/network/overlying_grid.py
+++ b/edisgo/network/overlying_grid.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/network/results.py
+++ b/edisgo/network/results.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 import os
 

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import itertools
@@ -985,9 +996,9 @@ class TimeSeries:
         for s in sectors:
             for case in cases:
                 for voltage_level in ["mv", "lv"]:
-                    power_scaling.at[
-                        f"{case}_{voltage_level}", s
-                    ] = worst_case_scale_factors[f"{voltage_level}_{case}_cp_{s}"]
+                    power_scaling.at[f"{case}_{voltage_level}", s] = (
+                        worst_case_scale_factors[f"{voltage_level}_{case}_cp_{s}"]
+                    )
 
         # calculate active power of charging points
         active_power = pd.concat(
@@ -1379,9 +1390,11 @@ class TimeSeries:
 
         # scale time series by nominal power
         ts_scaled = generators_df.apply(
-            lambda x: ts_generators[x.type] * x.p_nom
-            if x.type in ts_generators.columns
-            else ts_generators["other"] * x.p_nom,
+            lambda x: (
+                ts_generators[x.type] * x.p_nom
+                if x.type in ts_generators.columns
+                else ts_generators["other"] * x.p_nom
+            ),
             axis=1,
         ).T
         if not ts_scaled.empty:
@@ -1439,9 +1452,9 @@ class TimeSeries:
 
         # write to TimeSeriesRaw
         for col in ts_loads:
-            self.time_series_raw.conventional_loads_active_power_by_sector[
-                col
-            ] = ts_loads[col]
+            self.time_series_raw.conventional_loads_active_power_by_sector[col] = (
+                ts_loads[col]
+            )
 
         # set load_names if None
         if load_names is None:
@@ -1498,9 +1511,9 @@ class TimeSeries:
 
         # write to TimeSeriesRaw
         for col in ts_loads:
-            self.time_series_raw.charging_points_active_power_by_use_case[
-                col
-            ] = ts_loads[col]
+            self.time_series_raw.charging_points_active_power_by_use_case[col] = (
+                ts_loads[col]
+            )
 
         # set load_names if None
         if load_names is None:

--- a/edisgo/network/topology.py
+++ b/edisgo/network/topology.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/opf/__init__.py
+++ b/edisgo/opf/__init__.py
@@ -1,0 +1,10 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/edisgo/opf/opf_solutions/__init__.py
+++ b/edisgo/opf/opf_solutions/__init__.py
@@ -1,0 +1,10 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/edisgo/opf/powermodels_opf.py
+++ b/edisgo/opf/powermodels_opf.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import json
 import logging
 import os

--- a/edisgo/opf/results/__init__.py
+++ b/edisgo/opf/results/__init__.py
@@ -1,0 +1,10 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/edisgo/opf/results/opf_result_class.py
+++ b/edisgo/opf/results/opf_result_class.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 import os
 

--- a/edisgo/opf/timeseries_reduction.py
+++ b/edisgo/opf/timeseries_reduction.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 
 import numpy as np

--- a/edisgo/tools/__init__.py
+++ b/edisgo/tools/__init__.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 
 from contextlib import contextmanager

--- a/edisgo/tools/config.py
+++ b/edisgo/tools/config.py
@@ -1,22 +1,20 @@
-"""This file is part of eDisGo, a python package for distribution network
-analysis and optimization.
-
-It is developed in the project open_eGo: https://openegoproject.wordpress.com
-
-eDisGo lives on github: https://github.com/openego/edisgo/
-The documentation is available on RTD: https://edisgo.readthedocs.io/en/dev/
-
-Based on code by oemof developing group
-
-This module provides a highlevel layer for reading and writing config files.
-
-"""
-
-__copyright__ = "Reiner Lemoine Institut gGmbH"
-__license__ = "GNU Affero General Public License Version 3 (AGPL-3.0)"
-__url__ = "https://github.com/openego/edisgo/blob/master/LICENSE"
-__author__ = "nesnoj, gplssm"
-
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# This file is part of eDisGo. Copyright belongs to
+# Reiner Lemoine Institut gGmbH, authors are recorded in the version control
+# history of the file, available from its original location on github:
+# https://github.com/openego/eDisGo/.
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# eDisGo st available on RTD: https://edisgo.readthedocs.io.
 
 import copy
 import datetime

--- a/edisgo/tools/geo.py
+++ b/edisgo/tools/geo.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/tools/geopandas_helper.py
+++ b/edisgo/tools/geopandas_helper.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import os

--- a/edisgo/tools/logger.py
+++ b/edisgo/tools/logger.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import logging
 import os
 import sys

--- a/edisgo/tools/networkx_helper.py
+++ b/edisgo/tools/networkx_helper.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 from networkx import Graph

--- a/edisgo/tools/plots.py
+++ b/edisgo/tools/plots.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/tools/powermodels_io.py
+++ b/edisgo/tools/powermodels_io.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import math
 
 import numpy as np

--- a/edisgo/tools/preprocess_pypsa_opf_structure.py
+++ b/edisgo/tools/preprocess_pypsa_opf_structure.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import numpy as np
 import pandas as pd
 
@@ -40,9 +51,9 @@ def preprocess_pypsa_opf_structure(edisgo_grid, psa_network, hvmv_trafo=False):
 
     # check if generator slack has a fluctuating variable set
     gen_slack_loc = psa_network.generators.control == "Slack"
-    psa_network.buses.control.loc[
-        psa_network.generators.bus.loc[gen_slack_loc]
-    ] = "Slack"
+    psa_network.buses.control.loc[psa_network.generators.bus.loc[gen_slack_loc]] = (
+        "Slack"
+    )
     is_fluct = psa_network.generators.fluctuating.loc[gen_slack_loc][0]
     # check for nan value
     if is_fluct != is_fluct:

--- a/edisgo/tools/pseudo_coordinates.py
+++ b/edisgo/tools/pseudo_coordinates.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/tools/spatial_complexity_reduction.py
+++ b/edisgo/tools/spatial_complexity_reduction.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import copy

--- a/edisgo/tools/temporal_complexity_reduction.py
+++ b/edisgo/tools/temporal_complexity_reduction.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging
@@ -71,7 +82,7 @@ def _scored_most_critical_loading(
         crit_lines_score.dropna(how="all").dropna(how="all", axis=1).fillna(0)
     )
     # sort sum in descending order
-    return crit_lines_score.sum(axis=1).sort_values(ascending=False, kind='stable')
+    return crit_lines_score.sum(axis=1).sort_values(ascending=False, kind="stable")
 
 
 def _scored_most_critical_voltage_issues(
@@ -121,9 +132,9 @@ def _scored_most_critical_voltage_issues(
         lv_station_buses = [
             lv_grid.station.index[0] for lv_grid in edisgo_obj.topology.mv_grid.lv_grids
         ]
-        edisgo_obj.topology.buses_df.loc[
-            lv_station_buses, "grid_feeder"
-        ] = lv_station_buses
+        edisgo_obj.topology.buses_df.loc[lv_station_buses, "grid_feeder"] = (
+            lv_station_buses
+        )
         # weight voltage violations with expansion costs
         costs = _costs_per_feeder(edisgo_obj, lv_station_buses=lv_station_buses)
         # map feeder costs to buses
@@ -143,7 +154,7 @@ def _scored_most_critical_voltage_issues(
     # drop components and time steps without violations
     voltage_diff = voltage_diff.dropna(how="all").dropna(how="all", axis=1).fillna(0)
     # sort sum in descending order
-    return voltage_diff.sum(axis=1).sort_values(ascending=False, kind='stable')
+    return voltage_diff.sum(axis=1).sort_values(ascending=False, kind="stable")
 
 
 def _scored_most_critical_loading_time_interval(
@@ -514,7 +525,7 @@ def _most_critical_time_interval(
     crit_timesteps = (
         crit_timesteps.iloc[int(time_steps_per_time_interval) - 1 :]
         .iloc[time_step_day_start::time_steps_per_day]
-        .sort_values(ascending=False, kind='stable')
+        .sort_values(ascending=False, kind="stable")
     )
     # get time steps in each time interval - these are set up setting the given time
     # step to be the end of the respective time interval, as rolling() function gives

--- a/edisgo/tools/tools.py
+++ b/edisgo/tools/tools.py
@@ -1,3 +1,14 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from __future__ import annotations
 
 import logging
@@ -486,9 +497,9 @@ def get_path_length_to_station(edisgo_obj):
                 lv_station = lvgrid.station.index[0]
                 for bus in lvgrid.buses_df.index:
                     lv_path = nx.shortest_path(lv_graph, source=lv_station, target=bus)
-                    edisgo_obj.topology.buses_df.at[
-                        bus, "path_length_to_station"
-                    ] = len(path) + len(lv_path)
+                    edisgo_obj.topology.buses_df.at[bus, "path_length_to_station"] = (
+                        len(path) + len(lv_path)
+                    )
     return edisgo_obj.topology.buses_df.path_length_to_station
 
 

--- a/edisgo/tools/voltage_over_distance.py
+++ b/edisgo/tools/voltage_over_distance.py
@@ -1,8 +1,18 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # edisgo/tools/voltage_over_distance.py
 
 from __future__ import annotations
-from edisgo.tools.tools import get_path_length_to_station
-from typing import Optional, Tuple
+
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
@@ -18,12 +28,16 @@ def _get_v_res_df(edisgo_obj) -> pd.DataFrame:
 
     v_res = getattr(edisgo_obj.results, "v_res", None)
     if v_res is None:
-        raise RuntimeError("No voltage results (results.v_res) found. Run edisgo.analyze() first.")
+        raise RuntimeError(
+            "No voltage results (results.v_res) found. Run edisgo.analyze() first."
+        )
 
     return v_res() if callable(v_res) else v_res
 
 
-def _infer_load_and_feedin_timesteps(edisgo_obj, v_df: Optional[pd.DataFrame] = None) -> Tuple[pd.Timestamp, pd.Timestamp]:
+def _infer_load_and_feedin_timesteps(
+    edisgo_obj, v_df: pd.DataFrame | None = None
+) -> tuple[pd.Timestamp, pd.Timestamp]:
     """
     Robust worst-case timestep inference.
 
@@ -48,22 +62,30 @@ def _infer_load_and_feedin_timesteps(edisgo_obj, v_df: Optional[pd.DataFrame] = 
 
         # If all-NaN, fall back
         if not row_min.dropna().empty and not row_max.dropna().empty:
-            t_load = pd.Timestamp(row_min.idxmin())   # worst undervoltage
-            t_feed = pd.Timestamp(row_max.idxmax())   # worst overvoltage
+            t_load = pd.Timestamp(row_min.idxmin())  # worst undervoltage
+            t_feed = pd.Timestamp(row_max.idxmax())  # worst overvoltage
             return t_load, t_feed
 
     # 2) Fallback: residual load from timeseries
     ts = getattr(edisgo_obj, "timeseries", None)
     if ts is None:
-        raise RuntimeError("Cannot infer worst-case timesteps: no voltage results and no timeseries.")
+        raise RuntimeError(
+            "Cannot infer worst-case timesteps: no voltage results and no timeseries."
+        )
 
     loads_p = getattr(ts, "loads_active_power", None)
     gens_p = getattr(ts, "generators_active_power", None)
 
-    if loads_p is None or gens_p is None or len(loads_p.index) == 0 or len(gens_p.index) == 0:
+    if (
+        loads_p is None
+        or gens_p is None
+        or len(loads_p.index) == 0
+        or len(gens_p.index) == 0
+    ):
         raise RuntimeError(
             "Cannot infer worst-case timesteps: voltage results are empty and "
-            "timeseries.loads_active_power / generators_active_power are missing or empty."
+            "timeseries.loads_active_power / generators_active_power "
+            "are missing or empty."
         )
 
     loads_sum = loads_p.sum(axis=1)
@@ -71,12 +93,13 @@ def _infer_load_and_feedin_timesteps(edisgo_obj, v_df: Optional[pd.DataFrame] = 
     residual = (loads_sum - gens_sum).dropna()
 
     if residual.empty:
-        raise RuntimeError("Cannot infer worst-case timesteps: residual load series is empty.")
+        raise RuntimeError(
+            "Cannot infer worst-case timesteps: residual load series is empty."
+        )
 
     t_load = pd.Timestamp(residual.idxmax())
     t_feed = pd.Timestamp(residual.idxmin())
     return t_load, t_feed
-
 
 
 def _series_at_t(v_df: pd.DataFrame, t: pd.Timestamp) -> pd.Series:
@@ -100,15 +123,16 @@ def _series_at_t(v_df: pd.DataFrame, t: pd.Timestamp) -> pd.Series:
     s.index = s.index.map(str)
     return s
 
+
 def build_voltage_over_distance_df(
     *,
     buses: pd.Index,
     dist_a: pd.Series,
     v_a_load: pd.Series,
     v_a_feed: pd.Series,
-    dist_b: Optional[pd.Series] = None,
-    v_b_load: Optional[pd.Series] = None,
-    v_b_feed: Optional[pd.Series] = None,
+    dist_b: pd.Series | None = None,
+    v_b_load: pd.Series | None = None,
+    v_b_feed: pd.Series | None = None,
 ) -> pd.DataFrame:
     """
     Build the DataFrame used for voltage-over-distance plots.
@@ -143,6 +167,7 @@ def build_voltage_over_distance_df(
 
     return pd.concat(parts, ignore_index=True)
 
+
 def make_voltage_over_distance_figure(
     *,
     title: str,
@@ -150,13 +175,13 @@ def make_voltage_over_distance_figure(
     dist_a: pd.Series,
     v_a_load: pd.Series,
     v_a_feed: pd.Series,
-    dist_b: Optional[pd.Series] = None,
-    v_b_load: Optional[pd.Series] = None,
-    v_b_feed: Optional[pd.Series] = None,
+    dist_b: pd.Series | None = None,
+    v_b_load: pd.Series | None = None,
+    v_b_feed: pd.Series | None = None,
     band_low: float,
     band_high: float,
     x_label: str = "Path length to station [-]",
-    df: Optional[pd.DataFrame] = None,
+    df: pd.DataFrame | None = None,
 ) -> go.Figure:
     """
     Builds a plotly scatter figure with 4 traces:
@@ -175,7 +200,6 @@ def make_voltage_over_distance_figure(
             v_b_load=v_b_load,
             v_b_feed=v_b_feed,
         )
-
 
     fig = go.Figure()
 
@@ -196,9 +220,12 @@ def make_voltage_over_distance_figure(
                 mode="markers",
                 name=label,
                 customdata=np.stack([sub["bus"]], axis=-1),
-                hovertemplate="bus=%{customdata[0]}<br>path=%{x}<br>v=%{y:.4f} p.u.<extra></extra>",
+                hovertemplate=(
+                    "bus=%{customdata[0]}<br>path=%{x}"
+                    "<br>v=%{y:.4f} p.u.<extra></extra>"
+                ),
             )
-        )    
+        )
     fig.update_layout(
         title=title,
         xaxis_title=x_label,

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,13 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Setup"""
 
 import os


### PR DESCRIPTION
Closes #56  (file headers / copyright information).

## What changed

### License headers (all .py files in edisgo/ + setup.py + doc/conf.py)
- Added a uniform `#`-style copyright and license header to every Python file in the project. Previously most files had no header at all; a few used `"""..."""` module-level docstrings for project info, which caused those strings to appear as module documentation in the auto-generated API reference (sphinx-autoapi renders module docstrings).
- The new header uses `#` comments so it is invisible to Sphinx, follows the SPDX convention (`SPDX-License-Identifier: AGPL-3.0-or-later`), and references the git history for contributor attribution instead of hard-coding author names.
- Removed `__copyright__`, `__license__`, `__url__`, and `__author__` module-level dunder attributes from `edisgo/tools/config.py` (the only file that had them).
- Existing genuine module docstrings (e.g. `edisgo/io/pypsa_io.py`) are kept; only project-info boilerplate `"""..."""` strings were removed.

### Pre-commit hook
- Added `Lucas-C/pre-commit-hooks` (`insert-license`) to `.pre-commit-config.yaml`. The hook checks on every commit that the license header is present in all `.py` files (excluding `tests/`) and inserts it automatically if missing.
- License text lives in `.license-header.txt` for easy central updates.

### Flake8 fixes (unrelated to headers, found during the same pass)
- `edisgo/edisgo.py`: wrapped two over-long string literals (E501), removed two unused local variables `v_b_load` / `v_b_feed` (F841).
- `edisgo/io/generators_import.py`: wrapped two over-long comments (E501).
- `edisgo/io/mviews_filters.py`: SQLAlchemy `== None` comparisons kept intentionally (generates `IS NULL` in SQL); suppressed with `# noqa: E711`.
- `edisgo/io/mviews_replacement.py`: wrapped long docstring examples (E501), removed unused `base_prefix` local variable (F841), removed duplicate `schema` assignment.
- `edisgo/io/powermodels_io.py`: replaced `type(x) == str/dict` with `isinstance()` (E721).
- `edisgo/tools/voltage_over_distance.py`: removed unused imports `Optional`, `Tuple`, `get_path_length_to_station` (F401); wrapped over-long string literals (E501).

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
