### PR TITLE
Spatial complexity reduction for the run pipeline (partial)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,92 @@
+# Context / Glossary
+
+Domain vocabulary for the eDisGo run pipeline. Glossary only — no implementation
+details, no decisions (those live in `docs/adr/`).
+
+## Complexity reduction
+
+- **Spatial complexity reduction** — merging nearby buses into a smaller set of
+  representative buses (clustering *along the grid*, keeping it radial) to shrink the
+  grid for faster power flow / optimization. Implemented by
+  `EDisGo.spatial_complexity_reduction`, which builds a *busmap* + *linemap* and mutates
+  the Topology. Used only to accelerate the optimization; reinforcement runs on the
+  **full grid**.
+- **Temporal complexity reduction** — keeping only grid-critical time steps/intervals
+  instead of the full year. See the `select_timesteps` task.
+- **Busmap** — DataFrame mapping each original bus to its clustered *new_bus* (with new
+  coordinates). Index = original bus names.
+- **Linemap** — DataFrame mapping original line names to *new_line_name* after lines are
+  recalculated/merged.
+- **Reduced grid** — the spatially-reduced EDisGo object the OPF runs on.
+- **Full grid** — the original, unreduced EDisGo object; reinforcement always runs here.
+- **Map-back / restore** — writing the OPF flexibility dispatch from the reduced grid
+  onto the full grid. Only the components the OPF *rewrites* are mapped back — flexible
+  charging points, heat pumps, DSM loads, and storage. Inflexible loads/generators are
+  **skipped** (the OPF does not change their series; the full grid already holds them
+  correctly). Implemented by core function
+  `tools/spatial_complexity_reduction.py::apply_reduced_results_to_full_grid(full_grid,
+  reduced_grid, *, flexible_cps=None, flexible_hps=None, flexible_loads=None,
+  flexible_storage_units=None)` + thin wrapper `EDisGo.map_reduced_results_to_full_grid`.
+  Provenance for disaggregation comes solely from `old_name` on the reduced grid's
+  `loads_df`/`generators_df` — no busmap/linemap stash needed on `ctx`.
+  - `aggregation_mode=False`: components keep their names → write back **by component
+    name**.
+  - `aggregation_mode=True`: loads/generators may be merged into a representative
+    (originals recorded in `old_name`; storage is never aggregated). The representative's
+    optimized series is **disaggregated** onto its `old_name` members.
+- **Disaggregation rule** — split a merged representative's optimized series onto its
+  original members **per time step**, weighted by each member's own *pre-OPF flexibility
+  envelope* (a known input, never the optimized result): `upper_power(t)` band for
+  charging points, heat-demand/thermal envelope for heat pumps, `p_max(t)` band for DSM.
+  Per-step weighting means a charging point only receives power at steps where it has a
+  connected vehicle (`upper_power(t) > 0`). Sums back to the representative exactly at
+  every step; equal split as the zero-envelope fallback.
+- **Reactive power on restore** — `spatial_restore` writes active power only, then calls
+  `EDisGo.set_time_series_reactive_power_control()` itself (plain fixed-cosphi default),
+  mirroring exactly how `pm_optimize`'s own results-writer
+  (`io/powermodels_io.py::from_powermodels`) handles it: write P, then blanket-recompute Q.
+  No bespoke reactive-power logic — proportional-split and recompute are mathematically
+  identical under fixed-cosphi since all `old_name` members of one representative share
+  the same `power_factor`.
+
+## Pipeline tasks (spatial reduction)
+
+- **spatial_reduce** — task run *before* `optimize`: deepcopy the full grid, stash it,
+  and spatially reduce the working object so `optimize` runs on the reduced grid.
+- **spatial_restore** — task run *after* `optimize`: write the optimized dispatch time
+  series back onto the stashed full grid and make it active again. **Optional** — a run
+  may legitimately stop after the reduced-grid optimization when only the derived time
+  series matter.
+- **Full-grid stash** — the deepcopied full grid kept in memory on `ctx` between
+  `spatial_reduce` and `spatial_restore`. Held in-memory (matching legacy eGo, which kept
+  both full and reduced grids resident during optimize). Persisting it to a disk artifact
+  to lower peak memory is a possible later optimization, not the initial design.
+
+## Config surface (spatial reduction)
+
+- Top-level YAML block `spatial_reduction:` (mirrors `timeseries_selection:`), holding
+  `mode`, `cluster_area`, `reduction_factor`, `reduction_factor_not_focused`,
+  `aggregation_mode`, and aggregation sub-modes. Read inside the `spatial_reduce` task via
+  `ctx.raw_config.get("spatial_reduction", {})`.
+- eGo injects it exactly like `timeseries_selection`: a global `spatial_reduction` default
+  plus a `spatial_reduction_per_grid` dict keyed by `str(mv_grid_id)`, whole-block
+  replacement (not a field-level merge). If neither is set the key is omitted entirely and
+  the eDisGo preset's own default applies.
+
+## Ordering (spatial reduction)
+
+Pipeline order: `select_timesteps` → `spatial_reduce` → `optimize` → `spatial_restore`
+→ `reinforce`.
+
+- Spatial reduction touches only **topology**; temporal reduction touches only the
+  **time index** — orthogonal operations that commute as *mechanisms*. Spatial reduction
+  works on any time index, including full-year (clustering depends on coordinates/graph
+  distance, not the time series; the `reduction_factor_not_focused` worst-case power flow
+  runs on an internal deepcopy and does not disturb the working series).
+- But the **pipeline** pins `select_timesteps` before `spatial_reduce`: the full-grid
+  stash inherits whatever time index exists at deepcopy time, and reinforce runs on that
+  stash. Reducing timesteps first means the stash (and therefore reinforce) carries the
+  reduced index — full **topology**, reduced **time index**. Reversing the two would
+  force separately re-reducing the stash's index.
+- `spatial_restore` does **no time-index surgery** — it only writes flexible-component
+  dispatch back onto the stashed full grid.

--- a/docs_notes/issue_aggregation_mode_flexibility_bands_not_aggregated.md
+++ b/docs_notes/issue_aggregation_mode_flexibility_bands_not_aggregated.md
@@ -1,0 +1,83 @@
+# `spatial_complexity_reduction(aggregation_mode=True)` doesn't aggregate `electromobility.flexibility_bands`, breaking `optimize` on merged charging points
+
+**Type:** bug
+**Found:** 2026-07-15, running the real `uc6_spatial_reduction.yaml` pipeline
+on grid 32377 with `spatial_reduction.aggregation_mode: true`.
+**Affects:** `spatial_complexity_reduction`/`apply_busmap`
+(`edisgo/tools/spatial_complexity_reduction.py`), specifically the load
+aggregation step; consumed by `_build_electromobility`
+(`edisgo/io/powermodels_io.py`).
+
+## Problem
+
+When `aggregation_mode=True`, `apply_busmap` merges loads at the same bus
+(`aggregate_loads_df`, `spatial_complexity_reduction.py:1587-1599`) and
+correctly aggregates their **time series** via `aggregate_timeseries`
+(`spatial_complexity_reduction.py:1718`, called for `loads_active_power` /
+`loads_reactive_power`). This works fine for DSM loads and heat pumps, whose
+OPF constraints are read directly from `loads_df`/`dsm.p_max`/
+`heat_pump.heat_demand_df` keyed by whatever name is currently in `loads_df`.
+
+Charging points are different: the OPF's own constraint builder,
+`_build_electromobility` (`edisgo/io/powermodels_io.py:1212`), does **not**
+read its upper-power bound from `loads_df` — it reads
+`electromobility.flexibility_bands["upper_power"][cp_name]`, a separate
+DataFrame keyed by charging-point name. `spatial_complexity_reduction` never
+touches `flexibility_bands` during aggregation, so it still only has entries
+for the *original*, pre-merge charging-point names.
+
+When a bus has 2+ charging points and gets merged into one representative
+load (e.g. `Load_Bus_mvgd_32377_F2_B2_charging_point_hpc`), that
+representative name has:
+- a correctly-aggregated `loads_active_power` entry (summed from the
+  originals), but
+- **no** entry at all in `flexibility_bands["upper_power"]`.
+
+`task_optimize` derives `flexible_cps` from `loads_df` (filtering
+`type == "charging_point"`), so it passes the representative's name into
+`pm_optimize` → `to_powermodels` → `_build_electromobility`, which then does
+`flex_bands_df["upper_power"][emob_df.index[cp_i]]` and raises `KeyError`
+for the representative name.
+
+## Reproduction
+
+Run `uc6_spatial_reduction.yaml` (or any preset with the spatial bracket) on
+a grid with 2+ charging points sharing a bus, with
+`spatial_reduction: {enabled: true, aggregation_mode: true,
+load_aggregation_mode: bus}` and `optimize: {flexible: [...,
+charging_points, ...]}`. Crashes inside `optimize`, before `spatial_restore`
+ever runs:
+
+```
+KeyError: 'Load_Bus_mvgd_32377_F2_B2_charging_point_hpc'
+  .../edisgo/io/powermodels_io.py:1212, in _build_electromobility
+    * flex_bands_df["upper_power"][emob_df.index[cp_i]].iloc[0]
+```
+
+## Scope note
+
+This is independent of the spatial-reduction pipeline-integration work
+(`spatial_reduce`/`spatial_restore`/`apply_reduced_results_to_full_grid`) —
+it's a gap in `spatial_complexity_reduction` itself (the reduction side),
+already reachable via `EDisGo.spatial_complexity_reduction` +
+`EDisGo.pm_optimize` directly, with no pipeline involved. It only manifests
+under `aggregation_mode=True` with charging points present; `aggregation_
+mode=False` is unaffected since every component keeps its original name
+there, and `flexibility_bands` stays valid.
+
+Also worth checking as part of the same fix: whether heat pumps have an
+analogous issue if the OPF ever reads a heat-pump-specific band keyed
+differently from `loads_df` (current understanding, from the spatial-
+reduction design session, is that heat pumps use `heat_demand_df`/`cop_df`/
+`loads_df.p_set` directly, which DO get aggregated correctly — but worth
+double-checking with a merged multi-heat-pump bus once this issue is picked
+up, in case some other heat-pump-specific structure has the same gap).
+
+## Suggested fix
+
+Extend `apply_busmap`'s load-aggregation step to also aggregate
+`electromobility.flexibility_bands` (`upper_power`, `lower_energy`,
+`upper_energy`) onto the same representative name, using the same
+`old_name`-based grouping/summing already used for `aggregate_timeseries`
+— summing `upper_power` per merged group is the natural analogue of summing
+`p_set`/active power for the representative.

