### PR TITLE
make engine optional in import_heat_pumps, import_dsm, import_home_batteries

### DIFF
--- a/doc/usage_details.rst
+++ b/doc/usage_details.rst
@@ -181,6 +181,14 @@ OEP Database (Standard)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The OEP database provides the egon-data interface and is the default data source.
+No ``engine`` argument is required — when omitted, a default OEP engine is created
+automatically. The following methods support this behaviour:
+:meth:`~.edisgo.EDisGo.set_time_series_active_power_predefined`,
+:meth:`~.edisgo.EDisGo.import_generators`,
+:meth:`~.edisgo.EDisGo.import_electromobility`,
+:meth:`~.edisgo.EDisGo.import_heat_pumps`,
+:meth:`~.edisgo.EDisGo.import_dsm`, and
+:meth:`~.edisgo.EDisGo.import_home_batteries`.
 
 Example
 ^^^^^^^

--- a/doc/whatsnew/v0-3-0.rst
+++ b/doc/whatsnew/v0-3-0.rst
@@ -31,3 +31,11 @@ Changes
 * Added clipping of heat pump electrical power at its maximum value `#428 <https://github.com/openego/eDisGo/pull/428>`
 * Replaced flake8, isort, pyupgrade, and Black with Ruff for linting
   and formatting in pre-commit configuration `#222 <https://github.com/openego/eDisGo/issues/222>`_
+* Made ``engine`` parameter optional in
+  :meth:`~.edisgo.EDisGo.set_time_series_active_power_predefined`,
+  :meth:`~.edisgo.EDisGo.import_generators`,
+  :meth:`~.edisgo.EDisGo.import_electromobility`,
+  :meth:`~.edisgo.EDisGo.import_heat_pumps`,
+  :meth:`~.edisgo.EDisGo.import_dsm`, and
+  :meth:`~.edisgo.EDisGo.import_home_batteries`;
+  defaults to a standard open energy platform engine when not provided

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -1130,12 +1130,14 @@ class EDisGo:
             if raise_not_converged and len(timesteps_not_converged) > 0:
                 raise ValueError(
                     "Power flow analysis did not converge for the "
-                    f"following {len(timesteps_not_converged)} time steps: {timesteps_not_converged}."
+                    f"following {len(timesteps_not_converged)} time steps: "
+                    f"{timesteps_not_converged}."
                 )
             elif len(timesteps_not_converged) > 0:
                 logger.warning(
                     "Power flow analysis did not converge for the "
-                    f"following {len(timesteps_not_converged)} time steps: {timesteps_not_converged}."
+                    f"following {len(timesteps_not_converged)} time steps: "
+                    f"{timesteps_not_converged}."
                 )
             return timesteps_converged, timesteps_not_converged
 
@@ -2136,7 +2138,9 @@ class EDisGo:
             self, strategy=strategy, charging_park_ids=charging_park_ids, **kwargs
         )
 
-    def import_heat_pumps(self, scenario, engine, timeindex=None, import_types=None):
+    def import_heat_pumps(
+        self, scenario, engine=None, timeindex=None, import_types=None
+    ):
         """
         Gets heat pump data for specified scenario from oedb and integrates the heat
         pumps into the grid.
@@ -2194,8 +2198,9 @@ class EDisGo:
         scenario : str
             Scenario for which to retrieve heat pump data. Possible options
             are 'eGon2035' and 'eGon100RE'.
-        engine : :sqlalchemy:`sqlalchemy.Engine<sqlalchemy.engine.Engine>`
-            Database engine.
+        engine : :sqlalchemy:`sqlalchemy.Engine<sqlalchemy.engine.Engine>` or None
+            Database engine. If None, a default engine to the open energy platform
+            is created.
         timeindex : :pandas:`pandas.DatetimeIndex<DatetimeIndex>` or None
             Specifies time steps for which to set COP and heat demand data. Leap years
             can currently not be handled. In case the given
@@ -2212,6 +2217,7 @@ class EDisGo:
             "central_resistive_heaters". If None, all are imported.
 
         """
+        engine = engine if engine is not None else egon_engine()
         # set up year to index data by
         # first try to get index from time index
         if timeindex is None:
@@ -2308,7 +2314,7 @@ class EDisGo:
         """
         hp_operating_strategy(self, strategy=strategy, heat_pump_names=heat_pump_names)
 
-    def import_dsm(self, scenario: str, engine: Engine, timeindex=None):
+    def import_dsm(self, scenario: str, engine: Engine = None, timeindex=None):
         """
         Gets industrial and CTS DSM profiles from the
         `OpenEnergy DataBase <https://openenergyplatform.org/database/>`_.
@@ -2327,8 +2333,9 @@ class EDisGo:
         scenario : str
             Scenario for which to retrieve DSM data. Possible options
             are 'eGon2035' and 'eGon100RE'.
-        engine : :sqlalchemy:`sqlalchemy.Engine<sqlalchemy.engine.Engine>`
-            Database engine.
+        engine : :sqlalchemy:`sqlalchemy.Engine<sqlalchemy.engine.Engine>` or None
+            Database engine. If None, a default engine to the open energy platform
+            is created.
         timeindex : :pandas:`pandas.DatetimeIndex<DatetimeIndex>` or None
             Specifies time steps for which to get data. Leap years can currently not be
             handled. In case the given timeindex contains a leap year, the data will be
@@ -2340,6 +2347,7 @@ class EDisGo:
             is indexed using the default year and returned for the whole year.
 
         """
+        engine = engine if engine is not None else egon_engine()
         dsm_profiles = dsm_import.oedb(
             edisgo_obj=self, scenario=scenario, engine=engine, timeindex=timeindex
         )
@@ -2351,7 +2359,7 @@ class EDisGo:
     def import_home_batteries(
         self,
         scenario: str,
-        engine: Engine,
+        engine: Engine = None,
     ):
         """
         Gets home battery data for specified scenario and integrates the batteries into
@@ -2379,10 +2387,12 @@ class EDisGo:
         scenario : str
             Scenario for which to retrieve home battery data. Possible options
             are 'eGon2035' and 'eGon100RE'.
-        engine : :sqlalchemy:`sqlalchemy.Engine<sqlalchemy.engine.Engine>`
-            Database engine.
+        engine : :sqlalchemy:`sqlalchemy.Engine<sqlalchemy.engine.Engine>` or None
+            Database engine. If None, a default engine to the open energy platform
+            is created.
 
         """
+        engine = engine if engine is not None else egon_engine()
         home_batteries_oedb(
             edisgo_obj=self,
             scenario=scenario,
@@ -3641,7 +3651,8 @@ class EDisGo:
             if comparison.any():
                 logger.warning(
                     "Heat demand is higher than rated heatpump power"
-                    f" of heatpumps: {comparison.index[comparison.values].values}. Demand can not be covered if no sufficient"
+                    f" of heatpumps: {comparison.index[comparison.values].values}."
+                    " Demand can not be covered if no sufficient"
                     " heat storage capacities are available."
                 )
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -39,7 +39,6 @@ class TestExamples:
         assert result.exec_error is None
 
     @pytest.mark.slow
-    @pytest.mark.skip(reason="deprecated - should not be tested right now")
     def test_edisgo_simple_example_ipynb(self):
         path = os.path.join(self.examples_dir_path, "edisgo_simple_example.ipynb")
         notebook = pytest_notebook.notebook.load_notebook(path=path)


### PR DESCRIPTION

Falls back to egon_engine() when no engine is provided.

# Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] New and adjusted code includes type hinting now
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The Read the Docs documentation is compiling correctly
- [x] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [x] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
