### PR TITLE
Fix charging point connection handling

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -1837,7 +1837,16 @@ class EDisGo:
                 raise ValueError(
                     "Neither appropriate voltage level nor nominal power were supplied."
                 )
-            voltage_level = determine_grid_integration_voltage_level(self, p)
+        
+            if comp_type == "charging_point":
+                if float(p) < 0.1:
+                    # < 100 kW: LV grid
+                    voltage_level = 7
+                else:
+                    # >= 100 kW: MV grid
+                    voltage_level = 5
+            else:
+                voltage_level = determine_grid_integration_voltage_level(self, p)
 
         # convert geolocation to shapely Point if needed
         if type(geolocation) is not Point:
@@ -1857,26 +1866,28 @@ class EDisGo:
         # -------------------------
         else:
             lv_buses = self.topology.buses_df.drop(self.topology.mv_grid.buses_df.index)
-            lv_buses_dropna = lv_buses.dropna(axis=0, subset=["x", "y"])
-
-            # fallback path for non-georeferenced LV grids
-            if len(lv_buses_dropna) < len(lv_buses):
-                if kwargs.get("mvlv_subst_id", None) is None:
-                    substations = self.topology.buses_df.loc[
-                        self.topology.transformers_df.bus1.unique()
-                    ]
-                    nearest_substation, _ = find_nearest_bus_14a(geolocation, substations)
-                    kwargs["mvlv_subst_id"] = int(nearest_substation.split("_")[-2])
-
-                comp_name = self.topology.connect_to_lv_14a(self, kwargs, comp_type)
-
-            else:
-                max_distance_from_target_bus = kwargs.pop(
-                    "max_distance_from_target_bus", 0.3 #CHANGED #14a
+            lv_buses_without_xy = lv_buses[
+                lv_buses[["x", "y"]].isna().any(axis=1)
+            ]
+        
+            if not lv_buses_without_xy.empty:
+                logger.warning(
+                    "Not all LV buses are georeferenced. "
+                    "%d of %d LV buses have missing x/y coordinates and will be ignored "
+                    "by connect_to_lv_based_on_geolocation_14a. "
+                    "This can lead to non-local LV connections if affected grid areas are missing. "
+                    "Example buses without coordinates: %s",
+                    len(lv_buses_without_xy),
+                    len(lv_buses),
+                    list(lv_buses_without_xy.index[:10]),
                 )
-                comp_name = self.topology.connect_to_lv_based_on_geolocation_14a(
-                    self, kwargs, comp_type, max_distance_from_target_bus
-                )
+        
+            max_distance_from_target_bus = kwargs.pop(
+                "max_distance_from_target_bus", 0.3
+            )
+            comp_name = self.topology.connect_to_lv_based_on_geolocation_14a(
+                self, kwargs, comp_type, max_distance_from_target_bus
+            )
 
         if add_ts:
             if comp_type == "generator":

--- a/edisgo/io/electromobility_import.py
+++ b/edisgo/io/electromobility_import.py
@@ -1441,7 +1441,6 @@ def integrate_charging_parks_14a(edisgo_obj):
 
     charging_parks = list(edisgo_obj.electromobility.potential_charging_parks)
     
-    #temp1
     total_parks = len(charging_parks)
     
     parks_demand_gt_0 = [
@@ -1452,7 +1451,6 @@ def integrate_charging_parks_14a(edisgo_obj):
         cp for cp in charging_parks
         if cp.within_grid
     ]
-    #temp2
     
     designated_charging_parks = [
         cp
@@ -1460,14 +1458,12 @@ def integrate_charging_parks_14a(edisgo_obj):
         if (cp.designated_charging_point_capacity > 0) and cp.within_grid
     ]
 
-    #temp1    
     print("\nCharging park filter check (14a)")
     print("-" * 44)
     print(f"{'Total parks in all mv_grid_ids':<30}{total_parks:>6}")
     print(f"{'CP with Demand > 0':<30}{len(parks_demand_gt_0):>6}")
     print(f"{'CP within grid':<30}{len(parks_within_grid):>6}")
     print(f"{'Designated CP (both true)':<30}{len(designated_charging_parks):>6}")
-    #temp2
     
     charging_park_ids = []
     edisgo_ids = []

--- a/edisgo/network/topology.py
+++ b/edisgo/network/topology.py
@@ -2003,132 +2003,10 @@ class Topology:
                 )
 
         return comp_name
