### PR TITLE
fix: scope predefined_* self-provided-DataFrame inputs to the timeindex

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -69,6 +69,7 @@ from edisgo.tools.spatial_complexity_reduction import (
     spatial_complexity_reduction,
 )
 from edisgo.tools.tools import (
+    check_timeindex_coverage,
     determine_grid_integration_voltage_level,
     get_path_length_to_station,
 )
@@ -77,38 +78,6 @@ if "READTHEDOCS" not in os.environ:
     from shapely.geometry import Point
 
 logger = logging.getLogger(__name__)
-
-
-def _check_timeindex_coverage(timeindex, name, df):
-    """
-    Raises ``ValueError`` if `df` has columns but is missing data for a time
-    step in `timeindex`.
-
-    Used by :attr:`~.edisgo.EDisGo.set_time_series_manual` to enforce that
-    user-provided time series actually cover the active timeindex, instead of
-    silently writing a partially- or non-overlapping series. A DataFrame with
-    no columns is exempt - nothing is being written, so there is nothing to
-    validate coverage for.
-
-    Parameters
-    ----------
-    timeindex : :pandas:`pandas.DatetimeIndex<DatetimeIndex>`
-        Time index to check coverage against. Assumed non-empty by the
-        caller.
-    name : str
-        Parameter name to reference in the raised error message.
-    df : :pandas:`pandas.DataFrame<DataFrame>` or None
-        DataFrame to check. Skipped if ``None`` or has no columns.
-
-    """
-    if df is None or df.shape[1] == 0:
-        return
-    missing = timeindex.difference(df.index)
-    if len(missing) > 0:
-        raise ValueError(
-            f"'{name}' does not cover the current timeindex - missing time "
-            f"steps: {list(missing)}."
-        )
 
 
 class EDisGo:
@@ -407,7 +376,7 @@ class EDisGo:
                 ("loads_q", loads_q),
                 ("storage_units_q", storage_units_q),
             ):
