### PR TITLE
fix: scope apply_heat_pump_operating_strategy output to the active ti…

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -2376,6 +2376,16 @@ class EDisGo:
             pumps for which COP information in :attr:`~.edisgo.EDisGo.heat_pump` is
             given are used. Default: None.
 
+        Notes
+        -----
+        The written load time series are scoped to
+        :attr:`~.network.timeseries.TimeSeries.timeindex`, regardless of
+        whether :attr:`~.edisgo.EDisGo.heat_pump`'s COP/heat demand time
+        series currently span a wider or different range. Raises
+        ``KeyError`` if they are missing data for a time step in the active
+        timeindex - see :func:`~.flex_opt.heat_pump_operation.operating_strategy`
+        for details.
+
         """
         hp_operating_strategy(self, strategy=strategy, heat_pump_names=heat_pump_names)
 

--- a/edisgo/flex_opt/heat_pump_operation.py
+++ b/edisgo/flex_opt/heat_pump_operation.py
@@ -38,14 +38,33 @@ def operating_strategy(
         parameter in :attr:`~.edisgo.EDisGo.apply_heat_pump_operating_strategy` for
         more information. Default: None.
 
+    Notes
+    -----
+    The written ``loads_active_power`` is scoped to
+    ``edisgo_obj.timeseries.timeindex``, regardless of whether
+    ``edisgo_obj.heat_pump.heat_demand_df``/``cop_df`` currently span a wider
+    or different range (e.g. because the timeindex changed after
+    :attr:`~.edisgo.EDisGo.import_heat_pumps` ran). Raises ``KeyError`` if
+    either is missing data for a time step in ``timeindex`` - this is
+    data-staleness the caller should fix (re-import or re-set the heat pump
+    time series for the active timeindex), not something to silently paper
+    over.
+
     """
     if heat_pump_names is None:
         heat_pump_names = edisgo_obj.heat_pump.cop_df.columns
 
     if strategy == "uncontrolled":
+        # Scope to the active timeindex explicitly rather than relying on
+        # heat_demand_df/cop_df already matching it - import_heat_pumps trims
+        # both to the timeindex active at import time, but nothing re-trims
+        # them if the timeindex changes afterward (e.g. a later
+        # select_timesteps step), which would otherwise silently write rows
+        # outside the current timeindex into loads_active_power.
+        timeindex = edisgo_obj.timeseries.timeindex
         ts = (
-            edisgo_obj.heat_pump.heat_demand_df.loc[:, heat_pump_names]
-            / edisgo_obj.heat_pump.cop_df.loc[:, heat_pump_names]
+            edisgo_obj.heat_pump.heat_demand_df.loc[timeindex, heat_pump_names]
+            / edisgo_obj.heat_pump.cop_df.loc[timeindex, heat_pump_names]
         )
         edisgo_obj.timeseries.add_component_time_series(
             "loads_active_power",

--- a/tests/flex_opt/test_heat_pump_operation.py
+++ b/tests/flex_opt/test_heat_pump_operation.py
@@ -70,3 +70,32 @@ class TestHeatPumpOperation:
         msg = "Heat pump operating strategy dummy is not a valid option."
         with pytest.raises(ValueError, match=msg):
             operating_strategy(self.edisgo, strategy="dummy")
+
+    def test_operating_strategy_trims_to_short_timeindex(self):
+        """
+        Regression test for eDisGo#703: operating_strategy used to write
+        loads_active_power over the full span of heat_demand_df/cop_df
+        regardless of the active edisgo.timeseries.timeindex. When those are
+        wider or shifted relative to the active timeindex (e.g. because the
+        timeindex changed after import_heat_pumps ran), the written series
+        must be trimmed to exactly edisgo.timeseries.timeindex.
+        """
+        timeindex = pd.date_range("1/1/2011 12:00", periods=2, freq="H")
+        wide_timeindex = pd.date_range("1/1/2011", periods=24, freq="H")
+
+        edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path, timeindex=timeindex)
+        edisgo.heat_pump.cop_df = pd.DataFrame(
+            data={"hp1": [5.0] * 24, "hp2": [7.0] * 24}, index=wide_timeindex
+        )
+        edisgo.heat_pump.heat_demand_df = pd.DataFrame(
+            data={"hp1": [1.0] * 24, "hp2": [3.0] * 24}, index=wide_timeindex
+        )
+
+        operating_strategy(edisgo)
+
+        pd.testing.assert_index_equal(
+            edisgo.timeseries._loads_active_power.index, timeindex
+        )
+        pd.testing.assert_index_equal(
+            edisgo.timeseries._loads_reactive_power.index, timeindex
+        )


### PR DESCRIPTION
## Scope `apply_heat_pump_operating_strategy` output to the active timeindex

Part of the #703 checklist (time-series writers not uniformly respecting a pre-existing `timeindex`). Item 2 of 7 — see `docs_notes/issue_temporal_reduction_flexibility_bands.md` for the full checklist.

### Problem

`operating_strategy` computed `loads_active_power` (`heat_demand_df / cop_df`) using **all rows** of whatever index those two DataFrames happen to have — no scoping to `edisgo.timeseries.timeindex`. `import_heat_pumps` trims both to the timeindex active at import time, but nothing re-trims them if the timeindex changes afterward (e.g. a later `select_timesteps` step). Any such staleness would silently propagate into `loads_active_power` via `add_component_time_series`'s raw concat.

### Fix

Scope both operands to `edisgo.timeseries.timeindex` via `.loc[]` before dividing. This **raises `KeyError`** if `heat_demand_df`/`cop_df` are missing data for a time step in the active timeindex, rather than silently writing rows outside it — this is data staleness the caller should fix (re-import or re-set the heat pump time series), not something to paper over silently.

### Testing

- [x] New regression test confirms a wider/stale `heat_demand_df`/`cop_df` no longer leaks extra rows into `loads_active_power` — fails against the pre-fix code, passes with the fix
- [x] Existing `test_heat_pump_operation.py` suite passes unmodified
- [x] Broader related suite (heat_pump/timeseries/edisgo, 36 tests) passes with no collateral changes
