### PR TITLE
fix: scope get_flexibility_bands to the active timeindex

### DIFF
--- a/edisgo/network/electromobility.py
+++ b/edisgo/network/electromobility.py
@@ -23,6 +23,7 @@ import pandas as pd
 from sklearn import preprocessing
 
 from edisgo.network.components import PotentialChargingParks
+from edisgo.tools.tools import align_series_to_timeindex
 
 if "READTHEDOCS" not in os.environ:
     import geopandas as gpd
@@ -396,6 +397,21 @@ class Electromobility:
             for more information. To avoid this behaviour, set `tol` to 0.0.
             Default: 1e-6.
 
+        Notes
+        -----
+        The bands are always built spanning SimBEV's own native calendar and
+        simulated date range (independent of ``edisgo_obj.timeseries.timeindex``
+        - a charging process straddling a later window's boundary must still
+        count toward the band inside that window). If
+        ``edisgo_obj.timeseries.timeindex`` is non-empty, the returned/stored
+        bands are then year-aligned (SimBEV's calendar is commonly a fixed
+        reference year, independent of the scenario year) and trimmed to
+        exactly that timeindex - this is done regardless of `resample`, since
+        it is a correctness fix (avoiding a ``KeyError`` when a consumer later
+        indexes the bands by ``edisgo_obj.timeseries.timeindex``), not an
+        optional resampling convenience. When the timeindex is empty, the
+        bands are returned untouched, spanning SimBEV's own range/calendar.
+
         Returns
         --------
         dict(str, :pandas:`pandas.DataFrame<DataFrame>`)
@@ -582,15 +598,26 @@ class Electromobility:
 
         # sanity check
         self.check_integrity()
-        # check time index
+
+        # Scope the bands to edisgo_obj's own timeindex, so this method is
+        # correct regardless of caller (not just the run pipeline, which
+        # previously had to patch this up itself via
+        # reduce_timeseries_data_to_given_timeindex right after calling this
+        # method). The bands built above always span SimBEV's own native
+        # calendar (its start_date, typically a fixed reference year like
+        # 2011) and simulated range - independent of edisgo_timeindex, which
+        # is why this can't just be a `.loc[edisgo_timeindex]` here: a year
+        # mismatch alone would raise KeyError, and a shorter/different-range
+        # edisgo_timeindex would too. align_series_to_timeindex year-shifts
+        # and reindexes (filling any still-missing steps with NaN rather than
+        # raising) before the final trim below.
         if len(edisgo_timeindex) > 0:
-            missing_indices = [_ for _ in edisgo_timeindex if _ not in flex_band_index]
-            if len(missing_indices) > 0:
-                logger.warning(
-                    "There are time steps in timeindex of TimeSeries object that "
-                    "are not in the index of the flexibility bands. This may lead "
-                    "to problems."
-                )
+            for key, df in self.flexibility_bands.items():
+                if not df.empty:
+                    self.flexibility_bands[key] = align_series_to_timeindex(
+                        df, edisgo_timeindex
+                    ).loc[edisgo_timeindex]
+
         return self.flexibility_bands
 
     def fix_flexibility_bands_rounding_errors(self, tol=1e-6):

--- a/edisgo/run/tasks/flex.py
+++ b/edisgo/run/tasks/flex.py
@@ -210,19 +210,16 @@ def task_build_flexibility_bands(edisgo, ctx, *, use_case=None):
     :func:`task_import_electromobility` can do inline. Running it as a
     separate step lets it execute *after* the analysis time index is fixed
     (e.g. after ``oedb_ts`` / timestep selection), so
-    :meth:`Electromobility.get_flexibility_bands` resamples the bands to the
-    edisgo time-series frequency instead of leaving them at the raw SimBEV
-    resolution. This mirrors how the heat-pump time series are set outside
-    ``import_heat_pumps``, and is more efficient than building bands over a
-    non-final index.
+    :meth:`Electromobility.get_flexibility_bands` resamples/scopes the bands
+    to the edisgo time-series frequency and timeindex instead of leaving
+    them at the raw SimBEV resolution and range. This mirrors how the
+    heat-pump time series are set outside ``import_heat_pumps``, and is more
+    efficient than building bands over a non-final index.
 