-    
-    # def connect_to_mv_14a(self, edisgo_object, comp_data, comp_type="generator"): #CHANGED
-    #     """
-    #     14a variant of connect_to_mv.
-
-    #     """
-    #     if "p" not in comp_data.keys():
-    #         comp_data["p"] = (
-    #             comp_data["p_set"]
-    #             if "p_set" in comp_data.keys()
-    #             else comp_data["p_nom"]
-    #         )
-
-    #     voltage_level = comp_data.pop("voltage_level")
-    #     power = comp_data.pop("p")
-
-    #     # create new bus for new component
-    #     if not isinstance(comp_data["geom"], Point):
-    #         geom = wkt_loads(comp_data["geom"])
-    #     else:
-    #         geom = comp_data["geom"]
-          
-    #     if comp_type == "charging_point":
-
-    #         mv_buses = self.mv_grid.buses_df
-    #         target_bus, target_bus_distance = geo.find_nearest_bus_14a(geom, mv_buses)
-
-    #         MAX_DIST = 0.3  # km
-        
-    #         if target_bus_distance >= MAX_DIST:
-    #             print(
-    #                 f"SKIP CP (too far from MV bus): dist={target_bus_distance:.3f} km"
-    #             )
-    #             return None
-
-    #         # attach directly to existing MV bus
-    #         comp_data.pop("geom", None)
-    #         comp_data.pop("p", None)
-
-    #         return self.add_load(
-    #             bus=target_bus,
-    #             type="charging_point",
-    #             **comp_data
-    #         )
-
-    #     # ===== FIND NEAREST MV BUS =====
-    #     mv_buses = self.mv_grid.buses_df
-    #     target_bus, target_bus_distance = geo.find_nearest_bus_14a(geom, mv_buses)
-
-    #     MAX_DIST = 0.3
-
-    #     if comp_type == "charging_point" and target_bus_distance < MAX_DIST:
-    #         bus = target_bus
-    #     else:
-    #         print("comp_type has to be charging_point in _14a workflow")
-
-    #     # add component to newly created bus
-    #     comp_data.pop("geom")
-    #     if comp_type == "generator":
-    #         comp_name = self.add_generator(bus=bus, **comp_data)
-    #     elif comp_type == "charging_point":
-    #         comp_name = self.add_load(bus=bus, type="charging_point", **comp_data)
-    #     elif comp_type == "heat_pump":
-    #         comp_name = self.add_load(bus=bus, type="heat_pump", **comp_data)
-    #     else:
-    #         comp_name = self.add_storage_unit(bus=bus, **comp_data)
-
-    #     # ===== voltage level 4: component is connected to MV station =====
-    #     if voltage_level == 4:
-    #         print("Voltage_level 4 in connect_t_mv_14a has no 14a workflow yet.")
-
-    #     elif voltage_level == 5:
-    #         # get branches within the predefined `connection_buffer_radius`
-    #         lines = geo.calc_geo_lines_in_buffer(
-    #             grid_topology=self,
-    #             bus=self.buses_df.loc[bus, :],
-    #             grid=self.mv_grid,
-    #             buffer_radius=int(
-    #                 edisgo_object.config["grid_connection"]["conn_buffer_radius"]
-    #             ),
-    #             buffer_radius_inc=int(
-    #                 edisgo_object.config["grid_connection"]["conn_buffer_radius_inc"]
-    #             ),
-    #         )
-
-    #         # calc distance between component and grid's lines -> find nearest line
-    #         conn_objects_min_stack = geo.find_nearest_conn_objects(
-    #             grid_topology=self,
-    #             bus=self.buses_df.loc[bus, :],
-    #             lines=lines,
-    #             conn_diff_tolerance=edisgo_object.config["grid_connection"][
-    #                 "conn_diff_tolerance"
-    #             ],
-    #         )
-
-    #         # connect
-    #         # go through the stack (from nearest to farthest connection target
-    #         # object)
-    #         comp_connected = False
-    #         for dist_min_obj in conn_objects_min_stack:
-    #             # do not allow connection to virtual busses
-    #             if "virtual" not in dist_min_obj["repr"]:
-    #                 target_obj_result = self._connect_mv_bus_to_target_object(
-    #                     edisgo_object=edisgo_object,
-    #                     bus=self.buses_df.loc[bus, :],
-    #                     target_obj=dist_min_obj,
-    #                     comp_type=comp_type,
-    #                     power=power,
-    #                 )
-
-    #                 if target_obj_result is not None:
-    #                     comp_connected = True
-    #                     break
-
-    #         if not comp_connected:
-    #             logger.error(
-    #                 f"Component {comp_name} could not be connected. Try to increase the"
-    #                 f" parameter `conn_buffer_radius` in config file `config_grid.cfg` "
-    #                 f"to gain more possible connection points."
-    #             )
-
-    #     return comp_name
 
     def connect_to_mv_14a(self, edisgo_object, comp_data, comp_type="generator"):
         """
-        Connect a charging point directly to the nearest existing MV bus.
+        Connect a charging point directly to the nearest MV-side bus of an MV/LV transformer.
         
         This 14a variant is intended exclusively for charging points.
         It never creates a new bus. If no MV bus is found within the
@@ -2190,6 +2068,7 @@ class Topology:
         # Pop fields that are not needed by add_load(...)
         comp_data.pop("voltage_level")
         geom_raw = comp_data.pop("geom")
+        comp_data.pop("p", None)
 
         # Parse geometry
         if isinstance(geom_raw, Point):
@@ -2197,13 +2076,24 @@ class Topology:
         else:
             geom = wkt_loads(geom_raw)
 
-        # Find nearest existing MV bus
-        mv_buses = self.mv_grid.buses_df
+        # Use only MV side of MV/LV transformers as possible target buses
+        mv_trafo_bus_ids = self.transformers_df["bus0"].dropna().unique()
+        
+        mv_buses = self.buses_df.loc[
+            self.buses_df.index.intersection(mv_trafo_bus_ids)
+        ].dropna(subset=["x", "y"])
+        
+        if mv_buses.empty:
+            raise ValueError(
+                "No MV-side transformer buses with coordinates found "
+                "for charging point connection."
+            )
+        
         target_bus, target_bus_distance = geo.find_nearest_bus_14a(geom, mv_buses)
 
         if target_bus_distance >= MAX_DIST_KM:
             raise ValueError(
-                f"Charging point cannot be connected: nearest MV bus is "
+                f"Charging point cannot be connected: nearest MV-side transformer bus is "
                 f"{target_bus_distance:.3f} km away, exceeding the maximum "
                 f"allowed distance of {MAX_DIST_KM:.3f} km."
             )
@@ -2685,18 +2575,6 @@ class Topology:
         from scipy.spatial import cKDTree
 
         # -------------------------------------------------------------
-        # Charging-point bus eligibility by use case
-        # Extend this dictionary later as needed.
-        # None means: keep previous default behavior (= all LV buses)
-        # -------------------------------------------------------------
-        CHARGING_USE_CASE_BUS_COMP_TYPES = {
-            "home": ["house_connection"],
-            "work": None,
-            "public": None,
-            "hpc": None,
-        }
-
-        # -------------------------------------------------------------
         # Helper: build KDTree cache
         # -------------------------------------------------------------
         def _build_cache(bus_df):
@@ -2732,14 +2610,6 @@ class Topology:
             dist, idx = cache["tree"].query([px, py], k=1)
 
             return cache["index"][idx], float(dist)
-
-        # -------------------------------------------------------------
-        # Helper: cache key for filtered LV buses
-        # -------------------------------------------------------------
-        def _cache_attr_name_for_use_case(use_case):
-            if use_case is None:
-                return "_geo_cache_lv_14a_all"
-            return f"_geo_cache_lv_14a_{use_case}"
 
         # -------------------------------------------------------------
         # Setup
@@ -2788,35 +2658,30 @@ class Topology:
             lv_buses = self.buses_df.drop(self.mv_grid.buses_df.index)
 
             # ---------------------------------------------------------
-            # Optional use-case-specific filtering for charging points
+            # Charging points in LV: only connect to house connections
             # ---------------------------------------------------------
             if comp_type == "charging_point":
-                use_case = comp_data.get("sector")
-                allowed_comp_types = CHARGING_USE_CASE_BUS_COMP_TYPES.get(use_case, None)
-
-                if allowed_comp_types is not None:
-                    if "comp_type" not in lv_buses.columns:
-                        raise KeyError(
-                            "Column 'comp_type' not found in buses_df, but it is "
-                            f"required for charging-point use case '{use_case}'."
-                        )
-
-                    lv_buses = lv_buses.loc[
-                        lv_buses["comp_type"].isin(allowed_comp_types)
-                    ]
-
-                    if lv_buses.empty:
-                        raise ValueError(
-                            f"No eligible LV buses found for charging use case "
-                            f"'{use_case}' with allowed comp_type values "
-                            f"{allowed_comp_types}."
-                        )
-
-                cache_attr = _cache_attr_name_for_use_case(use_case)
-
+                if "comp_type" not in lv_buses.columns:
+                    raise KeyError(
+                        "Column 'comp_type' not found in buses_df. "
+                        "It is required to connect charging points only to house_connection buses."
+                    )
+            
+                lv_buses = lv_buses.loc[
+                    lv_buses["comp_type"] == "house_connection"
+                ]
+            
+                if lv_buses.empty:
+                    raise ValueError(
+                        "No eligible LV buses with comp_type='house_connection' found "
+                        "for charging point connection."
+                    )
+            
+                cache_attr = "_geo_cache_lv_14a_cp_house_connection"
+            
             else:
-                cache_attr = _cache_attr_name_for_use_case(None)
-
+                cache_attr = "_geo_cache_lv_14a_all"
+ 
             valid_coords_count = len(lv_buses[["x", "y"]].dropna())
 
             if (

--- a/edisgo/tools/loma_tools.py
+++ b/edisgo/tools/loma_tools.py
@@ -650,7 +650,7 @@ def _duplicate_loads_from_source_ids(
 
         src_row = loads_df.loc[src_id].copy()
         src_bus = src_row["bus"]
-
+        
         if avoid_source_bus:
             bus_pool = eligible_buses[eligible_buses != src_bus]
             if len(bus_pool) == 0:
@@ -659,8 +659,92 @@ def _duplicate_loads_from_source_ids(
                 )
         else:
             bus_pool = eligible_buses
-
-        tgt_bus = rng.choice(bus_pool)
+        
+        # ------------------------------------------------------------
+        # 14a CP duplication logic
+        # < 100 kW: house_connection
+        # >= 100 kW: MV side of nearest MV/LV transformer
+        # ------------------------------------------------------------
+        if load_type == "charging_point":
+            if "p_set" not in src_row.index:
+                raise KeyError(
+                    f"Source charging point '{src_id}' has no 'p_set' column."
+                )
+        
+            p_set = float(src_row["p_set"])
+        
+            buses_df = edisgo.topology.buses_df
+            trafos_df = edisgo.topology.transformers_df
+        
+            # --------------------------------------------------------
+            # CP < 100 kW: duplicate only to house_connection buses
+            # --------------------------------------------------------
+            if p_set < 0.1:
+                if "comp_type" not in buses_df.columns:
+                    raise KeyError(
+                        "Column 'comp_type' not found in buses_df. "
+                        "It is required to connect duplicated charging points "
+                        "below 100 kW only to house_connection buses."
+                    )
+        
+                house_connection_buses = buses_df.index[
+                    buses_df["comp_type"] == "house_connection"
+                ]
+        
+                bus_pool_filtered = pd.Index(bus_pool).intersection(house_connection_buses)
+        
+                if len(bus_pool_filtered) == 0:
+                    raise ValueError(
+                        f"No eligible house_connection buses found for duplicated "
+                        f"charging point '{src_id}' with p_set={p_set:.6f} MW."
+                    )
+        
+                tgt_bus = rng.choice(np.array(bus_pool_filtered))
+        
+            # --------------------------------------------------------
+            # CP >= 100 kW: connect to MV side of nearest MV/LV trafo
+            # --------------------------------------------------------
+            else:
+                if "bus0" not in trafos_df.columns:
+                    raise KeyError(
+                        "Column 'bus0' not found in transformers_df. "
+                        "It is required to identify the MV side of MV/LV transformers."
+                    )
+        
+                mv_trafo_bus_ids = trafos_df["bus0"].dropna().unique()
+        
+                mv_trafo_buses = buses_df.loc[
+                    buses_df.index.intersection(mv_trafo_bus_ids)
+                ].dropna(subset=["x", "y"])
+        
+                if mv_trafo_buses.empty:
+                    raise ValueError(
+                        f"No MV-side transformer buses with coordinates found for "
+                        f"duplicated charging point '{src_id}' with p_set={p_set:.6f} MW."
+                    )
+        
+                if src_bus not in buses_df.index:
+                    raise KeyError(
+                        f"Source bus '{src_bus}' of duplicated charging point "
+                        f"'{src_id}' not found in buses_df."
+                    )
+        
+                src_x = buses_df.at[src_bus, "x"]
+                src_y = buses_df.at[src_bus, "y"]
+        
+                if pd.isna(src_x) or pd.isna(src_y):
+                    raise ValueError(
+                        f"Source bus '{src_bus}' of duplicated charging point "
+                        f"'{src_id}' has no valid coordinates."
+                    )
+        
+                dx = mv_trafo_buses["x"] - src_x
+                dy = mv_trafo_buses["y"] - src_y
+        
+                tgt_bus = (dx**2 + dy**2).idxmin()
+        
+        else:
+            tgt_bus = rng.choice(bus_pool)
 
         new_id_base = f"{name_prefix}_{k}"
         new_id = _make_unique_load_id(loads_df.index.union(pd.Index(new_ids)), new_id_base)

--- a/examples/loma-14a.py
+++ b/examples/loma-14a.py
@@ -369,7 +369,7 @@ def main():
 
     plot_cp_hp_locations(edisgo, show=False, save=True)
 
-    #edisgo = run_optimization_14a(edisgo)
+    edisgo = run_optimization_14a(edisgo)
     edisgo.analyze()
 
 

--- a/examples/loma-14a.py
+++ b/examples/loma-14a.py
@@ -148,7 +148,6 @@ def integrate_ev_and_hp_for_14a(edisgo, *, shapefile_path, output_dir, setup_day
         if cache_dir is not None:
             _save_emob_cache(edisgo, cache_dir)
 
-
     """
     This step created the time series for the new eDisGo charging points.
     Without the preparation of Q before charging strategy I got an error while