--- a/docs_notes/issue_spatial_complexity_reduction_pipeline_integration.md
+++ b/docs_notes/issue_spatial_complexity_reduction_pipeline_integration.md
@@ -1,0 +1,140 @@
+# Integrate spatial complexity reduction into the run pipeline
+
+## Goal
+
+Add **spatial complexity reduction** to the eDisGo run pipeline as a
+counterpart to the existing temporal complexity reduction (timestep
+selection, `select_timesteps`). Spatial reduction merges nearby buses into
+representative buses to shrink the grid so the **optimization (OPF)** runs
+faster. **Reinforcement must run on the FULL grid** (full topology) — but on
+the *reduced* time index (temporal reduction still applies).
+
+## What's done
+
+- **Two bracketing pipeline tasks**, `spatial_reduce` (before `optimize`)
+  and `spatial_restore` (after, optional): `spatial_reduce` deepcopies and
+  stashes the full grid on the run context, then spatially reduces the
+  working object so `optimize` runs on a smaller grid; `spatial_restore`
+  writes the optimized flexible-component dispatch back onto the stashed
+  full grid and makes it active again for `reinforce`. Both are no-ops when
+  `spatial_reduction.enabled` is false, so a pipeline carrying the bracket
+  behaves identically to one without it when disabled.
+- **New core function** `apply_reduced_results_to_full_grid(full_grid,
+  reduced_grid, *, flexible_cps, flexible_hps, flexible_loads,
+  flexible_storage_units)` in `edisgo/tools/spatial_complexity_reduction.py`,
+  plus a thin `EDisGo.map_reduced_results_to_full_grid` wrapper — mirroring
+  how `spatial_complexity_reduction`/`EDisGo.spatial_complexity_reduction`
+  already pair up for the reduction half.
+- **Map-back only touches components the OPF rewrites**: flexible charging
+  points, heat pumps, DSM loads, and storage units. Inflexible
+  loads/generators are skipped since the OPF never changes their series.
+  With `aggregation_mode=False` (see "What's still open" below), every
+  component keeps its own name, so restore is a plain by-name write-back.
+- **Reactive power on restore**: `spatial_restore` writes active power only,
+  then calls `EDisGo.set_time_series_reactive_power_control()` itself —
+  mirroring exactly how the OPF's own results-writer
+  (`io/powermodels_io.py::from_powermodels`) handles it (write P, then
+  blanket-recompute Q). No new reactive-power logic anywhere.
+- **Validator integration**: extended the existing `requires`/`provides`
+  capability system rather than adding new validator machinery.
+  `spatial_reduce` provides `reduced_grid`; `optimize` additionally provides
+  `optimized_dispatch`; `spatial_restore` requires both — so a misordered
+  pipeline (e.g. `spatial_restore` before `optimize`) fails static
+  validation instead of crashing mid-run.
+- **Config surface**: top-level `spatial_reduction:` YAML block (`enabled`,
+  `mode`, `cluster_area`, `reduction_factor`, `reduction_factor_not_focused`,
+  `aggregation_mode`), mirroring `timeseries_selection:` exactly, read via
+  `ctx.raw_config.get("spatial_reduction", {})`.
+- **New preset** `edisgo/run/presets/uc6_spatial_reduction.yaml` wiring the
+  bracket into a real pipeline (`select_timesteps → reactive_power →
+  spatial_reduce → optimize → spatial_restore → reinforce → save`), disabled
+  by default via `spatial_reduction.enabled: false`.
+- **eGo integration**: `EDisGoNetworks._build_run_edisgo_config` injects
+  `spatial_reduction`/`spatial_reduction_per_grid` exactly like
+  `timeseries_selection`/`timeseries_selection_per_grid` (global default +
+  per-grid override keyed by MV grid id, whole-block replacement). New
+  `scenario_setting_uc6_example.json`, plus unit tests for the injection
+  logic.
+- **Tests**: `tests/tools/test_spatial_complexity_reduction.py`
+  (`TestApplyReducedResultsToFullGrid`) covers by-name write-back, the
+  numpy-array-input regression, the time-index-mismatch guard, and the
+  reactive-power recompute, with stub OPF results (no real Julia/Gurobi
+  dependency in CI).
+- **Verified end-to-end** against a real grid (32377) through both eDisGo
+  directly and through eGo: `spatial_reduce → optimize (Gurobi) →
+  spatial_restore → reinforce → save` all completed successfully, and a
+  dedicated notebook (`analyse_spatial_reduction.ipynb`) confirms the
+  reduced grid's OPF output exactly matches the full grid's post-restore
+  value for every flexible component (0 mismatches across 388 components on
+  the test run).
+- **Two bugs found and fixed during implementation** (unrelated to the
+  design, surfaced by actually running the code): a `flexible_* or []`
+  crash on numpy-array input (`task_optimize` derives `flexible_loads` as an
+  array, not a list); and `electromobility.flexibility_bands` not being
+  trimmed to the active time index after `build_flexibility_bands`, causing
+  a `KeyError` deep inside the OPF's charging-point constraint builder.
+
+## What's still open
+
+### `aggregation_mode=True` is not usable with charging points present
+
+`spatial_complexity_reduction` (`aggregation_mode=True`) merges loads at the
+same bus and correctly aggregates their **time series**
+(`loads_active_power`/`loads_reactive_power`). This works for DSM loads and
+heat pumps, whose OPF constraints are read directly from
+`loads_df`/`dsm.p_max`/`heat_pump.heat_demand_df`.
+
+Charging points are different: the OPF's constraint builder
+(`_build_electromobility` in `edisgo/io/powermodels_io.py`) reads its
+upper-power bound from `electromobility.flexibility_bands["upper_power"]`, a
+separate DataFrame keyed by charging-point name — and
+`spatial_complexity_reduction` never aggregates `flexibility_bands` during
+load merging. So a merged representative has a correctly-summed
+`loads_active_power` entry but **no** entry in `flexibility_bands`, and
+`optimize` crashes with a `KeyError` for the representative's name before
+`spatial_restore` ever runs.
+
+This is a gap in the reduction side (`spatial_complexity_reduction`/
+`apply_busmap`), not in `spatial_restore`/`apply_reduced_results_to_full_grid`
+— reachable via `EDisGo.spatial_complexity_reduction` + `EDisGo.pm_optimize`
+directly, no pipeline involved. It only manifests under
+`aggregation_mode=True` with charging points present at a bus with 2+ of
+them; `aggregation_mode=False` is unaffected. Full writeup with the exact
+traceback and a suggested fix (aggregate `flexibility_bands` in
+`apply_busmap`'s load-merging step, the same way `loads_active_power`
+already is) is in
+`docs_notes/issue_aggregation_mode_flexibility_bands_not_aggregated.md`.
+
+**Until this is fixed, `aggregation_mode` should stay `False`** — that is
+the default in the new preset and the only mode covered by the disaggregation
+tests and the end-to-end verification above.
+
+### Related, deferred design gap (not blocking, tracked separately)
+
+`build_flexibility_bands` builds bands over whatever date range the
+underlying SimBEV data spans and only resamples to the target *frequency*,
+not the target *date range* — the fix applied here trims them after the
+fact (`reduce_timeseries_data_to_given_timeindex`). Building them
+pre-scoped to the selected window in the first place would be cleaner and
+more efficient; see
+`docs_notes/issue_temporal_reduction_flexibility_bands.md`.
+
+### Not yet done
+
+- Reactive-power write-back has no dedicated integration test against a
+  real OPF run (covered by unit test with stub dispatch only).
+- No pipeline/task-level integration test for `spatial_reduce`/
+  `spatial_restore` (current test scope is core-function-only, per an
+  explicit scoping decision — see `docs_notes/spatial_reduction_grilling_session.md`).
+- Two ADR candidates flagged during design, not yet written: "spatial
+  reduction as two bracketing pipeline tasks, restore optional" (breaks the
+  established "logic lives inside `pm_optimize`" convention, trading
+  consistency for the ability to stop early after the reduced-grid OPF), and
+  "disaggregation by pre-OPF flexibility envelope" (a modeling choice with
+  real alternatives).
+
+## References
+
+- Full design session record: `docs_notes/spatial_reduction_grilling_session.md`
+- `aggregation_mode=True` + charging points gap: `docs_notes/issue_aggregation_mode_flexibility_bands_not_aggregated.md`
+- Flexibility-bands time-index gap (fixed): `docs_notes/issue_temporal_reduction_flexibility_bands.md`

--- a/docs_notes/issue_temporal_reduction_flexibility_bands.md
+++ b/docs_notes/issue_temporal_reduction_flexibility_bands.md
@@ -1,0 +1,81 @@
+# Flexibility bands should be built scoped to the selected time index, not built-then-trimmed
+
+**Type:** design gap / bug
+**Found:** 2026-07-15, while testing spatial complexity reduction against a
+manual-mode `select_timesteps` run (`uc6_spatial_reduction.yaml`).
+**Affects:** `task_build_flexibility_bands` (`edisgo/run/tasks/flex.py`),
+`Electromobility.get_flexibility_bands` (`edisgo/network/electromobility.py`),
+and by extension any other per-component band/envelope built after
+`select_timesteps` (heat pump `heat_demand_df`/`cop_df`, DSM `p_max`/`p_min`).
+
+## Problem
+
+`select_timesteps` (manual mode, `position: pre_import`) fixes
+`edisgo.timeseries.timeindex` to an arbitrary, possibly short window (e.g. 24
+hours starting `2035-01-15`) early in the pipeline, before electromobility
+data is even imported.
+
+`build_flexibility_bands` runs later and calls
+`Electromobility.get_flexibility_bands(edisgo, use_case=...)`. Per that
+method's own docstring, `resample=True` only "resamples the bands to the same
+**frequency** as time series data in the `TimeSeries` object" — it does
+*not* clip the bands to the same *date range*. The bands are built from the
+raw SimBEV charging-process data and keep whatever date range that data
+spans, matching the target row spacing (e.g. hourly) but not the target
+window.
+
+Nothing downstream re-trims `electromobility.flexibility_bands` to the
+selected 24-hour window afterward. The mismatch went unnoticed until a piece
+of code tried to actually index `flexibility_bands` using
+`edisgo.timeseries.timeindex` and hit a `KeyError`-shaped failure (missing
+time steps) — in this case, the new
+`apply_reduced_results_to_full_grid`/`spatial_restore` disaggregation logic,
+which reads `flexibility_bands["upper_power"]` as a per-charging-point,
+per-time-step weighting envelope.
+
+This is a **pre-existing gap**, not something introduced by spatial
+reduction — it already exists in `uc5_select_timesteps.yaml` (the preset
+`uc6_spatial_reduction.yaml`/`uc5_spatial_reduction.yaml` were both derived
+from). It simply had no consumer that indexed `flexibility_bands` by the
+active time index before now.
+
+## Immediate fix applied (unblocks spatial-reduction testing)
+
+`task_build_flexibility_bands` now calls
+`reduce_timeseries_data_to_given_timeindex(edisgo, edisgo.timeseries.timeindex,
+electromobility=True, timeseries=False, heat_pump=False, dsm=False,
+overlying_grid=False)` right after `get_flexibility_bands`, trimming
+`flexibility_bands` down to the active index. See
+`edisgo/run/tasks/flex.py::task_build_flexibility_bands`.
+
+This is a workaround (build full, then trim), not the better design below.
+
+## Suggested proper fix (not yet implemented — this issue)
+
+Build flexibility bands (and, likely, heat-pump/DSM bands) scoped to the
+already-selected time index from the start, rather than building over the
+full/native data range and trimming afterward:
+
+- `Electromobility.get_flexibility_bands` (or its caller) should accept/use
+  the target time index *before* running the difference-array band
+  construction, so the SimBEV charging-process data outside that window is
+  never even considered.
+- Audit whether `HeatPump`/`DSM` band construction (wherever their
+  time-varying bounds are first populated — likely in the `import_heat_pumps`
+  / `import_dsm` tasks or their underlying `edisgo/io/*` importers) has the
+  same built-on-full-range-then-maybe-trimmed pattern, since
+  `reduce_timeseries_data_to_given_timeindex` already has `heat_pump=True`/
+  `dsm=True` flags suggesting this was anticipated but may not be
+  consistently invoked at the right point in every pipeline path.
+- Consider whether this should be a single, explicit "finalize time index"
+  pipeline hook that every band-producing task can rely on having already
+  run, rather than each task needing to remember to trim itself.
+
+## Reproduction
+
+Run `uc6_spatial_reduction.yaml` (or `uc5_select_timesteps.yaml`) with
+`timeseries_selection: {mode: manual, start: "2035-01-15 00:00", periods:
+24, freq: h}` and `overlying_grid.enabled: true`, then inspect
+`edisgo.electromobility.flexibility_bands["upper_power"].index` after
+`build_flexibility_bands` runs — before the fix above, its date range does
+not match `edisgo.timeseries.timeindex`.