-                _check_timeindex_coverage(self.timeseries.timeindex, name, df)
+                check_timeindex_coverage(self.timeseries.timeindex, name, df)
         self.timeseries.set_active_power_manual(
             self,
             ts_generators=generators_p,

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -23,7 +23,11 @@ import pandas as pd
 
 from edisgo.flex_opt import q_control
 from edisgo.io import timeseries_import
-from edisgo.tools.tools import assign_voltage_level_to_component, resample
+from edisgo.tools.tools import (
+    assign_voltage_level_to_component,
+    check_timeindex_coverage,
+    resample,
+)
 
 if TYPE_CHECKING:
     from edisgo import EDisGo
@@ -1264,6 +1268,14 @@ class TimeSeries:
             `ts_generators` is 'oedb' and new ding0 grids with geo-referenced LV grids
             are used.
 
+        Notes
+        -----
+        When `ts_generators` is a self-provided DataFrame and a timeindex is
+        already set on `edisgo_object`, its index must cover that timeindex -
+        a `ValueError` is raised naming any missing time steps, rather than
+        silently writing a partially-covering series. Not checked for the
+        `'oedb'` option, which is already scoped to the timeindex.
+
         """
         # in case time series from oedb are used, retrieve oedb time series
         if isinstance(ts_generators, str) and ts_generators == "oedb":
@@ -1279,6 +1291,13 @@ class TimeSeries:
             raise ValueError(
                 "'ts_generators' must either be a pandas DataFrame or 'oedb'."
             )
+        else:
+            # self-provided DataFrame - the oedb path above is already scoped
+            # to edisgo_object's timeindex by feedin_oedb/feedin_oedb_legacy
+            if not edisgo_object.timeseries.timeindex.empty:
+                check_timeindex_coverage(
+                    edisgo_object.timeseries.timeindex, "ts_generators", ts_generators
+                )
 
         # set generator_names if None
         if generator_names is None:
@@ -1361,9 +1380,20 @@ class TimeSeries:
             'other', all dispatchable generators in the network (i.e. all but solar and
             wind generators) are used.
 
+        Notes
+        -----
+        If a timeindex is already set on `edisgo_object`, `ts_generators`'
+        index must cover it - a `ValueError` is raised naming any missing
+        time steps, rather than silently writing a partially-covering
+        series.
+
         """
         if not isinstance(ts_generators, pd.DataFrame):
             raise ValueError("'ts_generators' must be a pandas DataFrame.")
+        if not edisgo_object.timeseries.timeindex.empty:
+            check_timeindex_coverage(
+                edisgo_object.timeseries.timeindex, "ts_generators", ts_generators
+            )
 
         # write to TimeSeriesRaw
         for col in ts_generators:
@@ -1444,6 +1474,14 @@ class TimeSeries:
             in :func:`edisgo.io.timeseries_import.load_time_series_demandlib` for
             more information.
 
+        Notes
+        -----
+        When `ts_loads` is a self-provided DataFrame and a timeindex is
+        already set on `edisgo_object`, its index must cover that timeindex -
+        a `ValueError` is raised naming any missing time steps, rather than
+        silently writing a partially-covering series. Not checked for the
+        `'demandlib'` option, which is already scoped to the timeindex.
+
         """
         # in case time series from demandlib are used, retrieve demandlib time series
         if isinstance(ts_loads, str) and ts_loads == "demandlib":
@@ -1457,6 +1495,12 @@ class TimeSeries:
         elif ts_loads.empty:
             logger.warning("The profile you entered is empty. Method is skipped.")
             return
+        elif not edisgo_object.timeseries.timeindex.empty:
+            # self-provided DataFrame - the demandlib path above is already
+            # scoped to edisgo_object's timeindex by load_time_series_demandlib
+            check_timeindex_coverage(
+                edisgo_object.timeseries.timeindex, "ts_loads", ts_loads
+            )
 
         # write to TimeSeriesRaw
         for col in ts_loads:
@@ -1520,12 +1564,23 @@ class TimeSeries:
             If None, all charging points of use cases for which use-case-specific time
             series are provided are used.
 
+        Notes
+        -----
+        If a timeindex is already set on `edisgo_object`, `ts_loads`' index
+        must cover that timeindex - a `ValueError` is raised naming any
+        missing time steps, rather than silently writing a
+        partially-covering series.
+
         """
         if not isinstance(ts_loads, pd.DataFrame):
             raise ValueError("'ts_loads' must be a pandas DataFrame.")
         elif ts_loads.empty:
             logger.warning("The profile you entered is empty. Method is skipped.")
             return
+        elif not edisgo_object.timeseries.timeindex.empty:
+            check_timeindex_coverage(
+                edisgo_object.timeseries.timeindex, "ts_loads", ts_loads
+            )
 
         # write to TimeSeriesRaw
         for col in ts_loads:

--- a/edisgo/tools/tools.py
+++ b/edisgo/tools/tools.py
@@ -87,6 +87,40 @@ def align_series_to_timeindex(ts, timeindex, extra_step=False):
     return ts.reindex(target)
 
 
+def check_timeindex_coverage(timeindex, name, df):
+    """
+    Raises ``ValueError`` if `df` has columns but is missing data for a time
+    step in `timeindex`.
+
+    Used by :attr:`~.edisgo.EDisGo.set_time_series_manual` and the
+    self-provided-DataFrame options of
+    :class:`~.network.timeseries.TimeSeries`'s ``predefined_*`` methods to
+    enforce that user-provided time series actually cover the active
+    timeindex, instead of silently writing a partially- or non-overlapping
+    series. A DataFrame with no columns is exempt - nothing is being
+    written, so there is nothing to validate coverage for.
+
+    Parameters
+    ----------
+    timeindex : :pandas:`pandas.DatetimeIndex<DatetimeIndex>`
+        Time index to check coverage against. Assumed non-empty by the
+        caller.
+    name : str
+        Parameter name to reference in the raised error message.
+    df : :pandas:`pandas.DataFrame<DataFrame>` or None
+        DataFrame to check. Skipped if ``None`` or has no columns.
+
+    """
+    if df is None or df.shape[1] == 0:
+        return
+    missing = timeindex.difference(df.index)
+    if len(missing) > 0:
+        raise ValueError(
+            f"'{name}' does not cover the current timeindex - missing time "
+            f"steps: {list(missing)}."
+        )
+
+
 def select_worstcase_snapshots(edisgo_obj):
     """
     Select two worst-case snapshots from time series

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -1403,6 +1403,27 @@ class TestTimeSeries:
         )
         # fmt: on
 
+    def test_predefined_fluctuating_generators_by_technology_missing_timesteps(
+        self,
+    ):
+        """
+        Regression test for eDisGo#703: the self-provided-DataFrame path
+        used to silently accept a DataFrame missing time steps required by
+        the active timeindex.
+        """
+        timeindex = pd.date_range("1/1/2011 12:00", periods=2, freq="H")
+        self.edisgo.timeseries.timeindex = timeindex
+
+        incomplete_ts = pd.DataFrame(
+            data={"wind": [1], "solar": [3]},
+            index=timeindex[:1],
+        )
+
+        with pytest.raises(ValueError, match="ts_generators"):
+            self.edisgo.timeseries.predefined_fluctuating_generators_by_technology(
+                self.edisgo, incomplete_ts
+            )
+
     def test_predefined_fluctuating_generators_by_technology_oedb(self):
         edisgo_object = EDisGo(
             ding0_grid=pytest.ding0_test_network_3_path, legacy_ding0_grids=False
@@ -1547,6 +1568,27 @@ class TestTimeSeries:
             check_dtype=False,
         )
         # fmt: on
+
+    def test_predefined_dispatchable_generators_by_technology_missing_timesteps(
+        self,
+    ):
+        """
+        Regression test for eDisGo#703: the self-provided-DataFrame path
+        used to silently accept a DataFrame missing time steps required by
+        the active timeindex.
+        """
+        timeindex = pd.date_range("1/1/2011 12:00", periods=2, freq="H")
+        self.edisgo.timeseries.timeindex = timeindex
+
+        incomplete_ts = pd.DataFrame(
+            data={"other": [5]},
+            index=timeindex[:1],
+        )
+
+        with pytest.raises(ValueError, match="ts_generators"):
+            self.edisgo.timeseries.predefined_dispatchable_generators_by_technology(
+                self.edisgo, incomplete_ts
+            )
 
     def test_predefined_conventional_loads_by_sector(self, caplog):
         index = pd.date_range("1/1/2018", periods=3, freq="H")
@@ -1812,6 +1854,27 @@ class TestTimeSeries:
             original_annual_consumption
         )
 
+    def test_predefined_conventional_loads_by_sector_raises_on_missing_timesteps(
+        self,
+    ):
+        """
+        Regression test for eDisGo#703: the self-provided-DataFrame path
+        used to silently accept a DataFrame missing time steps required by
+        the active timeindex.
+        """
+        timeindex = pd.date_range("1/1/2018", periods=3, freq="H")
+        self.edisgo.timeseries.timeindex = timeindex
+
+        incomplete_ts = pd.DataFrame(
+            data={"residential": [1, 2]},
+            index=timeindex[:2],
+        )
+
+        with pytest.raises(ValueError, match="ts_loads"):
+            self.edisgo.timeseries.predefined_conventional_loads_by_sector(
+                self.edisgo, incomplete_ts
+            )
+
     def test_predefined_charging_points_by_use_case(self, caplog):
         index = pd.date_range("1/1/2018", periods=3, freq="H")
         self.edisgo.timeseries.timeindex = index
@@ -1918,6 +1981,27 @@ class TestTimeSeries:
             charging_points_active_power_by_use_case.shape\
                == (3, 5)
         # fmt: on
+
+    def test_predefined_charging_points_by_use_case_raises_on_missing_timesteps(
+        self,
+    ):
+        """
+        Regression test for eDisGo#703: the self-provided-DataFrame path
+        used to silently accept a DataFrame missing time steps required by
+        the active timeindex.
+        """
+        timeindex = pd.date_range("1/1/2018", periods=3, freq="H")
+        self.edisgo.timeseries.timeindex = timeindex
+
+        incomplete_ts = pd.DataFrame(
+            data={"home": [1, 2]},
+            index=timeindex[:2],
+        )
+
+        with pytest.raises(ValueError, match="ts_loads"):
+            self.edisgo.timeseries.predefined_charging_points_by_use_case(
+                self.edisgo, incomplete_ts
+            )
 
     def test_fixed_cosphi(self):
         # set active power time series for fixed cosphi
@@ -2339,8 +2423,8 @@ class TestTimeSeries:
                 setattr(self.edisgo.timeseries, attr, ts_tmp_duplicated)
                 self.edisgo.timeseries.check_integrity()
                 assert (
-                    f"{attr} has duplicated columns: {ts_tmp.iloc[:, 0:2].columns.values}"
-                    in caplog.text
+                    f"{attr} has duplicated columns: "
+                    f"{ts_tmp.iloc[:, 0:2].columns.values}" in caplog.text
                 )
                 caplog.clear()
                 setattr(self.edisgo.timeseries, attr, ts_tmp)


### PR DESCRIPTION
## Scope `predefined_*` self-provided-DataFrame inputs to the active timeindex

Part of the #703 checklist (time-series writers not uniformly respecting a pre-existing `timeindex`). Item 4 of 7 — see `docs_notes/issue_temporal_reduction_flexibility_bands.md` for the full checklist.

### Problem

The self-provided-DataFrame branches of `TimeSeries`'s four `predefined_*` methods (`predefined_fluctuating_generators_by_technology`, `predefined_dispatchable_generators_by_technology`, `predefined_conventional_loads_by_sector`, `predefined_charging_points_by_use_case`) had no coverage check against `edisgo.timeseries.timeindex` — same gap as `set_time_series_manual` (#712), just at different call sites. Their `'oedb'`/`'demandlib'` string-option siblings were already correctly scoped via `_timeindex_helper_func`.

### Fix

Reused the `check_timeindex_coverage` helper from #712, relocated from `edisgo.py` to `edisgo/tools/tools.py` (both `edisgo.py` and `edisgo/network/timeseries.py` need it; a direct cross-import the other way would be circular). Applied it to all four self-provided-DataFrame branches, right after their existing type/emptiness validation.

### Testing

- [x] New regression test per method (4 total) — each confirms a DataFrame missing timesteps raises `ValueError`; fails against the pre-fix code, passes with the fix
- [x] Existing `test_timeseries.py` suite passes unmodified (one pre-existing DB-dependent test in the same file was already skipped in this environment, unrelated to this change)
- [x] Broader related suite (edisgo/network/run/flex_opt, 240 tests) passes with no collateral changes

### Also included

Fixed one pre-existing `E501` (line-too-long) lint finding in `tests/network/test_timeseries.py`, unrelated to this change but blocking the pre-commit hook on this file.
