### PR TITLE
fix: pin setuptools < 82.0.0 to retain pkg_resources compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ def read(fname):
 
 
 requirements = [
+    "setuptools < 82.0.0",
     "contextily < 1.8.0",
     "dash < 3.5.0",
     "demandlib < 0.3.0",


### PR DESCRIPTION
setuptools >= 82 removes pkg_resources, which causes an ImportError when importing eDisGo. Pinning setuptools < 82.0.0 restores compatibility until all affected dependencies are migrated to importlib.metadata.

Fixes #599

# Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
