### PR TITLE
Fix set_time_series_active_power_predefined to auto-set timeindex whe…

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -557,10 +557,28 @@ class EDisGo:
             :py:attr:`~.network.timeseries.TimeSeries.timeindex` is used.
             If :py:attr:`~.network.timeseries.TimeSeries.timeindex` is not set, the data
             is indexed using a default year and set for the whole year.
+            In this case, the EDisGo TimeSeries timeindex is automatically set to
+            the selected default year so that imported data is linked to a valid
+            time index.
 
         """
         engine = kwargs["engine"] if "engine" in kwargs else egon_engine()
-        if self.timeseries.timeindex.empty:
+        if self.timeseries.timeindex.empty and kwargs.get("timeindex", None) is None:
+            if conventional_loads_ts == "oedb":
+                default_year = tools.get_year_based_on_scenario(kwargs.get("scenario"))
+                if default_year is None:
+                    default_year = 2011
+            else:
+                default_year = 2011
+            self.timeseries.timeindex = pd.date_range(
+                f"1/1/{default_year}", periods=8760, freq="H"
+            )
+            logger.warning(
+                "No timeindex was set. TimeSeries.timeindex is automatically "
+                f"set to the default year {default_year} to match imported "
+                "time series."
+            )
+        elif self.timeseries.timeindex.empty:
             logger.warning(
                 "When setting time series using predefined profiles it is better to "
                 "set a time index as all data in TimeSeries class is indexed by the"

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -164,6 +164,21 @@ class TestEDisGo:
             storage_units_ts, self.edisgo.timeseries.storage_units_reactive_power
         )
 
+    def test_set_time_series_active_power_predefined_oedb_auto_sets_timeindex(self):
+        # Test that timeindex is automatically set when importing predefined time series
+        # and no timeindex is provided
+        edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
+        # Ensure timeindex is empty initially
+        assert edisgo.timeseries.timeindex.empty
+        # Call set_time_series_active_power_predefined with demandlib data (local)
+        edisgo.set_time_series_active_power_predefined(
+            conventional_loads_ts="demandlib",
+        )
+        # Check that timeindex is now set to the default year (2011) with 8760 hours
+        assert not edisgo.timeseries.timeindex.empty
+        assert edisgo.timeseries.timeindex.year.unique()[0] == 2011
+        assert len(edisgo.timeseries.timeindex) == 8760
+
     def test_set_time_series_worst_case_analysis(self):
         self.edisgo.set_time_series_worst_case_analysis(
             cases="load_case", generators_names=["Generator_1"], loads_names=[]
@@ -285,6 +300,29 @@ class TestEDisGo:
             2,
             len(fluctuating_gens),
         )
+
+    @pytest.mark.slow
+    def test_set_time_series_active_power_predefined_oedb_auto_sets_timeindex(
+        self,
+    ):
+        edisgo_object = EDisGo(
+            ding0_grid=pytest.ding0_test_network_3_path,
+            legacy_ding0_grids=False,
+        )
+
+        edisgo_object.set_time_series_active_power_predefined(
+            conventional_loads_ts="oedb",
+            fluctuating_generators_ts="oedb",
+            scenario="eGon2035",
+            engine=pytest.engine,
+            conventional_loads_names=[
+                "Load_mvgd_33535_lvgd_1164210000_244_residential"
+            ],
+        )
+
+        assert not edisgo_object.timeseries.timeindex.empty
+        assert edisgo_object.timeseries.timeindex[0].year == 2035
+        assert edisgo_object.timeseries.timeindex.shape == (8760,)
 
     def test_set_time_series_reactive_power_control(self):
         # set active power time series for fixed cosphi

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -164,9 +164,7 @@ class TestEDisGo:
             storage_units_ts, self.edisgo.timeseries.storage_units_reactive_power
         )
 
-    def test_set_time_series_active_power_predefined_oedb_auto_sets_timeindex(self):
-        # Test that timeindex is automatically set when importing predefined time series
-        # and no timeindex is provided
+    def test_set_time_series_active_power_predefined_demandlib_auto_sets_timeindex(self):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
         # Ensure timeindex is empty initially
         assert edisgo.timeseries.timeindex.empty
@@ -221,10 +219,7 @@ class TestEDisGo:
 
         # check warning
         self.edisgo.set_time_series_active_power_predefined()
-        assert (
-            "When setting time series using predefined profiles it is better"
-            in caplog.text
-        )
+        assert "No timeindex was set. TimeSeries.timeindex is automatically" in caplog.text
 
         # check if right functions are called
         timeindex = pd.date_range("1/1/2011 12:00", periods=2, freq="H")


### PR DESCRIPTION
# Description
Fixes an issue where [set_time_series_active_power_predefined] could leave [TimeSeries.timeindex] empty when importing predefined profiles without an explicit timeindex.

- Automatically set TimeSeries.timeindex to default year (2011 or scenario-based) when importing predefined time series without explicit timeindex
- Add warning log when auto-setting timeindex
- Add regression test to ensure timeindex is properly set


Fixes #457 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
