### PR TITLE
Fix MV grid topology marker size for small grids

### DIFF
--- a/edisgo/tools/plots.py
+++ b/edisgo/tools/plots.py
@@ -397,7 +397,7 @@ def mv_grid_topology(
         else:
             return colors_dict["else"], sizes_dict["else"]
 
-    def nodes_by_technology(buses, edisgo_obj):
+    def nodes_by_technology(buses, edisgo_obj, grid_area=1):
         bus_sizes = {}
         bus_colors = {}
         colors_dict = {
@@ -411,17 +411,18 @@ def mv_grid_topology(
             "DisconnectingPoint": "0.75",
             "else": "orange",
         }
-        sizes_dict = {
-            "BranchTee": 10000,
-            "GeneratorFluctuating": 100000,
-            "Generator": 100000,
-            "Load": 100000,
-            "LVStation": 50000,
-            "MVStation": 120000,
-            "Storage": 100000,
-            "DisconnectingPoint": 75000,
-            "else": 200000,
+        fractions_dict = {
+            "BranchTee": 0.00005,
+            "GeneratorFluctuating": 0.0005,
+            "Generator": 0.0005,
+            "Load": 0.0005,
+            "LVStation": 0.00025,
+            "MVStation": 0.0006,
+            "Storage": 0.0005,
+            "DisconnectingPoint": 0.00035,
+            "else": 0.001,
         }
+        sizes_dict = {k: v * grid_area for k, v in fractions_dict.items()}
         for bus in buses:
             connected_components = (
                 edisgo_obj.topology.get_connected_components_from_bus(bus)
@@ -588,7 +589,8 @@ def mv_grid_topology(
 
     # bus colors and sizes
     if node_color == "technology":
-        bus_sizes, bus_colors = nodes_by_technology(pypsa_plot.buses.index, edisgo_obj)
+        bus_sizes = 0  # placeholder; overwritten after Mercator conversion
+        bus_colors = "r"
         bus_cmap = None
     elif node_color == "voltage":
         bus_sizes, bus_colors = nodes_by_voltage(
@@ -655,6 +657,14 @@ def mv_grid_topology(
         )
         pypsa_plot.buses.loc[:, "x"] = x2
         pypsa_plot.buses.loc[:, "y"] = y2
+    if node_color == "technology":
+        x_range = pypsa_plot.buses.x.max() - pypsa_plot.buses.x.min()
+        y_range = pypsa_plot.buses.y.max() - pypsa_plot.buses.y.min()
+        grid_area = x_range * y_range
+        bus_sizes, bus_colors = nodes_by_technology(
+            pypsa_plot.buses.index, edisgo_obj, grid_area=grid_area
+        )
+        bus_cmap = None
 
     # plot
     plt.figure(figsize=(12, 8))


### PR DESCRIPTION
# Description

Fixed the way eDisGo/edisgo/tools/plots.py/plot_mv_grid_topology() > mv_grid_topology() > nodes_by_technology() calculates / depicts the size of buses by norming the size_dict that is responsible for this method by using the grid area. Grid area is now a new parameter in nodes_by_technology().

Fixes #700 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file

grid 30879 (big, 1963 nodes)
<img width="467" height="732" alt="grid_30879_1963_buses_fixed" src="https://github.com/user-attachments/assets/6acca8bf-aeea-48e2-9e98-0b18cab4f097" />

grid 32377 (small, 396 nodes)
<img width="467" height="732" alt="grid_32377_396_buses_fixed" src="https://github.com/user-attachments/assets/c8691e07-f889-4125-bd6b-c45947e0bc78" />