### PR TITLE
Fix/issue 471 load scaling

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -558,8 +558,8 @@ class EDisGo:
 
         """
         engine = kwargs["engine"] if "engine" in kwargs else egon_engine()
-        set_timeindex = False
-        if timeindex is not None and not self.timeseries.timeindex.empty:
+        timeindex = kwargs.get("timeindex", None)
+        if timeindex is None and self.timeseries.timeindex.empty:
             logger.warning(
                 "When setting time series using predefined profiles it is better to "
                 "set a time index as all data in TimeSeries class is indexed by the"

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -558,7 +558,8 @@ class EDisGo:
 
         """
         engine = kwargs["engine"] if "engine" in kwargs else egon_engine()
-        if self.timeseries.timeindex.empty:
+        set_timeindex = False
+        if timeindex is not None and not self.timeseries.timeindex.empty:
             logger.warning(
                 "When setting time series using predefined profiles it is better to "
                 "set a time index as all data in TimeSeries class is indexed by the"

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -1452,15 +1452,15 @@ class TimeSeries:
         load_names = self._check_if_components_exist(edisgo_object, load_names, "loads")
         loads_df = edisgo_object.topology.loads_df.loc[load_names, :]
 
-        # check if loads contain annual demand
-        if not all(loads_df.annual_consumption.notnull()):
+        # check if loads contain nominal power
+        if not all(loads_df.p_set.notnull()):
             raise AttributeError(
-                "The annual consumption of some loads is missing. Please provide"
+                "The nominal power 'p_set' of some loads is missing. Please provide it."
             )
 
-        # scale time series by annual consumption
+        # scale time series by nominal power (consistent with generators)
         ts_scaled = loads_df.apply(
-            lambda x: ts_loads[x.sector] * x.annual_consumption,
+            lambda x: ts_loads[x.sector] * x.p_set,
             axis=1,
         ).T
         self.add_component_time_series("loads_active_power", ts_scaled)

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -1600,7 +1600,7 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_agricultural_LVGrid_5_2", "annual_consumption"
+                    "Load_agricultural_LVGrid_5_2", "p_set"
                 ]
                 * profiles["agricultural"]
             ).values,
@@ -1612,7 +1612,7 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_residential_LVGrid_5_3", "annual_consumption"
+                    "Load_residential_LVGrid_5_3", "p_set"
                 ]
                 * profiles["residential"]
             ).values,
@@ -1622,7 +1622,7 @@ class TestTimeSeries:
             self.edisgo.timeseries.loads_active_power["Load_retail_LVGrid_9_14"].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_retail_LVGrid_9_14", "annual_consumption"
+                    "Load_retail_LVGrid_9_14", "p_set"
                 ]
                 * profiles["cts"]
             ).values,
@@ -1634,7 +1634,7 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_industrial_LVGrid_6_1", "annual_consumption"
+                    "Load_industrial_LVGrid_6_1", "p_set"
                 ]
                 * profiles["industrial"]
             ).values,
@@ -1654,19 +1654,34 @@ class TestTimeSeries:
             self.edisgo.timeseries.loads_active_power[
                 "Load_industrial_LVGrid_6_1"
             ].values,
-            [0.05728395] * 3,
+            (
+                self.edisgo.topology.loads_df.loc[
+                    "Load_industrial_LVGrid_6_1", "p_set"
+                ]
+                * profiles["industrial"]
+            ).values,
         ).all()
         assert np.isclose(
             self.edisgo.timeseries.loads_active_power.loc[
                 index[1], "Load_agricultural_LVGrid_5_2"
             ],
-            0.0274958,
+            (
+                self.edisgo.topology.loads_df.loc[
+                    "Load_agricultural_LVGrid_5_2", "p_set"
+                ]
+                * profiles.loc[index[1], "agricultural"]
+            ),
         )
         assert np.isclose(
             self.edisgo.timeseries.loads_active_power.loc[
                 index, "Load_residential_LVGrid_9_2"
             ].values,
-            [0.00038328, 0.00027608, 0.00022101],
+            (
+                self.edisgo.topology.loads_df.loc[
+                    "Load_residential_LVGrid_9_2", "p_set"
+                ]
+                * profiles.loc[index, "residential"]
+            ).values,
         ).all()
         # test assertion error
         with pytest.raises(ValueError) as exc_info:
@@ -1696,7 +1711,7 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_agricultural_LVGrid_5_2", "annual_consumption"
+                    "Load_agricultural_LVGrid_5_2", "p_set"
                 ]
                 * profiles["agricultural"]
             ).values,
@@ -1707,7 +1722,7 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_residential_LVGrid_5_3", "annual_consumption"
+                    "Load_residential_LVGrid_5_3", "p_set"
                 ]
                 * profiles["residential"]
             ).values,
@@ -1716,7 +1731,7 @@ class TestTimeSeries:
             self.edisgo.timeseries.loads_active_power["Load_retail_LVGrid_9_14"].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_retail_LVGrid_9_14", "annual_consumption"
+                    "Load_retail_LVGrid_9_14", "p_set"
                 ]
                 * profiles["cts"]
             ).values,
@@ -1727,7 +1742,7 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_industrial_LVGrid_6_1", "annual_consumption"
+                    "Load_industrial_LVGrid_6_1", "p_set"
                 ]
                 * profiles["industrial"]
             ).values,
@@ -1755,7 +1770,7 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_agricultural_LVGrid_5_2", "annual_consumption"
+                    "Load_agricultural_LVGrid_5_2", "p_set"
                 ]
                 * profiles["agricultural"]
             ).values,
@@ -1766,7 +1781,7 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_residential_LVGrid_5_3", "annual_consumption"
+                    "Load_residential_LVGrid_5_3", "p_set"
                 ]
                 * profiles_new["residential"]
             ).values,
@@ -1775,7 +1790,7 @@ class TestTimeSeries:
             self.edisgo.timeseries.loads_active_power["Load_retail_LVGrid_9_14"].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_retail_LVGrid_9_14", "annual_consumption"
+                    "Load_retail_LVGrid_9_14", "p_set"
                 ]
                 * profiles["cts"]
             ).values,
@@ -1786,31 +1801,31 @@ class TestTimeSeries:
             ].values,
             (
                 self.edisgo.topology.loads_df.loc[
-                    "Load_industrial_LVGrid_6_1", "annual_consumption"
+                    "Load_industrial_LVGrid_6_1", "p_set"
                 ]
                 * profiles_new["industrial"]
             ).values,
         ).all()
 
-        # test Error if 'annual_consumption' is missing
-        # Save the original 'annual_consumption' values
-        original_annual_consumption = self.edisgo.topology.loads_df[
-            "annual_consumption"
+        # test Error if 'p_set' is missing
+        # Save the original 'p_set' values
+        original_p_set = self.edisgo.topology.loads_df[
+            "p_set"
         ].copy()
-        # Set 'annual_consumption' to None for the test
-        self.edisgo.topology.loads_df["annual_consumption"] = None
+        # Set 'p_set' to None for the test
+        self.edisgo.topology.loads_df["p_set"] = None
         with pytest.raises(AttributeError) as exc_info:
             self.edisgo.timeseries.predefined_conventional_loads_by_sector(
                 self.edisgo, "demandlib"
             )
         assert (
             exc_info.value.args[0]
-            == "The annual consumption of some loads is missing. Please provide"
+            == "The nominal power 'p_set' of some loads is missing. Please provide it."
         )
-        # Restore the original 'annual_consumption' values
+        # Restore the original 'p_set' values
         self.edisgo.topology.loads_df[
-            "annual_consumption"
-        ] = original_annual_consumption
+            "p_set"
+        ] = original_p_set
 
     def test_predefined_charging_points_by_use_case(self, caplog):
         index = pd.date_range("1/1/2018", periods=3, freq="H")


### PR DESCRIPTION
# Description

1. Fix load scaling in predefined_conventional_loads_by_sector — replaces annual_consumption with p_set
2. Fix load scaling and timeindex handling — updates tests + removes redundant toep check
3. Fix NameError in set_time_series_active_power_predefined — extracts timeindex from kwargs before use

Fixes #471

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