--- a/docs_notes/spatial_reduction_grilling_session.md
+++ b/docs_notes/spatial_reduction_grilling_session.md
@@ -1,0 +1,332 @@
+# Spatial complexity reduction — pipeline integration design (grilling session)
+
+**Status:** DESIGN CLOSED. All questions resolved 2026-07-14. Next: implement, and decide
+the two ADR candidates below.
+**Date:** 2026-07-09 (started), closed 2026-07-14.
+**Repo/branch:** `/storage/MS/ego/eDisGo`, branch `edisgo_run_edisgo`.
+**Companion files:** `CONTEXT.md` (glossary, at repo root), this file.
+
+---
+
+## Goal
+
+Integrate eDisGo's **spatial complexity reduction** into the run pipeline, as a
+counterpart to the temporal complexity reduction (timestep selection) already added.
+
+Spatial reduction merges nearby buses into representative buses to shrink the grid so
+the **optimization (OPF)** runs faster. **Reinforcement must run on the FULL grid**
+(full topology) — but on the *reduced* time index (temporal reduction still applies).
+
+---
+
+## How spatial reduction works (established from code)
+
+- `EDisGo.spatial_complexity_reduction()` (edisgo.py:3439) wraps
+  `tools/spatial_complexity_reduction.py::spatial_complexity_reduction()` (line 1830).
+- It builds a **busmap** (original bus → clustered `new_bus`) + **linemap**, then mutates
+  the Topology in place (or on a copy if `copy_edisgo=True`). Returns `(edisgo, busmap_df,
+  linemap_df)`.
+- Clustering uses coordinates / grid-graph distance — **independent of the time index**.
+  Works on a full-year grid too. `apply_pseudo_coordinates=True` (default) fills missing
+  coords.
+- **Storage is never aggregated** (only bus-relabeled) — keeps its name/identity even
+  with `aggregation_mode=True` (spatial_complexity_reduction.py:1756–1760).
+- **Loads/generators ARE merged** when `aggregation_mode=True` (lines 1699–1754), grouped
+  by bus(+type+sector). Originals recorded in an **`old_name`** column on the reduced
+  component rows; their series summed via `aggregate_timeseries`.
+- `reduction_factor_not_focused` uses `find_buses_of_interest` which runs a worst-case
+  power flow — but on an **internal deepcopy** (line 93), so it does NOT disturb the
+  working object's time series.
+
+### Legacy eGo reference (the pattern we are re-implementing cleanly)
+`eGo/ego/tools/edisgo_integration.py::_run_edisgo_task_optimisation` (~line 1632):
+- `edisgo_copy = deepcopy(edisgo_grid)` (full grid stays in `edisgo_grid`)
+- temporal-reduce copy → spatial-reduce copy → `pm_optimize` on copy
+- write dispatch back onto the full grid **by component name** (lines 1763–1795):
+  loads/generators/storage active+reactive power, sliced by `time_steps`
+- `edisgo_grid.timeseries.timeindex = timeindex` (union of optimized intervals)
+- reinforce runs on the full grid. Both grids were resident in memory simultaneously.
+
+---
+
+## Decisions made (confirmed with user)
+
+1. **Two bracketing tasks (Option A), NOT inside `pm_optimize`.**
+   - `spatial_reduce` (before `optimize`) and `spatial_restore` (after `optimize`).
+   - Rationale: reduce/restore are topology operations, not OPF concerns; must be
+     visible/toggleable in YAML; enables stopping after the reduced-grid OPF when only
+     the derived time series matter.
+   - This deliberately breaks the "all logic inside pm_optimize" principle we used for
+     the multi-interval split — justified by the stop-early capability. **ADR candidate.**
+
+2. **`spatial_restore` is OPTIONAL** — a run may stop after optimizing on the reduced
+   grid. (But when present it must follow optimize; see validator note.)
+
+3. **Full-grid stash kept IN MEMORY on `ctx`** (matches legacy, which held both grids
+   resident). Disk-artifact persistence to cut peak memory is a deferred optimization,
+   not v1. (Runner does support disk reload via `save` + `stage_artifacts` + `load_from`,
+   but we are not using it here.)
+
+4. **Aggregation support:** implement `aggregation_mode=False` FIRST, then design so
+   `aggregation_mode=True` follows.
+
+5. **Map-back only touches components the OPF rewrites:** flexible charging points, heat
+   pumps, DSM loads, and storage. **Inflexible loads/generators are SKIPPED** — the OPF
+   doesn't change them; the full grid already holds their correct series.
+   - `aggregation_mode=False`: write back **by component name**.
+   - `aggregation_mode=True`: disaggregate the representative's series onto its `old_name`
+     members.
+
+6. **Disaggregation rule (aggregation_mode=True):** split the representative's optimized
+   series onto original members **per time step**, weighted by each member's own **pre-OPF
+   flexibility envelope** (a known input, never the optimized result):
+   - charging points → `electromobility.flexibility_bands["upper_power"][cp_name]` (a CP
+     with no connected vehicle has `upper_power(t)=0`, so it receives no charge that step
+     — physically correct);
+   - heat pumps → `weight(t) = min(heat_demand_df[hp_name][t] / cop_df[hp_name][t],
+     loads_df.p_set[hp_name])`. **Refined during implementation (2026-07-14):** the
+     original "heat-demand/thermal envelope" phrasing was underspecified. Investigated
+     `edisgo/io/powermodels_io.py::_build_heatpump` (~lines 1259-1282): the OPF's actual
+     per-unit electrical cap is the CONSTANT rated power `loads_df.p_set`, not a
+     time-varying series — the genuinely time-varying pre-OPF quantity is
+     `heat_demand_df` (thermal, MW) divided by `cop_df` (electrical-equivalent demand).
+     Capping that ratio at each member's own `p_set` mirrors charging points exactly (a
+     CP's `upper_power(t)` is already a capped bound, not raw uncapped vehicle demand) and
+     ensures no member is ever assigned a share exceeding what it could physically draw;
+   - DSM → `dsm.p_max[load_name][t]` band (`edisgo/network/dsm.py:63`).
+   - All three sources share the same shape: rows = timestamps matching
+     `TimeSeries.timeindex`, columns = component names matching `Topology.loads_df.index`.
+   - Sums back to the representative exactly at each step; equal split as zero-envelope
+     fallback. (User explicitly preferred a time-series-based split over a static scalar,
+     because these envelopes are known pre-OPF and reflect actual flexibility-relevant
+     events, e.g. a connected vehicle or nonzero heat demand.)
+
+7. **Ordering:** `select_timesteps` → `spatial_reduce` → `optimize` → `spatial_restore`
+   → `reinforce`.
+   - The two reduction *mechanisms* commute (orthogonal: topology vs time index), BUT the
+     pipeline pins `select_timesteps` before `spatial_reduce` so the stashed full grid
+     (hence reinforce) inherits the **reduced** time index. Result: reinforce on full
+     **topology** × reduced **time index**.
+   - `spatial_restore` does **no time-index surgery** — only writes flexible dispatch back.
+
+8. **Tasks stay thin; computation lives in eDisGo core** (same principle as the
+   timestep-selection refactor). See open question for how this applies to restore.
+
+---
+
+## Where we paused — OPEN QUESTION (resume here)
+
+Applying "tasks are thin wrappers" to the restore half. Established:
+- **Reduction half is already correct:** `spatial_complexity_reduction()` is already a
+  self-contained core function + EDisGo method. `spatial_reduce` task just needs to
+  deepcopy+stash the full grid and call it. Nothing to extract.
+- **Restore half is the gap:** there is **NO** existing core function that maps reduced
+  OPF results back onto a full grid (the legacy logic lived inline in eGo's private
+  method; `_restore_pristine_inputs` in powermodels_opf.py:225 is unrelated — it's the
+  multi-interval snapshot/restore).
+
+**Proposal put to the user (awaiting confirmation):**
+- (a) Create a NEW core function, e.g.
+  `tools/spatial_complexity_reduction.py::apply_reduced_results_to_full_grid(full_grid,
+  reduced_grid, *, flexible_cps, flexible_hps, flexible_loads, flexible_storage_units)`
+  + a thin `EDisGo` method wrapper (mirroring `spatial_complexity_reduction`). The task
+  `spatial_restore` just reads the stashed full grid + flexible sets from `ctx` and calls
+  it. Used **outside** the pipeline, a caller passes `full_grid`, `reduced_grid`, and the
+  flexible sets directly (no `ctx`). This gives symmetry: both halves = core fn + method
+  wrapper + thin task; both usable standalone; disaggregation rule lives/tested in core.
+- (b) **`old_name`** carried on the reduced grid's `loads_df`/`generators_df` is
+  sufficient provenance for disaggregation — the reduced grid self-describes its origins,
+  so **no busmap needs stashing**. Full grid needed as the write target (holds individual
+  members + their pre-OPF weighting envelopes); reduced grid supplies optimized series +
+  `old_name`. Both grids are required args.
+
+**User's last message (the prompt to answer):** agrees restore logic should NOT live in
+the task and should become its own eDisGo function; flexible-component names stored in
+`ctx` and passed to the function, or passed differently when used outside the pipeline;
+reduction is already an independent eDisGo function.
+
+→ So (a) and (b) are essentially aligned with the user's view; next step is to CONFIRM the
+signature details (both grids as args; `old_name` sufficient, no busmap) and then move on.
+
+**RESOLVED (2026-07-14):**
+- Core function signature:
+  `apply_reduced_results_to_full_grid(full_grid, reduced_grid, *, flexible_cps=None,
+  flexible_hps=None, flexible_loads=None, flexible_storage_units=None)` — four separate
+  kwargs, one per flexible-component type, each defaulting to `None`/skip.
+- `EDisGo` method wrapper name: `map_reduced_results_to_full_grid` (full symmetry with the
+  core function name, no abbreviation).
+- `old_name` on the reduced grid's `loads_df`/`generators_df` is CONFIRMED sufficient
+  provenance for disaggregation. No busmap/linemap stash on `ctx`.
+
+---
+
+## Remaining questions still to grill (not yet discussed)
+
+- ~~Validator ordering~~ — **RESOLVED (2026-07-14).** Investigated
+  `edisgo/run/validator.py` (`validate()`, lines 47-139) + `edisgo/run/registry.py`
+  (`TaskMeta`, `register_task()`): ordering today is capability-based (`requires`/
+  `provides` sets accumulated linearly across the pipeline, `validator.py:96,118-130`),
+  NOT a dependency graph and NOT named task-to-task precedence. The one existing hardcoded
+  exception is `reactive_power` must be last among `ts_altering` tasks
+  (`validator.py:110-116`). `select_timesteps`'s optional dual-position behavior
+  (`timeseries.py:328-403`) is NOT validator-enforced — it's a runtime-only check inside
+  the task, so it was not usable as a precedent.
+  - **Decision:** extend the existing capability system rather than add a new validator
+    concept or fall back to runtime-only checking (matches the pipeline's existing
+    mechanism everywhere else):
+    - `spatial_reduce` declares `provides={"reduced_grid"}`.
+    - `optimize` declares `provides={"optimized_dispatch", ...}` (in addition to its
+      existing provides).
+    - `spatial_restore` declares `requires={"reduced_grid", "optimized_dispatch"}`.
+  - This closes the gap where presence-only capability accumulation would otherwise let
+    `spatial_restore` validate successfully even if placed before `optimize` (both
+    `reduced_grid`-derived requirements would already be "satisfied" from
+    `spatial_reduce` alone) — requiring `optimized_dispatch` too means `spatial_restore`
+    cannot pass validation until `optimize` has actually appeared earlier in the
+    pipeline.
+  - **Correction (2026-07-14, during implementation):** `register_task`'s `requires`/
+    `provides` (`edisgo/run/registry.py:52-58`) are fixed at decoration time (module
+    load), NOT evaluated per-run — so "optimize requires `reduced_grid` only when spatial
+    reduction is configured for THIS run" is not expressible and was dropped.
+    `optimize`'s `requires` stays exactly `{"timeseries", "flex"}`, unchanged — it does
+    not need to know spatial reduction exists. Ordering is fully enforced from
+    `spatial_restore`'s side alone; adding `reduced_grid` to `optimize`'s `requires`
+    unconditionally would have broken every existing preset that runs `optimize` without
+    `spatial_reduce` (uc2, uc4, uc5_select_timesteps).
+- ~~YAML config surface~~ — **RESOLVED (2026-07-14).** Top-level `spatial_reduction:`
+  block, mirroring `timeseries_selection:`. Read via
+  `ctx.raw_config.get("spatial_reduction", {})` inside the `spatial_reduce` task, same
+  pattern as `select_timesteps` (`timeseries.py:415`). Holds `mode`, `cluster_area`,
+  `reduction_factor`, `reduction_factor_not_focused`, `aggregation_mode`, aggregation
+  sub-modes.
+- ~~eGo injection~~ — **RESOLVED (2026-07-14).** Verified `timeseries_selection`'s actual
+  injection in `EDisGoNetworks._build_run_edisgo_config()`,
+  `eGo/ego/tools/edisgo_integration.py:675-685`: global `timeseries_selection` default +
+  `timeseries_selection_per_grid` dict keyed by `str(mv_grid_id)`
+  (`edisgo_integration.py:681-684`), **whole-block replacement** (not field-level merge),
+  key omitted from `cfg` entirely if both are unset (line 684: `if ts_selection is not
+  None`), letting the eDisGo preset's own default apply. Granularity is truly per
+  individual MV grid (`mv_grid_id`, looped in `run_all`, `edisgo_integration.py:597-626`).
+  - **Decision:** `spatial_reduction` replicates this exactly — global `spatial_reduction`
+    default + `spatial_reduction_per_grid` dict keyed by `str(mv_grid_id)`, whole-block
+    replacement, omitted if unset (same as `timeseries_selection`, not the simpler
+    `overlying_grid` hardcoded-fallback pattern).
+- ~~Reactive power~~ — **RESOLVED (2026-07-14).** Investigated existing convention:
+  `pm_optimize`'s results-writer (`edisgo/io/powermodels_io.py::from_powermodels`,
+  lines 283-352) writes ONLY active power for flex components (heat pumps, CPs, DSM,
+  storage) into `_generators_active_power`/`_loads_active_power`/
+  `_storage_units_active_power`; reactive power is untouched there. Immediately after
+  (line 354-355), it calls the plain `edisgo_object.set_time_series_reactive_power_control()`
+  — same generic fixed-cosphi default (`network/timeseries.py::fixed_cosphi`,
+  `flex_opt/q_control.py`) used everywhere else in eDisGo, applied blanket over the whole
+  object, not scoped to flex components. Confirmed the existing `reactive_power` pipeline
+  task (`edisgo/run/tasks/timeseries.py:584-629`) is just a thin wrapper around the exact
+  same call — no special-casing for OPF-derived components anywhere in the codebase today.
+  - Considered alternative: split reactive power proportionally to each `old_name`
+    member's share of the representative's active power (mirroring the active-power
+    disaggregation rule) instead of recomputing. **Verified mathematically equivalent**
+    under fixed-cosphi: all `old_name` members of one representative share the same
+    `type` → same `power_factor`, so `Q = P · tan(φ)` per member gives an identical result
+    whether derived by proportional split or by recomputing from each member's
+    disaggregated P directly.
+  - **Decision:** `spatial_restore` writes active power for flexible components onto the
+    full grid, then calls `set_time_series_reactive_power_control()` itself — mirrors
+    `pm_optimize`'s own convention exactly (write P, then blanket-recompute Q). Reuses the
+    existing method with no new reactive-power math anywhere, and makes `spatial_restore`
+    correct standalone even in pipelines with no downstream `reactive_power` task.
+- ~~Testing strategy~~ — **RESOLVED (2026-07-14).** Scope for this first pass: core
+  function only (`apply_reduced_results_to_full_grid`), NOT pipeline/task-level
+  integration tests (deferred). Cover both aggregation modes:
+  - `aggregation_mode=False`: by-name write-back correctness.
+  - `aggregation_mode=True`: disaggregation math — per-step envelope-weighted split,
+    exact-sum-back-to-representative check, and the equal-split zero-envelope fallback.
+  - Stub/fake OPF results as fixtures; no real `pm_optimize` call, no real pipeline run
+    through `ctx`/validator.
+- ~~uc5 preset~~ — **RESOLVED (2026-07-14).** New standalone preset
+  `edisgo/run/presets/uc5_spatial_reduction.yaml` (full copy of
+  `uc5_select_timesteps.yaml` + the spatial bracket, NOT an `extends` overlay — tasks
+  don't exist in code yet so this is documentation/example, and a standalone file matches
+  `uc5_select_timesteps.yaml`'s own self-contained style). Disable switch: explicit
+  `spatial_reduction.enabled` flag (mirrors `overlying_grid.enabled`, NOT
+  `timeseries_selection`'s absent-block-is-the-toggle style) — lets params stay in the
+  YAML while toggling on/off with one flag. Bracket placement: `spatial_reduce` right
+  before `optimize`, `spatial_restore` right after; `reactive_power` stays where it already
+  is (pre-OPF full-series cosphi on the reduced index), unaffected by the spatial bracket.
+  Final order: `select_timesteps(post_grid) → reactive_power → spatial_reduce → optimize →
+  spatial_restore → reinforce`.
+
+---
+
+## Implementation (2026-07-14)
+
+Implemented and tested end-to-end (real venv, python3.10, `pip install -e ".[dev]"`,
+real ding0 test grid `tests/data/ding0_test_network_1`):
+
+- `apply_reduced_results_to_full_grid` +
+  `EDisGo.map_reduced_results_to_full_grid` —
+  `edisgo/tools/spatial_complexity_reduction.py`, `edisgo/edisgo.py`.
+- `spatial_reduce` / `spatial_restore` tasks — new file `edisgo/run/tasks/spatial.py`,
+  registered in `edisgo/run/tasks/__init__.py`.
+- `RunContext.full_grid_stash` — new field, `edisgo/run/context.py`.
+- `task_optimize` writes `flexible_cps`/`flexible_hps`/`flexible_loads`/
+  `flexible_storage_units` to `ctx.flags`; `@register_task("optimize", ...)` gained
+  `provides={"optimized_dispatch"}` — `edisgo/run/tasks/analysis.py`.
+- New preset `edisgo/run/presets/uc5_spatial_reduction.yaml` (already covered above).
+- New tests `tests/tools/test_spatial_complexity_reduction.py::TestApplyReducedResultsToFullGrid`
+  (6 tests: by-name write-back, multi-member disaggregation sum check, singleton-rename
+  regression, time-index-mismatch error, storage-unit by-name path, reactive-power
+  recompute). Full existing suite (`tests/tools/`, `tests/run/`, `tests/opf/`) reverified
+  green: 99 passed, 1 unrelated skip.
+
+**Two real bugs found by a dedicated code-review agent (dispatched because no import-
+capable env existed initially) and fixed before landing:**
+
+1. **Singleton-rename data corruption (serious).** Original code took a `_write_by_name`
+   fast path whenever a flexible-component set had NO multi-member merged group,
+   assuming an unmerged representative's name always equals its member's name. FALSE
+   under `aggregation_mode=True`: `spatial_complexity_reduction` renames **every**
+   group's representative, including singleton groups (a bus with exactly one flexible
+   load of a type/sector) — confirmed empirically on the real test grid (11 such
+   singletons exist in `ding0_test_network_1` alone). `_write_by_name` using the
+   representative's (renamed) name against `full_grid` (which only has the original,
+   un-renamed name) silently created a phantom column via pandas' `.loc[]` auto-vivify
+   behavior, leaving the real target column stale — a silent, hard-to-detect data
+   corruption, not a crash. **Fix:** removed the `_write_by_name` fast path for CPs/HPs/
+   DSM loads entirely; always route through `_disaggregate`, which was proven correct for
+   every case (matching name, mismatched singleton, multi-member) by direct test.
+   `_write_by_name` now only serves storage units, which are genuinely never renamed.
+2. **`flexible_* or []` crashes on numpy-array input (real, hit on first live
+   end-to-end run).** `task_optimize` derives `flexible_loads` as
+   `edisgo.dsm.p_min.columns.values` (`analysis.py:357`) — a numpy array — unlike the
+   other three `flexible_*` lists, which use `.tolist()`. `array or []` raises
+   `ValueError: The truth value of an array with more than one element is ambiguous...`
+   for any such array with 2+ elements. This surfaced immediately on the very first real
+   pipeline run (`run_example_06.py`, `uc6_spatial_reduction.yaml`, `aggregation_mode:
+   false`) — the OPF/Gurobi solve completed successfully, `spatial_restore` crashed on
+   the very next line. **Fix:** replaced `flexible_x = flexible_x or []` with
+   `flexible_x = list(flexible_x) if flexible_x is not None else []` for all four
+   parameters in `apply_reduced_results_to_full_grid` — `is None` is the correct
+   emptiness check for an optional list-like argument that may be a list, tuple, or numpy
+   array (the codebase's own docstrings elsewhere already document these params as
+   accepting `numpy.ndarray or None`). Added regression test
+   `test_accepts_numpy_array_flexible_component_lists`.
+3. **Unguarded `KeyError` on time-index mismatch (robustness).** If a flexibility-band/
+   DSM/heat-pump attribute on `full_grid` doesn't cover `full_grid.timeseries.timeindex`
+   (e.g. the full-grid stash was taken before time-index selection ran — a real risk for
+   any pipeline not following the `select_timesteps` → `spatial_reduce` convention, since
+   nothing in the registry enforces that order), the disaggregation envelope lookup would
+   raise a bare `KeyError` deep inside a `.loc` call. **Fix:** added
+   `_require_full_timeindex`, a defensive check before each envelope lookup that raises a
+   clear `ValueError` naming the mismatch and the likely cause. Decided against also
+   adding a validator `requires={"timeseries"}` declaration — the pipeline is already
+   constructed so a time index is guaranteed set before `spatial_reduce` runs (decision 7,
+   above), so the defensive check alone is sufficient without touching registry metadata.
+
+## ADR candidates (offer at end of session)
+
+1. "Spatial reduction as two bracketing pipeline tasks, restore optional" — hard to
+   reverse, surprising (breaks the pm_optimize-owns-its-logic principle), real trade-off
+   (consistency vs stop-early). → write when design settles.
+2. Possibly: "Disaggregation by pre-OPF flexibility envelope per time step" — a modeling
+   choice with alternatives (static scalar, proportional-to-original-series). Borderline;
+   decide at end.

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -64,7 +64,10 @@ from edisgo.opf.results.opf_result_class import OPFResults
 from edisgo.tools import plots, tools
 from edisgo.tools.config import Config
 from edisgo.tools.geo import find_nearest_bus