-    ``get_flexibility_bands`` only resamples to the active *frequency* - the
-    bands still span whatever date range the underlying SimBEV charging-
-    process data covers, which is not necessarily the same range as
-    ``edisgo.timeseries.timeindex`` (e.g. a manually-selected window). This
-    task additionally trims the bands down to that exact index, so
-    ``electromobility.flexibility_bands`` always matches
-    ``edisgo.timeseries.timeindex`` after this step runs.
+    ``get_flexibility_bands`` itself year-aligns and trims the bands down to
+    ``edisgo.timeseries.timeindex`` (see its docstring) whenever that
+    timeindex is non-empty, so ``electromobility.flexibility_bands`` always
+    matches it after this step runs - no separate trim call needed here.
 
     Parameters
     ----------
@@ -240,20 +237,9 @@ def task_build_flexibility_bands(edisgo, ctx, *, use_case=None):
     edisgo.EDisGo
         The modified EDisGo instance.
     """
-    from edisgo.tools.tools import reduce_timeseries_data_to_given_timeindex
-
     if use_case is None:
         use_case = ["home", "work", "public", "hpc"]
     edisgo.electromobility.get_flexibility_bands(edisgo, use_case=use_case)
-    reduce_timeseries_data_to_given_timeindex(
-        edisgo,
-        edisgo.timeseries.timeindex,
-        timeseries=False,
-        electromobility=True,
-        heat_pump=False,
-        dsm=False,
-        overlying_grid=False,
-    )
     return edisgo
 
 

--- a/tests/network/test_electromobility.py
+++ b/tests/network/test_electromobility.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_index_equal
 
 from edisgo.edisgo import EDisGo
 from edisgo.io import electromobility_import
@@ -184,6 +184,60 @@ class TestElectromobility:
             "upper_energy"
         ].index
         assert (flex_bands_index[1] - flex_bands_index[0]) == pd.Timedelta("1H")
+
+    def test_get_flexibility_bands_scopes_to_mismatched_timeindex(self):
+        """
+        Regression test for eDisGo#703: get_flexibility_bands used to build
+        bands spanning SimBEV's own native calendar/range only, with no
+        alignment to edisgo.timeseries.timeindex - indexing the bands by a
+        timeindex in a different year (SimBEV's start_date here is 2011)
+        and/or a shorter window than SimBEV's simulated range raised
+        KeyError. The bands must now be year-aligned and trimmed to exactly
+        that timeindex.
+        """
+        edisgo_obj = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo_obj, self.simbev_path, self.tracbev_path
+        )
+        electromobility_import.distribute_charging_demand(edisgo_obj)
+        electromobility_import.integrate_charging_parks(edisgo_obj)
+
+        assert edisgo_obj.electromobility.simbev_config_df.start_date.values[
+            0
+        ] == np.datetime64("2011-01-01")
+        short_timeindex = pd.date_range("2035-01-15", periods=24, freq="h")
+        edisgo_obj.set_timeindex(short_timeindex)
+
+        bands = edisgo_obj.electromobility.get_flexibility_bands(
+            edisgo_obj, ["work", "public"]
+        )
+
+        for key in ("upper_power", "lower_energy", "upper_energy"):
+            assert_index_equal(bands[key].index, short_timeindex)
+            # must not raise KeyError
+            edisgo_obj.electromobility.flexibility_bands[key].loc[short_timeindex]
+
+    def test_get_flexibility_bands_empty_timeindex_is_a_no_op(self):
+        """
+        With no timeindex set at all, get_flexibility_bands must return the
+        bands untouched, spanning SimBEV's own native calendar/range - there
+        is nothing to align/trim against yet.
+        """
+        edisgo_obj = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo_obj, self.simbev_path, self.tracbev_path
+        )
+        electromobility_import.distribute_charging_demand(edisgo_obj)
+        electromobility_import.integrate_charging_parks(edisgo_obj)
+
+        assert edisgo_obj.timeseries.timeindex.empty
+
+        bands = edisgo_obj.electromobility.get_flexibility_bands(
+            edisgo_obj, ["work", "public"]
+        )
+
+        assert len(bands["upper_power"].index) == 7 * 96  # 7 days, 15-min steps
+        assert bands["upper_power"].index[0] == pd.Timestamp("2011-01-01")
 
     def test_fix_flexibility_bands_rounding_errors(self, caplog):
         # set up test data

--- a/tests/run/test_tasks.py
+++ b/tests/run/test_tasks.py
@@ -17,9 +17,11 @@ import pytest
 import edisgo.run as edisgo_run
 
 from edisgo.edisgo import EDisGo
+from edisgo.io import electromobility_import
 from edisgo.run.config import load_config
 from edisgo.run.context import RunContext
 from edisgo.run.tasks.analysis import task_optimize
+from edisgo.run.tasks.flex import task_build_flexibility_bands
 from edisgo.run.tasks.io import task_import_overlying_grid_data
 from edisgo.run.tasks.timeseries import (
     task_manual_ts,
@@ -56,6 +58,40 @@ class TestManualTs:
 
         assert gen in result.timeseries.generators_active_power.columns
         assert ctx.flags["timeseries_set"] is True
+
+
+class TestBuildFlexibilityBands:
+    def test_build_flexibility_bands_scopes_to_timeindex(self):
+        """
+        Regression test for eDisGo#703: task_build_flexibility_bands used to
+        need an explicit reduce_timeseries_data_to_given_timeindex call after
+        get_flexibility_bands to trim/year-align the bands to the active
+        timeindex; get_flexibility_bands now does this itself, so the task
+        (which no longer makes that call) must still produce bands matching
+        edisgo.timeseries.timeindex exactly - including across the year
+        mismatch between SimBEV's own calendar (2011 in this fixture) and
+        the scenario timeindex (2035 here).
+        """
+        edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo,
+            pytest.simbev_example_scenario_path,
+            pytest.tracbev_example_scenario_path,
+        )
+        electromobility_import.distribute_charging_demand(edisgo)
+        electromobility_import.integrate_charging_parks(edisgo)
+
+        short_timeindex = pd.date_range("2035-01-15", periods=24, freq="h")
+        edisgo.set_timeindex(short_timeindex)
+
+        ctx = RunContext()
+        result = task_build_flexibility_bands(edisgo, ctx)
+
+        for key in ("upper_power", "lower_energy", "upper_energy"):
+            pd.testing.assert_index_equal(
+                result.electromobility.flexibility_bands[key].index,
+                short_timeindex,
+            )
 
 
 class TestImportOverlyingGridData:


### PR DESCRIPTION
## Scope `get_flexibility_bands` to the active timeindex, fixing the original #703 crash

Part of the #703 checklist (time-series writers not uniformly respecting a pre-existing `timeindex`). Item 5 of 7, and the originally reported crash — see `docs_notes/issue_temporal_reduction_flexibility_bands.md` for the full checklist.

### Problem

`get_flexibility_bands` builds EV charging flexibility bands spanning SimBEV's own native calendar and simulated date range, completely independent of `edisgo.timeseries.timeindex`. SimBEV's calendar is commonly a fixed reference year (2011 in the test fixtures); a scenario's own timeindex is commonly a different year (e.g. 2035) and/or a much shorter window. Indexing the returned bands by such a timeindex raised `KeyError` — the literal crash originally reported.

A workaround already existed at one call site (`task_build_flexibility_bands`, which called `reduce_timeseries_data_to_given_timeindex` right after `get_flexibility_bands`), but this was a local patch, not a fix to the function's own contract — any other caller was still exposed.

### Fix

`get_flexibility_bands` now year-aligns (reusing `align_series_to_timeindex`) and trims its returned/stored bands to `edisgo_obj.timeseries.timeindex` whenever it's non-empty — regardless of the `resample` parameter, since this is a correctness fix, not an optional resampling convenience. Band **construction** itself is untouched (still spans SimBEV's full native range) — a charging event straddling a later window's boundary must still count toward the band inside that window. When `timeindex` is empty, behavior is unchanged (untouched, full-range bands).

Removed the now-redundant explicit `reduce_timeseries_data_to_given_timeindex(...)` call in `task_build_flexibility_bands`, since the fix makes it a no-op.

### Testing

- [x] New regression test directly reproducing the original #703 scenario (SimBEV's 2011 calendar vs. a 2035, 24-hour scenario timeindex) — confirmed `KeyError` pre-fix, correctly scoped bands post-fix
- [x] New test confirming the empty-timeindex no-op behavior is unchanged
- [x] New pipeline-level test confirming `task_build_flexibility_bands` still produces correctly-scoped bands after removing the redundant call — confirmed to fail if the `get_flexibility_bands` fix were missing (the actual regression this guards against)
- [x] Existing `test_electromobility.py` and `test_tasks.py` suites pass unmodified
- [x] Broader related suite (electromobility/tasks/timeseries/edisgo/flex_opt, 155 tests) passes with no collateral changes
