### PR TITLE
fix(docs): repair broken links in linkcheck CI

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -243,6 +243,10 @@ linkcheck_ignore = [
     # zenodo and numpy.org return errors in CI even though the links are correct
     r"https://zenodo.org/*",
     r"https://numpy.org/*",
+    # ACM Digital Library (via doi.org) returns 403 to the CI bot, link is correct
+    r"https://doi.org/10.1145/.*",
+    # pandoc.org intermittently fails decompression in CI, link is correct
+    r"https://pandoc.org",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/tutorials/simple_example.ipynb
+++ b/doc/tutorials/simple_example.ipynb
@@ -404,12 +404,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "A single grid's generators, loads, storage units and switches can also be\n",
-    "retrieved as [Generator](https://edisgo.readthedocs.io/en/features-refactoring/api/edisgo.network.html#edisgo.network.components.Generator) object,\n",
-    "[Load](https://edisgo.readthedocs.io/en/features-refactoring/api/edisgo.network.html#edisgo.network.components.Load) object, [Storage](https://edisgo.readthedocs.io/en/features-refactoring/api/edisgo.network.html#edisgo.network.components.Storage) object, and\n",
-    "[Switch](https://edisgo.readthedocs.io/en/features-refactoring/api/edisgo.network.html#edisgo.network.components.Switch) objects, respecitvely:"
-   ]
+   "source": "A single grid's generators, loads, storage units and switches can also be\nretrieved as [Generator](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Generator.html) object,\n[Load](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Load.html) object, [Storage](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Storage.html) object, and\n[Switch](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Switch.html) objects, respecitvely:"
   },
   {
    "cell_type": "code",

--- a/examples/edisgo_simple_example.ipynb
+++ b/examples/edisgo_simple_example.ipynb
@@ -406,9 +406,9 @@
    "metadata": {},
    "source": [
     "A single grid's generators, loads, storage units and switches can also be\n",
-    "retrieved as [Generator](https://edisgo.readthedocs.io/en/features-refactoring/api/edisgo.network.html#edisgo.network.components.Generator) object,\n",
-    "[Load](https://edisgo.readthedocs.io/en/features-refactoring/api/edisgo.network.html#edisgo.network.components.Load) object, [Storage](https://edisgo.readthedocs.io/en/features-refactoring/api/edisgo.network.html#edisgo.network.components.Storage) object, and\n",
-    "[Switch](https://edisgo.readthedocs.io/en/features-refactoring/api/edisgo.network.html#edisgo.network.components.Switch) objects, respecitvely:"
+    "retrieved as [Generator](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Generator.html) object,\n",
+    "[Load](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Load.html) object, [Storage](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Storage.html) object, and\n",
+    "[Switch](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Switch.html) objects, respecitvely:"
    ]
   },
   {


### PR DESCRIPTION
The Sphinx linkcheck build failed on three broken links:

- simple_example.ipynb and examples/edisgo_simple_example.ipynb linked the Generator/Load/Storage/Switch component docs via the deleted `features-refactoring` branch and old `api/edisgo.network.html` path, returning 404. Repointed them to the current `en/dev/autoapi/edisgo/network/components/<Class>.html` URLs.
- Added the ACM doi (https://doi.org/10.1145/...) to linkcheck_ignore; dl.acm.org returns 403 to the CI bot although the link is valid.
- Added https://pandoc.org to linkcheck_ignore; it intermittently fails decompression in CI although the link is valid.