-from edisgo.tools.spatial_complexity_reduction import spatial_complexity_reduction
+from edisgo.tools.spatial_complexity_reduction import (
+    apply_reduced_results_to_full_grid,
+    spatial_complexity_reduction,
+)
 from edisgo.tools.tools import (
     determine_grid_integration_voltage_level,
     get_path_length_to_station,
@@ -3577,6 +3580,64 @@ class EDisGo:
             **kwargs,
         )
         return edisgo_obj, busmap_df, linemap_df
+
+    def map_reduced_results_to_full_grid(
+        self,
+        reduced_grid: EDisGo,
+        flexible_cps: list | None = None,
+        flexible_hps: list | None = None,
+        flexible_loads: list | None = None,
+        flexible_storage_units: list | None = None,
+    ) -> EDisGo:
+        """
+        Writes optimized flexible-component dispatch from a spatially-reduced
+        grid back onto this (full) grid.
+
+        Counterpart to :meth:`spatial_complexity_reduction`: where that
+        method shrinks this grid for a faster OPF, this method maps the OPF's
+        active-power results from ``reduced_grid`` back onto ``self`` so
+        reinforcement can run on the full topology. Only components the OPF
+        actually rewrites are touched — flexible charging points, heat pumps,
+        DSM loads, and storage units. Inflexible loads/generators are
+        untouched, since the OPF never changed their series and ``self``
+        already holds the correct values for them.
+
+        See :func:`~.tools.spatial_complexity_reduction.apply_reduced_results_to_full_grid`
+        for the full matching/disaggregation rules and the reactive-power
+        recompute this method triggers as a side effect.
+
+        Parameters
+        ----------
+        reduced_grid : :class:`~.EDisGo`
+            The spatially-reduced EDisGo instance the OPF ran on. Supplies
+            the optimized active-power series and, if aggregated, the
+            ``old_name`` provenance for disaggregation.
+        flexible_cps : list of str, optional
+            Names of flexible charging points in ``reduced_grid`` to map
+            back.
+        flexible_hps : list of str, optional
+            Names of flexible heat-pump loads in ``reduced_grid`` to map
+            back.
+        flexible_loads : list of str, optional
+            Names of flexible DSM loads in ``reduced_grid`` to map back.
+        flexible_storage_units : list of str, optional
+            Names of flexible storage units in ``reduced_grid`` to map back.
+
+        Returns
+        -------
+        :class:`~.EDisGo`
+            ``self``, with active power written for the given flexible
+            components and reactive power recomputed.
+
+        """
+        return apply_reduced_results_to_full_grid(
+            full_grid=self,
+            reduced_grid=reduced_grid,
+            flexible_cps=flexible_cps,
+            flexible_hps=flexible_hps,
+            flexible_loads=flexible_loads,
+            flexible_storage_units=flexible_storage_units,
+        )
 
     def check_integrity(self):
         """

--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -269,9 +269,7 @@ class EDisGo:
         """
         from edisgo.run import _run_pipeline_on
 
-        return _run_pipeline_on(
-            self, config, overlying_grid_data=overlying_grid_data
-        )
+        return _run_pipeline_on(self, config, overlying_grid_data=overlying_grid_data)
 
     def import_ding0_grid(self, path, legacy_ding0_grids=True):
         """
@@ -3602,7 +3600,8 @@ class EDisGo:
         untouched, since the OPF never changed their series and ``self``
         already holds the correct values for them.
 
-        See :func:`~.tools.spatial_complexity_reduction.apply_reduced_results_to_full_grid`
+        See
+        :func:`~.tools.spatial_complexity_reduction.apply_reduced_results_to_full_grid`
         for the full matching/disaggregation rules and the reactive-power
         recompute this method triggers as a side effect.
 

--- a/edisgo/run/context.py
+++ b/edisgo/run/context.py
@@ -1,3 +1,13 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """
 Runtime context passed to every task during pipeline execution.
 
@@ -19,6 +29,7 @@ Typical uses:
 Tasks should treat ``flags`` as advisory — they MAY short-circuit based
 on a flag but MUST NOT assume a flag is present.
 """
+
 from __future__ import annotations
 
 import logging

--- a/edisgo/run/context.py
+++ b/edisgo/run/context.py
@@ -67,6 +67,11 @@ class RunContext:
         ``overlying_grid_data=`` argument of :func:`edisgo.run.run_edisgo`.
         Consumed by the ``import_overlying_grid_data`` task when
         ``overlying_grid.source == "etrago"``.
+    full_grid_stash : edisgo.EDisGo or None
+        The pre-reduction :class:`~edisgo.EDisGo` instance, deepcopied and
+        stashed by the ``spatial_reduce`` task before it spatially reduces
+        the working object. Consumed (and cleared back to ``None``) by
+        ``spatial_restore``. ``None`` when spatial reduction is not in use.
 
     """
 
