### PR TITLE
Fix/703 set time series manual

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -79,6 +79,38 @@ if "READTHEDOCS" not in os.environ:
 logger = logging.getLogger(__name__)
 
 
+def _check_timeindex_coverage(timeindex, name, df):
+    """
+    Raises ``ValueError`` if `df` has columns but is missing data for a time
+    step in `timeindex`.
+
+    Used by :attr:`~.edisgo.EDisGo.set_time_series_manual` to enforce that
+    user-provided time series actually cover the active timeindex, instead of
+    silently writing a partially- or non-overlapping series. A DataFrame with
+    no columns is exempt - nothing is being written, so there is nothing to
+    validate coverage for.
+
+    Parameters
+    ----------
+    timeindex : :pandas:`pandas.DatetimeIndex<DatetimeIndex>`
+        Time index to check coverage against. Assumed non-empty by the
+        caller.
+    name : str
+        Parameter name to reference in the raised error message.
+    df : :pandas:`pandas.DataFrame<DataFrame>` or None
+        DataFrame to check. Skipped if ``None`` or has no columns.
+
+    """
+    if df is None or df.shape[1] == 0:
+        return
+    missing = timeindex.difference(df.index)
+    if len(missing) > 0:
+        raise ValueError(
+            f"'{name}' does not cover the current timeindex - missing time "
+            f"steps: {list(missing)}."
+        )
+
+
 class EDisGo:
     """
     Provides the top-level API for invocation of data import, power flow
@@ -351,7 +383,11 @@ class EDisGo:
         providing the input parameter 'timeindex' or using the function
         :attr:`~.edisgo.EDisGo.set_timeindex`.
         Also make sure that the time steps for which time series are provided include
-        the set time index.
+        the set time index - this is now enforced: a `ValueError` is raised if a
+        non-empty DataFrame is missing data for a time step in
+        :attr:`~.network.timeseries.TimeSeries.timeindex` when a time index is
+        already set. A DataFrame with no columns is exempt from this check (nothing
+        is being written, so there is nothing to validate coverage for).
 
         """
         # check if time index is already set, otherwise raise warning
@@ -362,6 +398,16 @@ class EDisGo:
                 "upon initialisation of the EDisGo object by providing the input "
                 "parameter 'timeindex' or using the function EDisGo.set_timeindex()."
             )
+        else:
+            for name, df in (
+                ("generators_p", generators_p),
+                ("loads_p", loads_p),
+                ("storage_units_p", storage_units_p),
+                ("generators_q", generators_q),
+                ("loads_q", loads_q),
+                ("storage_units_q", storage_units_q),
+            ):
+                _check_timeindex_coverage(self.timeseries.timeindex, name, df)
         self.timeseries.set_active_power_manual(
             self,
             ts_generators=generators_p,

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -164,7 +164,60 @@ class TestEDisGo:
             storage_units_ts, self.edisgo.timeseries.storage_units_reactive_power
         )
 
