### PR TITLE
Document line shunt susceptance in lines_df

### DIFF
--- a/edisgo/network/topology.py
+++ b/edisgo/network/topology.py
@@ -513,6 +513,10 @@ class Topology:
                 Resistance of line (or in case of multiple parallel lines
                 total resistance of lines) in Ohm.
 
+            b : float
+                Shunt susceptance of line (or in case of multiple parallel lines
+                total shunt susceptance of lines) in Siemens.
+
             s_nom : float
                 Apparent power which can pass through the line (or in case of
                 multiple parallel lines total apparent power which can pass


### PR DESCRIPTION
# Description

Add the missing `b` entry to the `Topology.lines_df` docstring, documenting line shunt susceptance in Siemens and the total value for parallel lines. This follows the actual `COLUMNS["lines_df"]` order and avoids the issue's outdated suggestion that `b` is always zero; the current implementation can compute it from a line type's `C_per_km`.

Fixes #653

## Type of change

- [x] Bug fix (non-breaking documentation correction)

# Checklist

- [x] The docstring now lists every `lines_df` column in implementation order.
- [x] `git diff --check`, Python compilation, AST parsing, and an exact docstring-column coverage assertion pass.
- [x] No runtime code, type hints, dependencies, tests, or new features were added, so no package or whatsnew entry is needed.
- [ ] `pre-commit` and Sphinx were unavailable in the local environment; repository CI is requested for those checks.
- [ ] The two targeted project tests could not start locally because `tests/conftest.py` imports unavailable `matplotlib`.

## AI assistance

This change was prepared with AI assistance and submitted through an automated contribution workflow. The final wording and diff were checked against the pinned eDisGo source, the current data-model documentation, and the issue acceptance criteria.