@@ -81,6 +86,7 @@ class RunContext:
     current_stage: str | None = None
     raw_config: dict[str, Any] = field(default_factory=dict)
     overlying_grid_data: Any = None
+    full_grid_stash: Any = None
 
     def ensure_engine(self):
         """

--- a/edisgo/run/presets/uc5_select_timesteps.yaml
+++ b/edisgo/run/presets/uc5_select_timesteps.yaml
@@ -46,8 +46,8 @@ grid:
   legacy_ding0_grids: false
 
 database:
-  ssh:
-    enabled: false
+  source: local
+
 
 # No explicit base time index is set. oedb_ts falls back to a full year derived
 # from the scenario when none is given, which is what auto interval selection

--- a/edisgo/run/presets/uc6_spatial_reduction.yaml
+++ b/edisgo/run/presets/uc6_spatial_reduction.yaml
@@ -1,0 +1,149 @@
+_comment: |
+  UC5 — OPF with configurable timestep selection (manual OR auto), PLUS spatial
+  complexity reduction bracketing the OPF step. Standalone copy of
+  uc5_select_timesteps.yaml (not an `extends` overlay) with the spatial_reduce /
+  spatial_restore bracket added around `optimize`.
+
+  The pipeline carries TWO select_timesteps steps, each with a `position`:
+  - position: pre_import  (before import_heat_pumps) — acts only in MANUAL
+    mode. It sets the explicit time index, which the heat-pump/DSM imports
+    and oedb_ts then use to fetch only the selected steps (cheap).
+  - position: post_grid   (after import_overlying_grid_data, before
+    reactive_power) — acts only in AUTO mode. It needs all active-power
+    time series (incl. overlying-grid generation) set to run the scoring
+    power flow via get_most_critical_time_intervals.
+  Whichever mode is configured, the other positioned step is a no-op.
+
+  Auto mode normally yields two disconnected intervals (one overloading,
+  one voltage). They are kept separate (a gap in the time index); if they
+  overlap, a non-overlapping pair is chosen if possible, otherwise they are
+  concatenated into one interval. A later optimize step can detect the gap
+  and run separate optimizations per interval.
+
+  Spatial complexity reduction (spatial_reduce / spatial_restore) brackets
+  `optimize` only:
+  - spatial_reduce (before optimize): deepcopies and stashes the full grid on
+    ctx, then spatially reduces the working object so `optimize` runs on a
+    smaller grid.
+  - spatial_restore (after optimize): writes the optimized flexible-component
+    dispatch back onto the stashed full grid (by name, or disaggregated onto
+    `old_name` members if aggregation_mode is true), recomputes reactive power
+    for those components, and makes the full grid active again for `reinforce`.
+  Both are no-ops when `spatial_reduction.enabled` is false (default), so
+  `reinforce` then runs on the same grid `optimize` used, same as
+  uc5_select_timesteps.yaml. `reactive_power` (pre-OPF, full time series) stays
+  where it already was, unaffected by the spatial bracket.
+  Reinforcement always runs on the full topology, regardless of the flag.
+
+_workflow:
+  - setup_grid: load ding0 topology
+  - import_generators / import_home_batteries
+  - select_timesteps (pre_import): manual only — set explicit time index
+  - import_heat_pumps / import_dsm: fetch only selected steps (manual)
+  - import_electromobility: dumb charging, flex bands
+  - oedb_ts: real wind/solar + load time series
+  - apply_charging_strategy / apply_heat_pump_strategy
+  - build_flexibility_bands: EV bands on the fixed hourly index
+  - import_overlying_grid_data: HV constraints from CSV dir
+  - select_timesteps (post_grid): auto only — reduce to critical intervals
+  - reactive_power: fixed cosphi on the reduced index
+  - spatial_reduce: no-op unless spatial_reduction.enabled — stash full grid,
+      reduce working object
+  - optimize: pm_optimize with flex assets, on the (possibly) reduced grid
+  - spatial_restore: no-op unless spatial_reduction.enabled — write dispatch
+      back onto the stashed full grid, recompute reactive power
+  - reinforce / save: always on the full topology
+
+# Self-contained (no `extends`): everything uc4_example provided is inlined
+# below, so this preset can be run on its own via
+#   run_edisgo({"extends": "uc5_spatial_reduction", "grid": {"ding0_path": ...}})
+scenario: eGon2035
+
+grid:
+  ding0_path: "/path/to/ding0_grid"
+  legacy_ding0_grids: false
+
+database:
+  source: local
+
+
+# No explicit base time index is set. oedb_ts falls back to a full year derived
+# from the scenario when none is given, which is what auto interval selection
+# needs (week-long critical intervals to pick from). For manual selection the
+# pre-import select_timesteps step sets the index instead.
+
+overlying_grid:
+  enabled: true          # set true to activate import_overlying_grid_data
+  source: csv            # "csv" (load from path) or "etrago" (kwarg)
+  path: "/storage/JoDa/edisgo_playground/overlying_grid_data"
+
+results:
+  directory: results/uc5_spatial_reduction
+
+# Top-level block read by the select_timesteps task via ctx.raw_config.
+# eGo can inject this block the same way it injects overlying_grid.
+# Set `mode` (and its parameters) here or override it in the run script.
+timeseries_selection:
+  mode: manual
+  # auto method: "power_flow" (default, scores intervals via a power flow) or
+  # "residual_load" (no power flow — the weeks ending at the max/min residual-load
+  # time steps; requires overlying-grid data).
+  method: residual_load
+  # --- shared auto parameters (both methods) ---
+  time_steps_per_time_interval: 168  # one week (must be a multiple of 24)
+  time_step_day_start: 4             # hour of day the intervals start/end on
+  # --- power_flow method parameters ---
+  percentage: 1.0
+  save_steps: true                   # write selected intervals CSV to results_dir
+  use_troubleshooting_mode: true     # handle power-flow non-convergence
+  overloading_factor: 0.95
+  voltage_deviation_factor: 0.95
+  # --- manual parameters (used when mode: manual) ---
+  # timestamps: ["2035-01-15 08:00", "2035-01-15 9:00", "2035-01-15 10:00"]
+  # or a range instead of `timestamps`:
+  start: "2035-01-15 00:00"
+  periods: 24
+  freq: h
+
+# Top-level block read by the spatial_reduce/spatial_restore tasks via
+# ctx.raw_config. eGo can inject this block the same way it injects
+# overlying_grid/timeseries_selection (global `spatial_reduction` default +
+# per-grid `spatial_reduction_per_grid` override keyed by mv_grid_id).
+spatial_reduction:
+  enabled: true          # set true to activate spatial_reduce/spatial_restore
+  mode: kmeansdijkstra               # clustering mode for spatial_complexity_reduction
+  cluster_area: feeder
+  reduction_factor: 0.3
+  reduction_factor_not_focused: False
+  aggregation_mode: flase  # start with false; true enables load/generator merging
+
+pipeline:
+  - setup_grid
+  - import_generators
+  - import_home_batteries
+  - select_timesteps: {position: pre_import}   # acts in manual mode only
+  - import_heat_pumps
+  - import_dsm
+  - import_electromobility:
+      charging_strategy: null
+      # flexibility bands are built later (build_flexibility_bands), once the
+      # analysis time index is fixed, so they are resampled to it
+  - oedb_ts:
+      dispatchable: {other: 0.7}
+  - apply_charging_strategy: {strategy: dumb}
+  - apply_heat_pump_strategy: {strategy: uncontrolled}
+  - build_flexibility_bands                    # hourly bands on the 2035 index
+  - import_overlying_grid_data
+  - select_timesteps: {position: post_grid}    # acts in auto mode only
+  - reactive_power
+  - spatial_reduce                             # no-op unless spatial_reduction.enabled
+  - optimize:
+      flexible: [heat_pumps, storage, charging_points, dsm]
+      method: soc
+      opf_version: 2
+  - spatial_restore                            # no-op unless spatial_reduction.enabled
+  - reinforce:
+      catch_convergence_problems: true
+  - save:
+      archive: true
+      save_opf_results: true

--- a/edisgo/run/presets/uc6_spatial_reduction.yaml
+++ b/edisgo/run/presets/uc6_spatial_reduction.yaml
@@ -75,10 +75,10 @@ database:
 overlying_grid:
   enabled: true          # set true to activate import_overlying_grid_data
   source: csv            # "csv" (load from path) or "etrago" (kwarg)
-  path: "/storage/JoDa/edisgo_playground/overlying_grid_data"
+  path: "/home/gurobi/.edisgo_input/overlying_grid"
 
 results:
-  directory: results/uc5_spatial_reduction
+  directory: results/uc6_spatial_reduction
 
 # Top-level block read by the select_timesteps task via ctx.raw_config.
 # eGo can inject this block the same way it injects overlying_grid.
@@ -115,7 +115,7 @@ spatial_reduction:
   cluster_area: feeder
   reduction_factor: 0.3
   reduction_factor_not_focused: False
-  aggregation_mode: flase  # start with false; true enables load/generator merging
+  aggregation_mode: false  # start with false; true enables load/generator merging
 
 pipeline:
   - setup_grid

--- a/edisgo/run/presets/uc6_spatial_reduction.yaml
+++ b/edisgo/run/presets/uc6_spatial_reduction.yaml
@@ -1,5 +1,5 @@
 _comment: |
-  UC5 — OPF with configurable timestep selection (manual OR auto), PLUS spatial
+  UC6 — OPF with configurable timestep selection (manual OR auto), PLUS spatial
   complexity reduction bracketing the OPF step. Standalone copy of
   uc5_select_timesteps.yaml (not an `extends` overlay) with the spatial_reduce /
   spatial_restore bracket added around `optimize`.
@@ -56,7 +56,7 @@ _workflow:
 
 # Self-contained (no `extends`): everything uc4_example provided is inlined
 # below, so this preset can be run on its own via
-#   run_edisgo({"extends": "uc5_spatial_reduction", "grid": {"ding0_path": ...}})
+#   run_edisgo({"extends": "uc6_spatial_reduction", "grid": {"ding0_path": ...}})
 scenario: eGon2035
 
 grid:

--- a/edisgo/run/tasks/__init__.py
+++ b/edisgo/run/tasks/__init__.py
@@ -26,6 +26,7 @@ that the runner sees them at execution time. The submodules are:
 * :mod:`.analysis` — ``check_integrity``, ``analyze``, ``reinforce``,
   ``base_reinforce``, ``optimize``
 * :mod:`.io` — ``save``, ``load_charging_from_files``
+* :mod:`.spatial` — ``spatial_reduce``, ``spatial_restore``
 
 Task signature convention: ``(edisgo, ctx, **params)``. A task may
 mutate ``edisgo`` in place and/or return a new EDisGo instance (the
@@ -33,4 +34,11 @@ returned value, if non-None, replaces the current one in the runner's
 loop).
 """
 
-from edisgo.run.tasks import analysis, flex, grid, io, timeseries  # noqa: F401
+from edisgo.run.tasks import (  # noqa: F401
+    analysis,
+    flex,
+    grid,
+    io,
+    spatial,
+    timeseries,
+)