-    def test_set_time_series_active_power_predefined_demandlib_auto_sets_timeindex(self):
+    def test_set_time_series_manual_raises_on_missing_timesteps(self):
+        """
+        Regression test for eDisGo#703: set_time_series_manual used to
+        silently accept a DataFrame missing time steps required by the
+        active timeindex. It must now raise ValueError instead.
+        """
+        timeindex = pd.date_range("1/1/2018", periods=3, freq="H")
+        self.edisgo.set_timeindex(timeindex)
+
+        # only 2 of the 3 required time steps
+        incomplete_ts = pd.DataFrame(
+            data={"GeneratorFluctuating_15": [2.0, 5.0]},
+            index=timeindex[:2],
+        )
+
+        with pytest.raises(ValueError, match="generators_p"):
+            self.edisgo.set_time_series_manual(generators_p=incomplete_ts)
+
+    def test_set_time_series_manual_exempts_zero_column_dataframe(self):
+        """
+        A DataFrame with no columns writes nothing, so it must be exempt
+        from the timeindex-coverage check even if its (empty) column
+        selection would otherwise be checked against a mismatched index.
+        Mirrors a real eGo call site that passes such a DataFrame as a
+        no-op placeholder.
+        """
+        timeindex = pd.date_range("1/1/2018", periods=3, freq="H")
+        self.edisgo.set_timeindex(timeindex)
+
+        empty_cols_ts = pd.DataFrame(index=pd.date_range("1/1/1970", periods=1))
+
+        # must not raise
+        self.edisgo.set_time_series_manual(generators_q=empty_cols_ts)
+
+    def test_set_time_series_manual_allows_covering_superset(self):
+        """
+        A DataFrame covering the active timeindex (even as a superset with
+        extra time steps outside it) must still be accepted.
+        """
+        timeindex = pd.date_range("1/1/2018", periods=3, freq="H")
+        self.edisgo.set_timeindex(timeindex)
+
+        wider_timeindex = pd.date_range("1/1/2018", periods=5, freq="H")
+        wider_ts = pd.DataFrame(
+            data={"GeneratorFluctuating_15": [2.0, 5.0, 6.0, 7.0, 8.0]},
+            index=wider_timeindex,
+        )
+
+        # must not raise
+        self.edisgo.set_time_series_manual(generators_p=wider_ts)
+
+    def test_set_time_series_active_power_predefined_demandlib_auto_sets_timeindex(
+        self,
+    ):
         edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
         # Ensure timeindex is empty initially
         assert edisgo.timeseries.timeindex.empty
@@ -219,7 +272,9 @@ class TestEDisGo:
 
         # check warning
         self.edisgo.set_time_series_active_power_predefined()
-        assert "No timeindex was set. TimeSeries.timeindex is automatically" in caplog.text
+        assert (
+            "No timeindex was set. TimeSeries.timeindex is automatically" in caplog.text
+        )
 
         # check if right functions are called
         timeindex = pd.date_range("1/1/2011 12:00", periods=2, freq="H")
@@ -422,7 +477,8 @@ class TestEDisGo:
         except Exception as e:
             if "Table does not exist" in str(e) or "HTTP 404" in str(e):
                 pytest.skip(
-                    "Database table not accessible (requires external database connection)"
+                    "Database table not accessible (requires external database "
+                    "connection)"
                 )
             else:
                 raise


### PR DESCRIPTION
## Raise `ValueError` when `set_time_series_manual` data misses timesteps

Part of the #703 checklist (time-series writers not uniformly respecting a pre-existing `timeindex`). Item 3 of 7 — see `docs_notes/issue_temporal_reduction_flexibility_bands.md` for the full checklist.

### Problem

`set_time_series_manual` only warned when no time index was set, but never validated that a user-supplied DataFrame actually covers a pre-existing `edisgo.timeseries.timeindex`. A DataFrame missing required timestamps was silently accepted and concatenated via `add_component_time_series`'s raw concat, leaving a partially-populated (`NaN`-gapped) series with no indication anything was wrong.

### Fix

Added a coverage check: raise `ValueError` naming the missing timestamps when a non-empty DataFrame doesn't cover the active `timeindex`. Two exemptions, both required for existing behavior to keep working:

- **Skip entirely when the timeindex is empty** — this is the documented "set data first, timeindex later" workflow, and there's nothing meaningful to validate coverage against.
- **Skip DataFrames with zero columns** — nothing is written, so there's nothing to check. Confirmed necessary: eGo's `edisgo_integration.py` has a real call site passing a zero-column DataFrame as a placeholder no-op.

### Testing

- [x] New regression tests: missing-timestamps DataFrame raises `ValueError` (fails against the pre-fix code, passes with the fix), zero-column DataFrame is exempt, a covering superset DataFrame still works
- [x] All existing tests touching this path (`test_edisgo.py`, `test_timeseries.py`, `test_tasks.py`) pass unmodified
- [x] Broader related suite (edisgo/timeseries/tasks/flex_opt, 134 tests) passes with no collateral changes

### Also included

Fixed three pre-existing `E501` (line-too-long) lint findings in `tests/test_edisgo.py`, unrelated to this change but blocking the pre-commit hook on this file.