@@ -217,11 +216,11 @@ def integrate_ev_and_hp_for_14a(edisgo, *, shapefile_path, output_dir, setup_day
         tol_2=0.9,
     )
 
-    # ============================================================
+    # ------------------------------------------------------------
     # Optional Utilities for sensitivity analysis/changing the amount of cp/hp
     # - target by absolute value or relative percentage
     # - Only use one option at a time (target_total, percentage)
-    # ============================================================
+    # ------------------------------------------------------------
     """
     In this step the total amount of charging points or heat pumps can be adjusted.
     Either by percentage or by a total amount including the infrastructure from
@@ -242,7 +241,7 @@ def integrate_ev_and_hp_for_14a(edisgo, *, shapefile_path, output_dir, setup_day
     
     set_charging_points_to_target(
         edisgo,
-        target_total=1000,  # sets total amount of CP to 1000
+        target_total=4000, # sets total amount of CP #412 SQ, 1000 2035
         # percentage=0.10, # increases total amount of CP by 10%
         # percentage=-0.10, # decreases total amount of CP by 10%
         eligible_buses=cp_eligible_buses,
@@ -251,7 +250,7 @@ def integrate_ev_and_hp_for_14a(edisgo, *, shapefile_path, output_dir, setup_day
         export_removed=False,
         export_dir=output_dir,
     )
-
+    
     # Recompute HP eligible buses after CP scaling
     valid_buses = set(edisgo.topology.buses_df.index)
     
@@ -262,7 +261,7 @@ def integrate_ev_and_hp_for_14a(edisgo, *, shapefile_path, output_dir, setup_day
 
     set_heat_pumps_to_target(
         edisgo,
-        target_total=2600,  # sets total amount of HP
+        target_total=575,  # sets total amount of HP #575 SQ, 2600 2035
         # percentage=0.10, # increases total amount of HP by 10%
         # percentage=-0.10, # decreases total amount of HP by 10%
         eligible_buses=hp_eligible_buses,
@@ -331,15 +330,14 @@ def prepare_edisgo_for_14a(edisgo, *, shapefile_path, output_dir, cache_dir=None
 
     edisgo.set_time_series_reactive_power_control()
 
-
 def main():
     # General Paths
     output_dir = "/home/paul/LoMa/test/edisgo_output"
     emob_cache_dir = "/home/paul/LoMa/loma-repo/emob_cache/husum_eGon2035"
-    
+
     # Whole Husum paths
-    # grid_path = "/home/paul/LoMa/loma-repo/results/Whole_Husum_model_pypsa_SQ" # Status-Quo
-    grid_path = "/home/paul/LoMa/loma-repo/results/Whole_Husum_model_pypsa_2035" # 2035
+    grid_path = "/home/paul/LoMa/loma-repo/results/Whole_Husum_final_statusQuo_LV_ids" # Status-Quo
+    # grid_path = "/home/paul/LoMa/loma-repo/results/Whole_Husum_model_pypsa_2035" # 2035
     path_husum_district_shp = (
         "/home/paul/LoMa/loma-repo/data/Input_files/MV_grid_district/husum_district.shp"
     )
@@ -348,16 +346,19 @@ def main():
     # grid_path = ""
     # path_husum_district_shp = "/home/paul/LoMa/loma-repo/data/Input_files/MGB_district"
 
-    edisgo = EDisGo(pypsa_csv_dir=grid_path, snapshot_range=(0, 2))
+    edisgo = EDisGo(pypsa_csv_dir=grid_path, snapshot_range=(0, 12)) 
+    #edisgo = EDisGo(pypsa_csv_dir=grid_path, snapshot_range=(0, 167)) #first week january 2025
+    #edisgo = EDisGo(pypsa_csv_dir=grid_path, snapshot_range=(2159, 2327)) #first week april 2025
+    #edisgo = EDisGo(pypsa_csv_dir=grid_path, snapshot_range=(5088, 5256)) #first week august 2025
 
     mv_grid_geom = gpd.read_file(path_husum_district_shp).to_crs(4326)
     edisgo.topology.grid_district["geom"] = mv_grid_geom.loc[0, "geometry"]
     edisgo.topology.grid_district["srid"] = 4326
-
+    
     edisgo.topology.check_integrity()
     pypsa_n = edisgo.to_pypsa()
     edisgo.analyze()
-
+    
     prepare_edisgo_for_14a(
         edisgo,
         shapefile_path=path_husum_district_shp,
@@ -368,10 +369,9 @@ def main():
 
     plot_cp_hp_locations(edisgo, show=False, save=True)
 
-    edisgo = run_optimization_14a(edisgo)
-
-
+    #edisgo = run_optimization_14a(edisgo)
     edisgo.analyze()
+
 
     # ────────────────────────── Slack diagnosis ──────────────────────────────
     slacks = edisgo.opf_results.grid_slacks_t
@@ -437,31 +437,3 @@ def main():
 if __name__ == "__main__":
     edisgo = main()
     
-    # # ── Temporary export of final charging point locations ─────────────────────
-    # output_dir = "/home/paul/LoMa/test/edisgo_output"
-    
-    # cp_df = edisgo.topology.loads_df[
-    #     edisgo.topology.loads_df["type"] == "charging_point"
-    # ].copy()
-    
-    # cp_df = cp_df.join(
-    #     edisgo.topology.buses_df[["x", "y"]],
-    #     on="bus",
-    # )
-    
-    # cp_df = cp_df.dropna(subset=["x", "y"])
-    
-    # cp_gdf = gpd.GeoDataFrame(
-    #     cp_df.reset_index(names="cp_id"),
-    #     geometry=gpd.points_from_xy(cp_df["x"], cp_df["y"]),
-    #     crs="EPSG:4326",
-    # )
-    
-    # cp_export_path = os.path.join(
-    #     output_dir,
-    #     "charging_point_locations_after_opf.shp",
-    # )
-    
-    # cp_gdf.to_file(cp_export_path)
-    
-    # print(f"Exported {len(cp_gdf)} charging point locations to {cp_export_path}")


### PR DESCRIPTION
# Description

Fixed an issue where the imported eDisGo charging points where not connected to the correct network level.
Now charging points with a p_set above 100kW are connected to the closest MV side of a MV/LV trafo.

The same issue occured when duplicating charging points with set_charging_points_to_target. 
Now duplicated charging points above 100kW are connected to the closest MV side of a MV/LV trafo.
