### PR TITLE
fix: add DSM.resample(), wire it into EDisGo.resample_timeseries

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -3811,8 +3811,8 @@ class EDisGo:
         """
         Resamples time series data in
         :class:`~.network.timeseries.TimeSeries`, :class:`~.network.heat.HeatPump`,
-        :class:`~.network.electromobility.Electromobility` and
-        :class:`~.network.overlying_grid.OverlyingGrid`.
+        :class:`~.network.electromobility.Electromobility`,
+        :class:`~.network.dsm.DSM` and :class:`~.network.overlying_grid.OverlyingGrid`.
 
         Both up- and down-sampling methods are possible.
 
@@ -3835,6 +3835,14 @@ class EDisGo:
         * :attr:`~.network.heat.HeatPump.cop_df`
 
         * :attr:`~.network.heat.HeatPump.heat_demand_df`
+
+        * :attr:`~.network.dsm.DSM.p_min`
+
+        * :attr:`~.network.dsm.DSM.p_max`
+
+        * :attr:`~.network.dsm.DSM.e_min`
+
+        * :attr:`~.network.dsm.DSM.e_max`
 
         * All data in :class:`~.network.overlying_grid.OverlyingGrid`
 
@@ -3868,6 +3876,7 @@ class EDisGo:
         self.timeseries.resample(method=method, freq=freq)
         self.electromobility.resample(freq=freq)
         self.heat_pump.resample_timeseries(method=method, freq=freq)
+        self.dsm.resample(method=method, freq=freq)
         self.overlying_grid.resample(method=method, freq=freq)
 
 

--- a/edisgo/network/dsm.py
+++ b/edisgo/network/dsm.py
@@ -19,6 +19,8 @@ from zipfile import ZipFile
 import numpy as np
 import pandas as pd
 
+from edisgo.tools import tools
+
 logger = logging.getLogger(__name__)
 
 
@@ -151,6 +153,32 @@ class DSM:
             "e_min",
             "e_max",
         ]
+
+    def resample(self, method: str = "ffill", freq: str | pd.Timedelta = "15min"):
+        """
+        Resamples DSM potential time series to a desired resolution.
+
+        Both up- and down-sampling methods are possible.
+
+        Parameters
+        ----------
+        method : str, optional
+            See :attr:`~.EDisGo.resample_timeseries` for more information.
+
+        freq : str, optional
+            See :attr:`~.EDisGo.resample_timeseries` for more information.
+
+        """
+        for attr in self._attributes:
+            attr_index = getattr(self, attr).index
+            if len(attr_index) < 2:
+                logger.debug(
+                    f"{attr} cannot be resampled as it contains less than two "
+                    f"time steps."
+                )
+            else:
+                freq_orig = attr_index[1] - attr_index[0]
+                tools.resample(self, freq_orig, method, freq, attr_to_resample=[attr])
 
     def reduce_memory(
         self,

--- a/tests/network/test_dsm.py
+++ b/tests/network/test_dsm.py
@@ -66,6 +66,33 @@ class TestDSM:
         self.dsm.e_max = pd.DataFrame()
         self.dsm.reduce_memory()
 
+    def test_resample(self):
+        """
+        Regression test for eDisGo#703: DSM had no resample() method, so
+        EDisGo.resample_timeseries silently left DSM data at its original
+        frequency while every sibling container (TimeSeries, Electromobility,
+        HeatPump, OverlyingGrid) was resampled.
+        """
+        # test up-sampling with default parameters
+        self.dsm.resample()
+        assert len(self.dsm.p_max) == 8
+        assert (self.dsm.p_max.iloc[0:4, 0] == 5).all()
+        assert (self.dsm.p_max.iloc[4:8, 1] == 8).all()
+        assert len(self.dsm.p_min) == 8
+        assert len(self.dsm.e_max) == 8
+        assert len(self.dsm.e_min) == 8
+
+        # test down-sampling
+        self.dsm.resample(freq="1H")
+        assert len(self.dsm.p_max) == 2
+        assert len(self.dsm.p_min) == 2
+        assert len(self.dsm.e_max) == 2
+        assert len(self.dsm.e_min) == 2
+
+        # test with empty dataframes - must not raise
+        self.dsm.e_max = pd.DataFrame()
+        self.dsm.resample()
+
     def test_to_csv(self):
         # test with default values
         save_dir = os.path.join(os.getcwd(), "dsm_csv")

--- a/tests/network/test_overlying_grid.py
+++ b/tests/network/test_overlying_grid.py
@@ -273,28 +273,11 @@ class TestOverlyingGridFunc:
                 df,
             )
 
-        # Resample timeseries and reindex to hourly timedelta
+        # Resample timeseries and reindex to hourly timedelta. DSM (p_min/p_max)
+        # is resampled by this call too (eDisGo#703) - no separate manual
+        # DSM resample needed anymore.
         self.edisgo.resample_timeseries(freq="1min")
 
-        for attr in ["p_min", "p_max"]:
-            new_dates = pd.DatetimeIndex(
-                [getattr(self.edisgo.dsm, attr).index[-1] + pd.Timedelta("1h")]
-            )
-            setattr(
-                self.edisgo.dsm,
-                attr,
-                getattr(self.edisgo.dsm, attr)
-                .reindex(
-                    getattr(self.edisgo.dsm, attr)
-                    .index.union(new_dates)
-                    .unique()
-                    .sort_values()
-                )
-                .ffill()
-                .resample("1min")
-                .ffill()
-                .iloc[:-1],
-            )
         self.timesteps = pd.date_range(start="01/01/2018", periods=240, freq="h")
         attributes = self.edisgo.timeseries._attributes
         for attr in attributes:

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -2055,9 +2055,19 @@ class TestEDisGo:
             },
             index=pd.date_range("1/1/2011 12:00", periods=2, freq="H"),
         )
+        # regression test for eDisGo#703: DSM data used to be silently left
+        # at its original frequency by resample_timeseries
+        self.edisgo.dsm.p_max = pd.DataFrame(
+            data={
+                "load_1": [5.0, 6.0],
+                "load_2": [7.0, 8.0],
+            },
+            index=pd.date_range("1/1/2011 12:00", periods=2, freq="H"),
+        )
         self.edisgo.resample_timeseries(freq="30min")
         assert len(self.edisgo.timeseries.loads_active_power) == 8
         assert len(self.edisgo.heat_pump.cop_df) == 4
+        assert len(self.edisgo.dsm.p_max) == 4
 
 
 class TestEDisGoFunc:


### PR DESCRIPTION
## Add `DSM.resample()`, wire it into `EDisGo.resample_timeseries`

Part of the #703 checklist (time-series writers not uniformly respecting a pre-existing `timeindex`). Item 6 of 7 — see `docs_notes/issue_temporal_reduction_flexibility_bands.md` for the full checklist.

### Problem

`DSM` had no `resample()` method, unlike every sibling container (`TimeSeries`, `HeatPump`, `Electromobility`, `OverlyingGrid`). `EDisGo.resample_timeseries()` — the public API for changing an entire `EDisGo` object's time resolution — never touched `dsm`, silently leaving `p_min`/`p_max`/`e_min`/`e_max` at their original frequency while everything else changed, with no warning.

### Fix

Added `DSM.resample(method, freq)`, mirroring `HeatPump.resample_timeseries`'s signature/pattern, iterating the existing `DSM._attributes` list. Wired it into `EDisGo.resample_timeseries` and updated its docstring's affected-attributes list (previously omitted DSM entirely).

### Testing

- [x] New `test_resample` in `test_dsm.py` — fails (`AttributeError`) pre-fix, passes post-fix
- [x] Extended `test_edisgo.py`'s existing `test_resample_timeseries` to cover `dsm.p_max` — fails (`assert 2 == 4`) pre-fix, passes post-fix
- [x] Broader related suite (network/run/flex_opt, 206 tests) passes with no collateral changes

### Also included — test fix uncovered by this change

`tests/network/test_overlying_grid.py`'s `setup_flexibility_data()` had a manual DSM-resample workaround (hand-rolling exactly what `DSM.resample()` now does) predating this fix. With the real fix in place, that workaround double-resampled already-correct data and broke `test_distribute_overlying_grid_timeseries` with a shape mismatch. Removed the now-redundant workaround block — confirmed the test passes cleanly with the real fix + workaround removed.
