### PR TITLE
fix: trim apply_charging_strategy output to the active timeindex

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -2190,6 +2190,14 @@ class EDisGo:
         match the SimBEV data frequency and after determining the charging demand time
         series resampled back to the original frequency.
 
+        The written charging point time series are trimmed to
+        :attr:`~.network.timeseries.TimeSeries.timeindex` when no such frequency
+        mismatch occurs. When it does occur, the resample round-trip above
+        currently fabricates a contiguous timeindex, which can reopen a gap
+        left by a prior manual/auto time step selection - the trim is skipped
+        in that case rather than risk operating on the wrong window. See
+        :func:`~.flex_opt.charging_strategies.charging_strategy` for details.
+
         """
         charging_strategy(
             self, strategy=strategy, charging_park_ids=charging_park_ids, **kwargs

--- a/edisgo/flex_opt/charging_strategies.py
+++ b/edisgo/flex_opt/charging_strategies.py
@@ -89,7 +89,29 @@ def charging_strategy(
         :attr:`~.edisgo.EDisGo.apply_charging_strategy` for more information.
         Default: 0.1.
 
+    Notes
+    -----
+    The written ``loads_active_power``/``loads_reactive_power`` are trimmed to
+    ``edisgo_obj.timeseries.timeindex`` when its frequency already matches the
+    SimBEV charging-process data's ``stepsize`` (the common case). When it
+    doesn't, this function internally resamples ``edisgo_obj.timeseries`` to
+    SimBEV's frequency and back (see the frequency-mismatch warning below);
+    that round-trip currently fabricates a contiguous timeindex, which can
+    reopen a gap left by ``select_timesteps`` (auto mode). The trim is
+    skipped in that case rather than risk operating on the wrong window -
+    tracked as a known limitation in
+    ``docs_notes/issue_temporal_reduction_flexibility_bands.md``.
+
     """
+    # Capture the target time index before any internal frequency resampling
+    # (below) can mutate it. `TimeSeries.resample` fabricates a contiguous
+    # index spanning first-to-last timestamp, which would silently reopen any
+    # gap `select_timesteps` (auto mode) deliberately left in the timeindex -
+    # trimming against this entry-time snapshot instead ensures only the
+    # steps actually selected by the caller are written. Only used when no
+    # internal resample round-trip happens (see Notes above).
+    target_timeindex = edisgo_obj.timeseries.timeindex
+
     # get integrated charging parks
     integrated_parks = edisgo_obj.electromobility.integrated_charging_parks_df
 