--- a/edisgo/run/tasks/analysis.py
+++ b/edisgo/run/tasks/analysis.py
@@ -268,7 +268,9 @@ def task_base_reinforce(
     return edisgo
 
 
-@register_task("optimize", requires={"timeseries", "flex"})
+@register_task(
+    "optimize", requires={"timeseries", "flex"}, provides={"optimized_dispatch"}
+)
 def task_optimize(
     edisgo,
     ctx,
@@ -307,7 +309,11 @@ def task_optimize(
         EDisGo instance to optimize.
     ctx : RunContext
         Run context. Used for logging and, for multi-interval runs, nothing
-        else is required from it.
+        else is required from it. The resolved ``flexible_*`` name lists are
+        written to ``ctx.flags['flexible_cps']`` / ``ctx.flags['flexible_hps']``
+        / ``ctx.flags['flexible_loads']`` / ``ctx.flags['flexible_storage_units']``
+        so a later ``spatial_restore`` step knows which components' dispatch
+        needs mapping back onto the full grid.
     flexible : list of str, optional
         High-level selector, subset of ``{"heat_pumps",
         "charging_points", "storage"}``. If ``None``, nothing is
@@ -358,6 +364,11 @@ def task_optimize(
         flexible_loads = []
     if flexible_storage_units is None:
         flexible_storage_units = []
+
+    ctx.flags["flexible_cps"] = flexible_cps
+    ctx.flags["flexible_hps"] = flexible_hps
+    ctx.flags["flexible_loads"] = flexible_loads
+    ctx.flags["flexible_storage_units"] = flexible_storage_units
 
     # pm_optimize handles a non-contiguous (reduced) time index internally:
     # it runs one OPF per contiguous interval and merges the results.

--- a/edisgo/run/tasks/flex.py
+++ b/edisgo/run/tasks/flex.py
@@ -216,6 +216,14 @@ def task_build_flexibility_bands(edisgo, ctx, *, use_case=None):
     ``import_heat_pumps``, and is more efficient than building bands over a
     non-final index.
 
+    ``get_flexibility_bands`` only resamples to the active *frequency* - the
+    bands still span whatever date range the underlying SimBEV charging-
+    process data covers, which is not necessarily the same range as
+    ``edisgo.timeseries.timeindex`` (e.g. a manually-selected window). This
+    task additionally trims the bands down to that exact index, so
+    ``electromobility.flexibility_bands`` always matches
+    ``edisgo.timeseries.timeindex`` after this step runs.
+
     Parameters
     ----------
     edisgo : edisgo.EDisGo
@@ -232,9 +240,20 @@ def task_build_flexibility_bands(edisgo, ctx, *, use_case=None):
     edisgo.EDisGo
         The modified EDisGo instance.
     """
+    from edisgo.tools.tools import reduce_timeseries_data_to_given_timeindex
+
     if use_case is None:
         use_case = ["home", "work", "public", "hpc"]
     edisgo.electromobility.get_flexibility_bands(edisgo, use_case=use_case)
+    reduce_timeseries_data_to_given_timeindex(
+        edisgo,
+        edisgo.timeseries.timeindex,
+        timeseries=False,
+        electromobility=True,
+        heat_pump=False,
+        dsm=False,
+        overlying_grid=False,
+    )
     return edisgo
 
 

--- a/edisgo/run/tasks/spatial.py
+++ b/edisgo/run/tasks/spatial.py
@@ -96,9 +96,7 @@ def task_spatial_reduce(edisgo, ctx, **overrides):
     return edisgo
 
 
-@register_task(
-    "spatial_restore", requires={"reduced_grid", "optimized_dispatch"}
-)
+@register_task("spatial_restore", requires={"reduced_grid", "optimized_dispatch"})
 def task_spatial_restore(edisgo, ctx, **overrides):
     """
     Write optimized flexible-component dispatch back onto the stashed full

--- a/edisgo/run/tasks/spatial.py
+++ b/edisgo/run/tasks/spatial.py
@@ -1,0 +1,150 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Spatial complexity reduction tasks bracketing ``optimize``.
+
+* :func:`task_spatial_reduce` (``spatial_reduce``) — stashes a deepcopy of
+  the full grid on ``ctx`` and spatially reduces the working object so
+  ``optimize`` runs on a smaller grid.
+* :func:`task_spatial_restore` (``spatial_restore``) — writes the optimized
+  flexible-component dispatch back onto the stashed full grid and makes it
+  the active object again, so ``reinforce`` runs on the full topology.
+
+Both are no-ops when ``spatial_reduction.enabled`` is false (the default),
+so a pipeline that carries this bracket behaves exactly like one that
+doesn't when spatial reduction is turned off.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from edisgo.run.registry import register_task
+
+
+@register_task("spatial_reduce", requires={"grid"}, provides={"reduced_grid"})
+def task_spatial_reduce(edisgo, ctx, **overrides):
+    """
+    Deepcopy and stash the full grid, then spatially reduce the working
+    object.
+
+    Configuration is read from the top-level ``spatial_reduction:`` config
+    block (so eGo can inject it the same way it injects
+    ``timeseries_selection``); inline step params override individual keys
+    of that block.
+
+    A no-op when ``enabled`` is not true — ``edisgo`` is returned unchanged
+    and ``ctx.full_grid_stash`` is left ``None``, so a downstream
+    ``spatial_restore`` also no-ops (see its docstring) and ``optimize``/
+    ``reinforce`` run on the same, unreduced grid as if this task were
+    absent from the pipeline.
+
+    Parameters
+    ----------
+    edisgo : edisgo.EDisGo
+        EDisGo instance to spatially reduce in place.
+    ctx : RunContext
+        Run context. Reads ``ctx.raw_config['spatial_reduction']``. Sets
+        ``ctx.full_grid_stash`` to the pre-reduction deepcopy.
+    **overrides
+        Inline step params overriding keys of the ``spatial_reduction``
+        block. Recognized keys: ``enabled`` (bool, default ``False``),
+        ``mode``, ``cluster_area``, ``reduction_factor``,
+        ``reduction_factor_not_focused``, ``aggregation_mode``, and the
+        aggregation sub-modes ``load_aggregation_mode`` /
+        ``generator_aggregation_mode`` — forwarded to
+        :meth:`~.EDisGo.spatial_complexity_reduction`.
+
+    Returns
+    -------
+    edisgo.EDisGo
+        The (possibly) spatially-reduced EDisGo instance.
+
+    """
+    cfg = {**ctx.raw_config.get("spatial_reduction", {}), **overrides}
+    if not cfg.get("enabled", False):
+        return edisgo
+
+    ctx.full_grid_stash = copy.deepcopy(edisgo)
+
+    kwargs = {
+        k: v
+        for k, v in cfg.items()
+        if k
+        in (
+            "mode",
+            "cluster_area",
+            "reduction_factor",
+            "reduction_factor_not_focused",
+            "apply_pseudo_coordinates",
+            "aggregation_mode",
+            "load_aggregation_mode",
+            "generator_aggregation_mode",
+            "line_naming_convention",
+            "mv_pseudo_coordinates",
+        )
+    }
+    edisgo.spatial_complexity_reduction(copy_edisgo=False, **kwargs)
+    return edisgo
+
+
+@register_task(
+    "spatial_restore", requires={"reduced_grid", "optimized_dispatch"}
+)
+def task_spatial_restore(edisgo, ctx, **overrides):
+    """
+    Write optimized flexible-component dispatch back onto the stashed full
+    grid, and make it the active object again.
+
+    Reads the flexible-component name lists ``optimize`` wrote to
+    ``ctx.flags`` and passes them, together with ``edisgo`` (the reduced,
+    just-optimized grid) and ``ctx.full_grid_stash`` (the pre-reduction
+    grid), to :meth:`~.EDisGo.map_reduced_results_to_full_grid`. See that
+    method (and the core function it wraps,
+    :func:`~.tools.spatial_complexity_reduction.apply_reduced_results_to_full_grid`)
+    for the matching/disaggregation rules.
+
+    A no-op when ``ctx.full_grid_stash`` is ``None`` — i.e. when
+    ``spatial_reduce`` did not run or ran disabled — so ``edisgo`` (the
+    grid ``optimize`` already ran on) is returned unchanged.
+
+    Parameters
+    ----------
+    edisgo : edisgo.EDisGo
+        The reduced EDisGo instance ``optimize`` ran on.
+    ctx : RunContext
+        Run context. Reads ``ctx.full_grid_stash`` and the
+        ``flexible_cps`` / ``flexible_hps`` / ``flexible_loads`` /
+        ``flexible_storage_units`` flags ``optimize`` set. Clears
+        ``ctx.full_grid_stash`` back to ``None`` after restoring.
+    **overrides
+        Unused; accepted for signature consistency with other tasks.
+
+    Returns
+    -------
+    edisgo.EDisGo
+        The full-grid EDisGo instance with flexible dispatch restored, or
+        ``edisgo`` unchanged if there is no stash to restore from.
+
+    """
+    full_grid = ctx.full_grid_stash
+    if full_grid is None:
+        return edisgo
+
+    full_grid.map_reduced_results_to_full_grid(
+        reduced_grid=edisgo,
+        flexible_cps=ctx.flags.get("flexible_cps"),
+        flexible_hps=ctx.flags.get("flexible_hps"),
+        flexible_loads=ctx.flags.get("flexible_loads"),
+        flexible_storage_units=ctx.flags.get("flexible_storage_units"),
+    )
+    ctx.full_grid_stash = None
+    return full_grid

--- a/edisgo/tools/spatial_complexity_reduction.py
+++ b/edisgo/tools/spatial_complexity_reduction.py
@@ -1916,6 +1916,237 @@ def spatial_complexity_reduction(
     return busmap_df, linemap_df
 
 
+def apply_reduced_results_to_full_grid(
+    full_grid: EDisGo,
+    reduced_grid: EDisGo,
+    *,
+    flexible_cps: list | None = None,
+    flexible_hps: list | None = None,
+    flexible_loads: list | None = None,
+    flexible_storage_units: list | None = None,
+) -> EDisGo:
+    """
+    Write optimized flexible-component dispatch from a spatially-reduced grid
+    back onto the full grid.
+
+    Counterpart to :func:`spatial_complexity_reduction`: where that function
+    shrinks a grid for a faster OPF, this function maps the OPF's active-power
+    results back onto the pre-reduction grid so reinforcement can run on the
+    full topology. Only components the OPF actually rewrites are touched —
+    flexible charging points, heat pumps, DSM loads, and storage units.
+    Inflexible loads/generators are untouched: the OPF never changed their
+    series, so ``full_grid`` already holds the correct values for them.
+
+    ``full_grid`` and ``reduced_grid`` are matched by name for storage units
+    (never aggregated by :func:`spatial_complexity_reduction`, so their names
+    are unchanged) and, for the other three flexibility types, by the
+    ``old_name`` column that :func:`spatial_complexity_reduction` writes onto
+    ``reduced_grid.topology.loads_df`` when ``aggregation_mode=True``. A
+    member listed in ``old_name`` is a load whose active-power series was
+    merged into one representative row; when ``aggregation_mode=False`` (or a
+    given member was not merged), ``old_name`` is absent and the member's own
+    name is used directly — i.e. a plain by-name write-back.
+
+    For a merged representative, the representative's optimized series is
+    disaggregated onto its ``old_name`` members **per time step**, weighted by
+    each member's own pre-OPF flexibility envelope (a known input, never the
+    optimized result):
+
+    * charging points — ``upper_power(t)`` from
+      ``electromobility.flexibility_bands`` (a charging point with no
+      connected vehicle has ``upper_power(t) == 0``, so it receives none of
+      the representative's dispatch that time step);
+    * heat pumps — ``min(heat_demand(t) / cop(t), p_set)``, i.e. the
+      electrical-equivalent heat demand capped at the heat pump's own rated
+      power, mirroring how a charging point's ``upper_power(t)`` is already a
+      capped bound rather than raw uncapped demand;
+    * DSM loads — ``p_max(t)`` from :attr:`~.network.dsm.DSM.p_max`.
+
+    Weights always sum back to the representative's value exactly at every
+    time step; a time step where every member's weight is 0 falls back to an
+    equal split.
+
+    Reactive power is not read from ``reduced_grid``. After writing active
+    power, this function calls
+    :meth:`~.EDisGo.set_time_series_reactive_power_control` on ``full_grid``
+    with its defaults, mirroring how the OPF itself derives reactive power
+    for the components it just optimized (see
+    :func:`~.io.powermodels_io.from_powermodels`) — reactive power is always
+    a function of whatever active power is currently set, regardless of
+    whether that active power came from a default, worst case, or the OPF.
+
+    Parameters
+    ----------
+    full_grid : :class:`~.EDisGo`
+        The pre-reduction EDisGo instance to write dispatch onto, modified in
+        place. Must contain every component named in ``flexible_cps`` /
+        ``flexible_hps`` / ``flexible_loads`` / ``flexible_storage_units`` and
+        (for merged components) every name listed in ``reduced_grid``'s
+        ``old_name`` columns.
+    reduced_grid : :class:`~.EDisGo`
+        The spatially-reduced EDisGo instance the OPF ran on. Supplies the
+        optimized active-power series and, if aggregated, the ``old_name``
+        provenance.
+    flexible_cps : list of str, optional
+        Names of flexible charging points in ``reduced_grid`` to map back.
+    flexible_hps : list of str, optional
+        Names of flexible heat-pump loads in ``reduced_grid`` to map back.
+    flexible_loads : list of str, optional
+        Names of flexible DSM loads in ``reduced_grid`` to map back.
+    flexible_storage_units : list of str, optional
+        Names of flexible storage units in ``reduced_grid`` to map back.
+
+    Returns
+    -------
+    :class:`~.EDisGo`
+        ``full_grid``, with active power written for the given flexible
+        components and reactive power recomputed.
+
+    """
+    # NOTE: "x or []" is unsafe here - callers may pass a numpy array (e.g.
+    # task_optimize derives flexible_loads as
+    # edisgo.dsm.p_min.columns.values), and "array or []" raises
+    # ValueError ("truth value of an array... is ambiguous") for any array
+    # with more than one element. "is None" is the correct emptiness check
+    # for an optional list-like argument.
+    flexible_cps = list(flexible_cps) if flexible_cps is not None else []
+    flexible_hps = list(flexible_hps) if flexible_hps is not None else []
+    flexible_loads = list(flexible_loads) if flexible_loads is not None else []
+    flexible_storage_units = (
+        list(flexible_storage_units) if flexible_storage_units is not None else []
+    )
+
+    def _require_full_timeindex(envelope: DataFrame, envelope_name: str) -> None:
+        """Raise a clear error if ``envelope`` doesn't cover the full grid's
+        active time index, instead of a bare ``KeyError`` deep inside a
+        ``.loc`` lookup.
+
+        This can only happen if ``full_grid``'s flexibility-band/DSM/heat-pump
+        attributes were never trimmed to the same time index as
+        ``full_grid.timeseries.timeindex`` - i.e. if the pre-reduction stash
+        was taken before the run's time index was finalized.
+        """
+        ti = full_grid.timeseries.timeindex
+        missing = ti.difference(envelope.index)
+        if len(missing) > 0:
+            raise ValueError(
+                f"apply_reduced_results_to_full_grid: full_grid's "
+                f"{envelope_name} does not cover {len(missing)} of "
+                f"full_grid.timeseries.timeindex's time steps (e.g. "
+                f"{missing[0]!r}). This usually means the full-grid stash "
+                f"was taken before the time index was finalized - run "
+                f"time-index selection (e.g. select_timesteps) before "
+                f"spatial_reduce."
+            )
+
+    def _old_name_map(loads_df: DataFrame, names: list) -> dict:
+        """Map each representative name in ``names`` to its member names.
+
+        A name absent from ``old_name`` (not merged, or
+        ``aggregation_mode=False``) maps to itself.
+        """
+        name_map = {}
+        for name in names:
+            old_name = loads_df.at[name, "old_name"] if "old_name" in loads_df else None
+            name_map[name] = old_name if isinstance(old_name, list) else [name]
+        return name_map
+
+    def _write_by_name(active_power: DataFrame, names: list, target: DataFrame) -> None:
+        ti = full_grid.timeseries.timeindex
+        target.loc[ti, names] = active_power.loc[ti, names].values
+
+    def _disaggregate(
+        active_power: DataFrame,
+        name_map: dict,
+        envelope: DataFrame,
+        target: DataFrame,
+    ) -> None:
+        """Split each representative's series onto its members per time step.
+
+        ``envelope`` holds each member's pre-OPF flexibility envelope
+        (columns = member names, index = time index); members missing from
+        ``envelope`` are treated as having an all-zero envelope (equal-split
+        fallback).
+        """
+        ti = full_grid.timeseries.timeindex
+        for representative, members in name_map.items():
+            if len(members) == 1 and members[0] == representative:
+                target.loc[ti, representative] = active_power.loc[ti, representative]
+                continue
+            weights = pd.DataFrame(index=ti, columns=members, dtype=float)
+            for member in members:
+                weights[member] = (
+                    envelope.loc[ti, member] if member in envelope.columns else 0.0
+                )
+            weight_sum = weights.sum(axis="columns")
+            zero_envelope = weight_sum == 0
+            shares = weights.div(weight_sum.replace(0, np.nan), axis="index")
+            shares.loc[zero_envelope, :] = 1.0 / len(members)
+            representative_power = active_power.loc[ti, representative]
+            for member in members:
+                target.loc[ti, member] = shares[member] * representative_power
+
+    reduced_loads_df = reduced_grid.topology.loads_df
+    full_loads_df = full_grid.topology.loads_df
+
+    # Always routed through _disaggregate (never the by-name fast path): under
+    # aggregation_mode=True, spatial_complexity_reduction renames EVERY group's
+    # representative row, including singleton groups (a bus with exactly one
+    # flexible load of a given type/sector) - so a representative's own name
+    # can differ from its single old_name member's name. _disaggregate already
+    # handles that case correctly (a singleton's one weight, whether zero or
+    # not, always resolves its share to the representative's full value), so
+    # there is no correct case left for a by-name fast path to shortcut.
+    if flexible_cps:
+        name_map = _old_name_map(reduced_loads_df, flexible_cps)
+        envelope = reduced_grid.electromobility.flexibility_bands["upper_power"]
+        _require_full_timeindex(envelope, "electromobility.flexibility_bands")
+        _disaggregate(
+            reduced_grid.timeseries.loads_active_power,
+            name_map,
+            envelope,
+            full_grid.timeseries._loads_active_power,
+        )
+
+    if flexible_hps:
+        name_map = _old_name_map(reduced_loads_df, flexible_hps)
+        members_flat = [m for members in name_map.values() for m in members]
+        heat_demand = full_grid.heat_pump.heat_demand_df[members_flat]
+        cop = full_grid.heat_pump.cop_df[members_flat]
+        p_set = full_loads_df.p_set[members_flat]
+        envelope = (heat_demand / cop).clip(upper=p_set, axis="columns")
+        _require_full_timeindex(envelope, "heat_pump.heat_demand_df/cop_df")
+        _disaggregate(
+            reduced_grid.timeseries.loads_active_power,
+            name_map,
+            envelope,
+            full_grid.timeseries._loads_active_power,
+        )
+
+    if flexible_loads:
+        name_map = _old_name_map(reduced_loads_df, flexible_loads)
+        _require_full_timeindex(full_grid.dsm.p_max, "dsm.p_max")
+        _disaggregate(
+            reduced_grid.timeseries.loads_active_power,
+            name_map,
+            full_grid.dsm.p_max,
+            full_grid.timeseries._loads_active_power,
+        )
+
+    if flexible_storage_units:
+        # Storage units are never aggregated by spatial_complexity_reduction
+        # (only bus-relabeled), so this is always a plain by-name write-back.
+        _write_by_name(
+            reduced_grid.timeseries.storage_units_active_power,
+            flexible_storage_units,
+            full_grid.timeseries._storage_units_active_power,
+        )
+
+    full_grid.set_time_series_reactive_power_control()
+
+    return full_grid
+
+
 def compare_voltage(
     edisgo_unreduced: EDisGo,
     edisgo_reduced: EDisGo,

--- a/run_example_06.py
+++ b/run_example_06.py
@@ -1,0 +1,39 @@
+# This file is part of eDisGo (Electrical Distribution Grid Optimization),
+# a Python package for analyzing flexibility options in distribution grids.
+#
+# Copyright (c) Reiner Lemoine Institut gGmbH
+# Contributors are listed in the version control history:
+# https://github.com/openego/eDisGo/
+#
+# Documentation: https://edisgo.readthedocs.io/
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Runner für uc6_spatial_reduction.yaml — einfach ``python run_example_05.py``."""
+
+import logging
+
+from edisgo.run.runner import run_edisgo
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+)
+
+# edisgo = run_edisgo("/storage/JoDa/ego/edisgo_run_edisgo/eDisGo/edisgo/run/presets/uc4_example_MS.yaml")  # noqa: E501
+edisgo = run_edisgo(
+    {
+        "extends": "uc6_spatial_reduction.yaml",
+        # "grid": {"ding0_path": "/home/gurobi/.ding0/run_hetzner_59763_2023_04_06/ding0_grids/32355"}  # noqa: E501
+        "grid": {
+            "ding0_path": "/home/gurobi/.ding0/2024-07-25T17:38:34_new_planning_new_edisgo/ding0_grids/32377"  # noqa: E501
+        },
+        # OG path must be the leaf dir for THIS grid (like ding0_path), not the parent.
+        "overlying_grid": {
+            "path": "/home/gurobi/.edisgo_input/overlying_grid/32377"
+        },
+    }
+)
+
+print("\n=== Fertig ===")
+print("Ausbaukosten:\n", edisgo.results.grid_expansion_costs)
+print("\nUngelöste Probleme:\n", edisgo.results.unresolved_issues)

--- a/run_example_06.py
+++ b/run_example_06.py
@@ -28,9 +28,7 @@ edisgo = run_edisgo(
             "ding0_path": "/home/gurobi/.ding0/2024-07-25T17:38:34_new_planning_new_edisgo/ding0_grids/32377"  # noqa: E501
         },
         # OG path must be the leaf dir for THIS grid (like ding0_path), not the parent.
-        "overlying_grid": {
-            "path": "/home/gurobi/.edisgo_input/overlying_grid/32377"
-        },
+        "overlying_grid": {"path": "/home/gurobi/.edisgo_input/overlying_grid/32377"},
     }
 )
 

--- a/tests/tools/test_spatial_complexity_reduction.py
+++ b/tests/tools/test_spatial_complexity_reduction.py
@@ -401,7 +401,8 @@ class TestSpatialComplexityReduction:
 
 class TestApplyReducedResultsToFullGrid:
     """
-    Tests for :func:`~.tools.spatial_complexity_reduction.apply_reduced_results_to_full_grid`.
+    Tests for
+    :func:`~.tools.spatial_complexity_reduction.apply_reduced_results_to_full_grid`.
 
     Uses stub OPF results (directly writing to
     ``reduced_grid.timeseries._loads_active_power`` /
@@ -528,9 +529,7 @@ class TestApplyReducedResultsToFullGrid:
             4.0,
         ]
 
-    def test_disaggregation_multi_member_sums_to_representative(
-        self, full_and_reduced
-    ):
+    def test_disaggregation_multi_member_sums_to_representative(self, full_and_reduced):
         full_grid, reduced_grid = full_and_reduced
         ti = full_grid.timeseries.timeindex
         rep = self._first_representative_with(reduced_grid, n_members=2)
@@ -552,9 +551,9 @@ class TestApplyReducedResultsToFullGrid:
         assert np.allclose(total.values, rep_power.values)
         # Member with zero envelope at t0/t2/t3 gets none of the dispatch;
         # both members zero at t1 falls back to an equal split.
-        assert result.timeseries.loads_active_power.at[ti[1], members[0]] == pytest.approx(
-            rep_power.iloc[1] / 2
-        )
+        assert result.timeseries.loads_active_power.at[
+            ti[1], members[0]
+        ] == pytest.approx(rep_power.iloc[1] / 2)
 
     def test_disaggregation_singleton_renamed_representative(self, full_and_reduced):
         # Regression test: under aggregation_mode=True, spatial_complexity_

--- a/tests/tools/test_spatial_complexity_reduction.py
+++ b/tests/tools/test_spatial_complexity_reduction.py
@@ -3,6 +3,7 @@ import copy
 from contextlib import nullcontext as does_not_raise
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from edisgo import EDisGo
@@ -396,3 +397,255 @@ class TestSpatialComplexityReduction:
     #     assert len(edisgo_root.topology.lines_df) - 1 == len(
     #         edisgo_clean.topology.lines_df
     #     )
+
+
+class TestApplyReducedResultsToFullGrid:
+    """
+    Tests for :func:`~.tools.spatial_complexity_reduction.apply_reduced_results_to_full_grid`.
+
+    Uses stub OPF results (directly writing to
+    ``reduced_grid.timeseries._loads_active_power`` /
+    ``_storage_units_active_power``) rather than running a real OPF, since
+    what is under test is the map-back/disaggregation logic, not
+    ``pm_optimize`` itself.
+    """
+
+    @pytest.fixture(autouse=True)
+    def test_edisgo_obj(self):
+        edisgo_root = EDisGo(ding0_grid=pytest.ding0_test_network_path)
+        edisgo_root.set_time_series_worst_case_analysis()
+        make_pseudo_coordinates(edisgo_root)
+        return edisgo_root
+
+    @pytest.fixture
+    def full_and_reduced(self, test_edisgo_obj):
+        full_grid = copy.deepcopy(test_edisgo_obj)
+        reduced_grid, _, _ = full_grid.spatial_complexity_reduction(
+            copy_edisgo=True,
+            mode="kmeansdijkstra",
+            cluster_area="feeder",
+            reduction_factor=0.1,
+            aggregation_mode=True,
+            load_aggregation_mode="bus",
+        )
+        return full_grid, reduced_grid
+
+    def _first_representative_with(self, reduced_grid, n_members):
+        loads_df = reduced_grid.topology.loads_df
+        candidates = loads_df[
+            loads_df["old_name"].apply(
+                lambda v: isinstance(v, list) and len(v) == n_members
+            )
+        ]
+        assert not candidates.empty, (
+            f"fixture grid has no aggregated load representative with "
+            f"exactly {n_members} old_name member(s); adjust the fixture "
+            f"or reduction_factor."
+        )
+        return candidates.index[0]
+
+    def test_by_name_write_back_aggregation_mode_false(self, test_edisgo_obj):
+        # aggregation_mode=False: no merging, so restore is a plain by-name
+        # write-back for every flexibility type.
+        full_grid = copy.deepcopy(test_edisgo_obj)
+        reduced_grid, _, _ = full_grid.spatial_complexity_reduction(
+            copy_edisgo=True,
+            mode="kmeansdijkstra",
+            cluster_area="feeder",
+            reduction_factor=0.1,
+            aggregation_mode=False,
+        )
+        ti = full_grid.timeseries.timeindex
+        load_name = reduced_grid.topology.loads_df.index[0]
+        storage_name = reduced_grid.topology.storage_units_df.index[0]
+        full_grid.dsm.p_max = pd.DataFrame(1.0, index=ti, columns=[load_name])
+
+        reduced_grid.timeseries._loads_active_power.loc[ti, load_name] = [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        ]
+        reduced_grid.timeseries._storage_units_active_power.loc[ti, storage_name] = [
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+        ]
+
+        result = spatial_complexity_reduction.apply_reduced_results_to_full_grid(
+            full_grid=full_grid,
+            reduced_grid=reduced_grid,
+            flexible_loads=[load_name],
+            flexible_storage_units=[storage_name],
+        )
+
+        assert result.timeseries.loads_active_power.loc[ti, load_name].tolist() == [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        ]
+        assert result.timeseries.storage_units_active_power.loc[
+            ti, storage_name
+        ].tolist() == [5.0, 6.0, 7.0, 8.0]
+
+    def test_accepts_numpy_array_flexible_component_lists(self, test_edisgo_obj):
+        # Regression test: task_optimize derives flexible_loads as
+        # edisgo.dsm.p_min.columns.values (a numpy array), unlike the other
+        # three flexible_* lists which are built with .tolist(). "x or []"
+        # raises ValueError ("truth value of an array... is ambiguous") for
+        # any such array with more than one element - a real crash hit on
+        # the first end-to-end pipeline run using aggregation_mode=False.
+        full_grid = copy.deepcopy(test_edisgo_obj)
+        reduced_grid, _, _ = full_grid.spatial_complexity_reduction(
+            copy_edisgo=True,
+            mode="kmeansdijkstra",
+            cluster_area="feeder",
+            reduction_factor=0.1,
+            aggregation_mode=False,
+        )
+        ti = full_grid.timeseries.timeindex
+        load_name = reduced_grid.topology.loads_df.index[0]
+        full_grid.dsm.p_max = pd.DataFrame(1.0, index=ti, columns=[load_name])
+        reduced_grid.timeseries._loads_active_power.loc[ti, load_name] = [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        ]
+
+        result = spatial_complexity_reduction.apply_reduced_results_to_full_grid(
+            full_grid=full_grid,
+            reduced_grid=reduced_grid,
+            flexible_loads=np.array([load_name]),
+        )
+
+        assert result.timeseries.loads_active_power.loc[ti, load_name].tolist() == [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        ]
+
+    def test_disaggregation_multi_member_sums_to_representative(
+        self, full_and_reduced
+    ):
+        full_grid, reduced_grid = full_and_reduced
+        ti = full_grid.timeseries.timeindex
+        rep = self._first_representative_with(reduced_grid, n_members=2)
+        members = reduced_grid.topology.loads_df.at[rep, "old_name"]
+
+        p_max = pd.DataFrame(0.0, index=ti, columns=members)
+        for i, member in enumerate(members):
+            p_max[member] = [0.1 * (i + 1), 0.0, 0.2 * (i + 1), 0.05 * (i + 1)]
+        full_grid.dsm.p_max = p_max
+
+        rep_power = pd.Series([1.0, 2.0, 0.0, 3.0], index=ti)
+        reduced_grid.timeseries._loads_active_power.loc[ti, rep] = rep_power.values
+
+        result = spatial_complexity_reduction.apply_reduced_results_to_full_grid(
+            full_grid=full_grid, reduced_grid=reduced_grid, flexible_loads=[rep]
+        )
+
+        total = result.timeseries.loads_active_power.loc[ti, members].sum(axis=1)
+        assert np.allclose(total.values, rep_power.values)
+        # Member with zero envelope at t0/t2/t3 gets none of the dispatch;
+        # both members zero at t1 falls back to an equal split.
+        assert result.timeseries.loads_active_power.at[ti[1], members[0]] == pytest.approx(
+            rep_power.iloc[1] / 2
+        )
+
+    def test_disaggregation_singleton_renamed_representative(self, full_and_reduced):
+        # Regression test: under aggregation_mode=True, spatial_complexity_
+        # reduction renames every group's representative, including
+        # singleton groups (a bus with exactly one flexible load of a given
+        # type/sector) - so the representative's name can differ from its
+        # one old_name member's name. A by-name write-back using the
+        # representative's name would silently miss the real target column
+        # on full_grid (which only has the original, un-renamed name) and
+        # create a phantom column instead - this must not happen.
+        full_grid, reduced_grid = full_and_reduced
+        ti = full_grid.timeseries.timeindex
+        rep = self._first_representative_with(reduced_grid, n_members=1)
+        member = reduced_grid.topology.loads_df.at[rep, "old_name"][0]
+        assert rep != member, "fixture assumption: representative was renamed"
+
+        full_grid.dsm.p_max = pd.DataFrame(1.0, index=ti, columns=[member])
+        rep_power = pd.Series([7.0, 8.0, 9.0, 10.0], index=ti)
+        reduced_grid.timeseries._loads_active_power.loc[ti, rep] = rep_power.values
+
+        result = spatial_complexity_reduction.apply_reduced_results_to_full_grid(
+            full_grid=full_grid, reduced_grid=reduced_grid, flexible_loads=[rep]
+        )
+
+        assert result.timeseries.loads_active_power.loc[ti, member].tolist() == (
+            rep_power.tolist()
+        )
+        assert rep not in result.timeseries.loads_active_power.columns
+
+    def test_raises_clear_error_on_time_index_mismatch(self, full_and_reduced):
+        full_grid, reduced_grid = full_and_reduced
+        ti = full_grid.timeseries.timeindex
+        rep = self._first_representative_with(reduced_grid, n_members=1)
+        member = reduced_grid.topology.loads_df.at[rep, "old_name"][0]
+
+        # dsm.p_max missing the last time step of full_grid's active index.
+        full_grid.dsm.p_max = pd.DataFrame(1.0, index=ti[:-1], columns=[member])
+        reduced_grid.timeseries._loads_active_power.loc[ti, rep] = [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+        ]
+
+        with pytest.raises(ValueError, match="does not cover"):
+            spatial_complexity_reduction.apply_reduced_results_to_full_grid(
+                full_grid=full_grid, reduced_grid=reduced_grid, flexible_loads=[rep]
+            )
+
+    def test_storage_units_never_aggregated_always_by_name(self, full_and_reduced):
+        full_grid, reduced_grid = full_and_reduced
+        ti = full_grid.timeseries.timeindex
+        storage_name = full_grid.topology.storage_units_df.index[0]
+        assert storage_name in reduced_grid.topology.storage_units_df.index
+        assert "old_name" not in reduced_grid.topology.storage_units_df.columns
+
+        reduced_grid.timeseries._storage_units_active_power.loc[ti, storage_name] = [
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+        ]
+        result = spatial_complexity_reduction.apply_reduced_results_to_full_grid(
+            full_grid=full_grid,
+            reduced_grid=reduced_grid,
+            flexible_storage_units=[storage_name],
+        )
+        assert result.timeseries.storage_units_active_power.loc[
+            ti, storage_name
+        ].tolist() == [1.0, 1.0, 1.0, 1.0]
+
+    def test_reactive_power_recomputed_after_restore(self, full_and_reduced):
+        full_grid, reduced_grid = full_and_reduced
+        ti = full_grid.timeseries.timeindex
+        rep = self._first_representative_with(reduced_grid, n_members=1)
+        member = reduced_grid.topology.loads_df.at[rep, "old_name"][0]
+        full_grid.dsm.p_max = pd.DataFrame(1.0, index=ti, columns=[member])
+
+        reactive_before = full_grid.timeseries.loads_reactive_power.loc[
+            ti, member
+        ].copy()
+        reduced_grid.timeseries._loads_active_power.loc[ti, rep] = [
+            50.0,
+            50.0,
+            50.0,
+            50.0,
+        ]
+
+        result = spatial_complexity_reduction.apply_reduced_results_to_full_grid(
+            full_grid=full_grid, reduced_grid=reduced_grid, flexible_loads=[rep]
+        )
+
+        reactive_after = result.timeseries.loads_reactive_power.loc[ti, member]
+        assert not reactive_after.equals(reactive_before)


### PR DESCRIPTION
Partial solution to #705 (spatial complexity reduction pipeline
integration — see `docs_notes/issue_spatial_complexity_reduction_pipeline_integration.md`
for the full issue writeup).

## Summary

Adds spatial complexity reduction to the eDisGo run pipeline, as a
counterpart to the existing temporal complexity reduction
(`select_timesteps`). Spatial reduction merges nearby buses into
representative buses to shrink the grid the OPF runs on; reinforcement
still runs on the full topology.

- New `spatial_reduce` / `spatial_restore` tasks bracketing `optimize`.
  `spatial_reduce` stashes a deepcopy of the full grid and spatially
  reduces the working object; `spatial_restore` writes the optimized
  flexible-component dispatch (charging points, heat pumps, DSM loads,
  storage) back onto the stashed full grid and recomputes reactive power.
  Both are no-ops when `spatial_reduction.enabled` is false.
- New core function `apply_reduced_results_to_full_grid` +
  `EDisGo.map_reduced_results_to_full_grid`, mirroring the existing
  `spatial_complexity_reduction`/`EDisGo.spatial_complexity_reduction`
  pairing.
- Validator integration via the existing `requires`/`provides` capability
  system (no new validator machinery): `spatial_reduce` provides
  `reduced_grid`, `optimize` additionally provides `optimized_dispatch`,
  `spatial_restore` requires both.
- New top-level `spatial_reduction:` config block, mirroring
  `timeseries_selection:` exactly — same shape, same eGo injection pattern
  (global default + per-grid override).
- New preset `uc6_spatial_reduction.yaml` and eGo example
  `scenario_setting_uc6_example.json`.
- eGo: `_build_run_edisgo_config` injects `spatial_reduction`/
  `spatial_reduction_per_grid` the same way it already injects
  `timeseries_selection`.

**This PR covers `aggregation_mode=False` only.** `aggregation_mode=True`
has a known, documented gap unrelated to this PR's own logic — see
"Known limitation" below and the linked issue.

## Testing

- `tests/tools/test_spatial_complexity_reduction.py::TestApplyReducedResultsToFullGrid`
  — by-name write-back, disaggregation-sum exactness, the numpy-array-input
  regression, the time-index-mismatch guard, and reactive-power recompute,
  all against stub OPF results (no Julia/Gurobi dependency).
- `eGo/tests/tools/test_edisgo_integration.py` — the
  `spatial_reduction`/`spatial_reduction_per_grid` injection logic.
- Verified end-to-end against a real grid (32377), both directly through
  eDisGo (`run_example_06.py`) and through eGo
  (`scenario_setting_uc6_example.json`): `spatial_reduce → optimize (Gurobi)
  → spatial_restore → reinforce → save` all completed successfully.
- `analyse_spatial_reduction.ipynb` (not part of this PR, kept local) drives
  the pipeline task-by-task and confirms the reduced grid's OPF output
  exactly matches the full grid's post-restore value for every flexible
  component (0/388 mismatches on the test run).

## Known limitation (tracked, not fixed in this PR)

`aggregation_mode=True` merges loads at the same bus and correctly
aggregates `loads_active_power`, but does not aggregate
`electromobility.flexibility_bands` — the OPF's charging-point constraint
builder reads that separately, keyed by charging-point name, so a merged
representative has no `upper_power` entry and `optimize` raises `KeyError`
before `spatial_restore` ever runs. Only manifests with `aggregation_mode:
true` and 2+ charging points sharing a bus. Full writeup with the exact
traceback and suggested fix in
`docs_notes/issue_aggregation_mode_flexibility_bands_not_aggregated.md`.
`aggregation_mode: false` is the default in the new preset and unaffected.

## Also included

- Fix: `build_flexibility_bands` now trims `electromobility.flexibility_bands`
  to the active time index right after building it — it previously only
  resampled to the active *frequency*, not the active *date range*, so a
  manual/short `select_timesteps` window left bands spanning the full
  underlying data range with nothing ever trimming them down. Unrelated to
  spatial reduction directly, but was blocking end-to-end testing of it
  (see `docs_notes/issue_temporal_reduction_flexibility_bands.md`).
- Fix: `flexible_* or []` in `apply_reduced_results_to_full_grid` raised
  `ValueError` on numpy-array input (`task_optimize` derives
  `flexible_loads` as `edisgo.dsm.p_min.columns.values`, not a list) —
  found on the first live end-to-end run.

## Not in this PR

- `aggregation_mode=True` fix (tracked issue, linked above).
- Pipeline/task-level integration tests for `spatial_reduce`/
  `spatial_restore` (current scope is core-function-only, by design — see
  `docs_notes/spatial_reduction_grilling_session.md`).
- Two ADR candidates flagged during design ("two bracketing tasks, restore
  optional"; "disaggregation by pre-OPF flexibility envelope") — not yet
  written up.