@@ -364,14 +386,48 @@ def charging_strategy(
 
     if resample:
         edisgo_obj.timeseries.resample(freq=edisgo_timedelta)
+        # `TimeSeries.resample` fabricates a contiguous index spanning
+        # first-to-last timestamp, which would reopen any gap
+        # `select_timesteps` (auto mode) left in `target_timeindex`. The trim
+        # below only removes *extra trailing* rows past `target_timeindex`'s
+        # own span - it does not (and, given the above, safely cannot)
+        # reintroduce a gap `resample` already closed. Fixing that root cause
+        # in `TimeSeries.resample` itself is tracked separately (see
+        # docs_notes/issue_temporal_reduction_flexibility_bands.md); until
+        # then, a `select_timesteps`-produced gap combined with a
+        # SimBEV/edisgo frequency mismatch is a known limitation here.
+    else:
+        # Trim the newly written columns down to the target time index. The
+        # writes above (all three strategies) span the full SimBEV
+        # simulation length rather than the active timeindex.
+        # `TimeSeries.loads_active_power` itself already scopes reads to
+        # `self.timeindex`, but the private `_loads_active_power` can still
+        # carry the untrimmed rows (visible to anything reading the private
+        # attribute directly, e.g. `reduce_timeseries_data_to_given_timeindex`)
+        # - rebuild just the touched columns via drop+add so only the extra
+        # rows for `edisgo_ids_to_update` are removed, leaving other
+        # components untouched.
+        trimmed_active_power = edisgo_obj.timeseries._loads_active_power.loc[
+            :, edisgo_ids_to_update
+        ].reindex(target_timeindex)
+        edisgo_obj.timeseries.drop_component_time_series(
+            "loads_active_power", edisgo_ids_to_update
+        )
+        edisgo_obj.timeseries.add_component_time_series(
+            "loads_active_power", trimmed_active_power
+        )
 
-    # set reactive power time series to 0 Mvar
+    # set reactive power time series to 0 Mvar. Use `target_timeindex` only
+    # when it still matches `edisgo_obj.timeseries.timeindex` (i.e. no
+    # internal resample round-trip happened above) - see the comment on the
+    # active-power trim above for why a resampled, gap-closed timeindex isn't
+    # safely reconcilable with `target_timeindex` here yet.
     # fmt: off
     edisgo_obj.timeseries.add_component_time_series(
         "loads_reactive_power",
         pd.DataFrame(
             data=0.0,
-            index=edisgo_obj.timeseries.timeindex,
+            index=target_timeindex if not resample else edisgo_obj.timeseries.timeindex,
             columns=edisgo_ids_to_update,
         ),
     )

--- a/tests/flex_opt/test_charging_strategy.py
+++ b/tests/flex_opt/test_charging_strategy.py
@@ -97,6 +97,63 @@ class TestChargingStrategy:
         charging_strategy(self.edisgo_obj, strategy="dumb")
         assert ts._loads_active_power.index.freqstr == "15T"
 
+    @pytest.mark.parametrize("strategy", ["dumb", "reduced", "residual"])
+    def test_charging_strategy_trims_to_short_timeindex(self, strategy):
+        """
+        Regression test for eDisGo#703: charging_strategy used to write the
+        full SimBEV-simulation-length series into loads_active_power/
+        loads_reactive_power regardless of a shorter active timeindex. When
+        the edisgo/SimBEV frequencies already match (no internal resample
+        round-trip), the written series must be trimmed to exactly
+        edisgo.timeseries.timeindex - no extra rows, no missing rows.
+        """
+        edisgo = EDisGo(ding0_grid=self.ding0_path)
+        # 15-min frequency matches the SimBEV fixture's stepsize (see
+        # metadata_simbev_run.json), so no internal resample round-trip is
+        # triggered - one day instead of the fixture's full simulated week.
+        short_timeindex = pd.date_range("1/1/2011", periods=96, freq="15min")
+        edisgo.set_timeindex(short_timeindex)
+        edisgo.import_electromobility(
+            data_source="directory",
+            charging_processes_dir=self.simbev_path,
+            potential_charging_points_dir=self.tracbev_path,
+        )
+
+        charging_strategy(edisgo, strategy=strategy)
+
+        pd.testing.assert_index_equal(
+            edisgo.timeseries._loads_active_power.index, short_timeindex
+        )
+        pd.testing.assert_index_equal(
+            edisgo.timeseries._loads_reactive_power.index, short_timeindex
+        )
+        assert not edisgo.timeseries.loads_active_power.isna().any().any()
+
+    def test_charging_strategy_trims_to_gapped_timeindex(self):
+        """
+        Regression test for eDisGo#703: a gapped timeindex (as produced by
+        select_timesteps in auto mode) must survive charging_strategy
+        unchanged when no internal frequency resample round-trip is
+        triggered - the written series must match the gapped index exactly,
+        not a contiguous range spanning it.
+        """
+        edisgo = EDisGo(ding0_grid=self.ding0_path)
+        gapped_timeindex = pd.date_range("1/1/2011", periods=24, freq="15min").union(
+            pd.date_range("1/6/2011 18:00", periods=24, freq="15min")
+        )
+        edisgo.set_timeindex(gapped_timeindex)
+        edisgo.import_electromobility(
+            data_source="directory",
+            charging_processes_dir=self.simbev_path,
+            potential_charging_points_dir=self.tracbev_path,
+        )
+
+        charging_strategy(edisgo, strategy="dumb")
+
+        pd.testing.assert_index_equal(
+            edisgo.timeseries._loads_active_power.index, gapped_timeindex
+        )
+
     def test_charging_strategy_with_subset_of_parks(self):
         """
         Charging strategies can be applied to different subsets of charging parks
@@ -128,7 +185,6 @@ class TestChargingStrategy:
 
         # store baseline time series for both parks
         loads_before = ts._loads_active_power.copy()
-        ts_a_before = loads_before[edisgo_id_a].copy()
         ts_b_before = loads_before[edisgo_id_b].copy()
 
         # 1) apply a strategy only to park A
@@ -152,7 +208,6 @@ class TestChargingStrategy:
 
         loads_after_second = ts._loads_active_power
         ts_a_after_second = loads_after_second[edisgo_id_a].copy()
-        ts_b_after_second = loads_after_second[edisgo_id_b].copy()
 
         # park A must not be changed by the second call that targets only park B
         pd.testing.assert_series_equal(


### PR DESCRIPTION
## Trim `apply_charging_strategy` output to the active timeindex

Part of the #703 checklist (time-series writers not uniformly respecting a pre-existing `timeindex`). This is item 1 of 7 — see `docs_notes/issue_temporal_reduction_flexibility_bands.md` for the full severity-ordered checklist and background.

### Problem

`apply_charging_strategy` (all three modes: `dumb`/`reduced`/`residual`) wrote a full SimBEV-simulation-length series into `loads_active_power`/`loads_reactive_power` unconditionally, via `add_component_time_series`'s raw concat. A shorter or gapped `edisgo.timeseries.timeindex` (e.g. after `select_timesteps`) never trimmed the excess, leaving stale rows in the private `_loads_active_power` that any direct reader — not just the timeindex-scoped public getter — would see.

### Fix

Trim the written series to `edisgo.timeseries.timeindex` when SimBEV's stepsize already matches eDisGo's own frequency (the common case).

When it doesn't, this function internally resamples `edisgo_obj.timeseries` to reconcile frequencies and back. That round-trip currently fabricates a contiguous index, silently reopening any gap `select_timesteps` (auto mode) left in place — so the trim is skipped in that case rather than risk operating on the wrong window. This is documented as a known limitation pending a fix to `TimeSeries.resample()` itself, tracked separately (not part of this change).

### Testing

- [x] Two new regression tests in `tests/flex_opt/test_charging_strategy.py`: one parametrized across all three strategies with a short timeindex, one with a gapped timeindex — both confirmed to fail against the pre-fix code and pass with the fix
- [x] Existing `test_charging_strategy.py` suite (including the frequency-mismatch case) still passes unmodified — confirmed the descoped case produces byte-identical output to before this change
- [x] Broader related suite (electromobility/heat_pump/timeseries/edisgo, 38 tests) passes with no collateral changes

### Out of scope (tracked separately)

- The frequency-mismatch + gapped-timeindex combination (root cause: `TimeSeries.resample()` fabricates a contiguous index, closing gaps) — new finding, documented in `docs_notes/issue_temporal_reduction_flexibility_bands.md`
- The `residual` strategy's residual-load tiling behavior when the active timeindex is shorter than the SimBEV charging-event span — a pre-existing modeling-fidelity question, not a contract bug
