### PR TITLE
Fix/703 expose reduce timeseries api

### DIFF
--- a/edisgo/edisgo.py
+++ b/edisgo/edisgo.py
@@ -72,6 +72,7 @@ from edisgo.tools.tools import (
     check_timeindex_coverage,
     determine_grid_integration_voltage_level,
     get_path_length_to_station,
+    reduce_timeseries_data_to_given_timeindex,
 )
 
 if "READTHEDOCS" not in os.environ:
@@ -3878,6 +3879,74 @@ class EDisGo:
         self.heat_pump.resample_timeseries(method=method, freq=freq)
         self.dsm.resample(method=method, freq=freq)
         self.overlying_grid.resample(method=method, freq=freq)
+
+    def reduce_timeseries_data_to_given_timeindex(
+        self,
+        timeindex,
+        freq="1H",
+        timeseries=True,
+        electromobility=True,
+        save_ev_soc_initial=True,
+        heat_pump=True,
+        dsm=True,
+        overlying_grid=True,
+    ):
+        """
+        Reduces timeseries data in this EDisGo object to given time index.
+
+        Thin wrapper around
+        :func:`edisgo.tools.tools.reduce_timeseries_data_to_given_timeindex`,
+        exposed here for discoverability - the underlying implementation is
+        otherwise only importable directly from ``edisgo.tools.tools``, which
+        made it easy to miss for anyone using :class:`~.EDisGo` outside the
+        ``run`` pipeline (its only prior callers).
+
+        Parameters
+        -----------
+        timeindex : :pandas:`pandas.DatetimeIndex<DatetimeIndex>`
+            Time index to set.
+        freq : str or :pandas:`pandas.Timedelta<Timedelta>`, optional
+            Frequency of time series data. This is only needed if it cannot be
+            inferred from the given `timeindex` and if electromobility data
+            and/or overlying grid data is reduced, as the initial SoC is
+            tried to be set using the time step before the first time step in
+            the given `timeindex`. Offset aliases can be found here:
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases.
+            Default: '1H'.
+        timeseries : bool
+            Indicates whether timeseries in
+            :class:`~.network.timeseries.TimeSeries` are reduced to given
+            time index. Default: True.
+        electromobility : bool
+            Indicates whether timeseries in
+            :class:`~.network.electromobility.Electromobility` are reduced to
+            given time index. Default: True.
+        save_ev_soc_initial : bool
+            Indicates whether to save initial EV SOC from timestep before
+            first timestep of given time index. Default: True.
+        heat_pump : bool
+            Indicates whether timeseries in :class:`~.network.heat.HeatPump`
+            are reduced to given time index. Default: True.
+        dsm : bool
+            Indicates whether timeseries in :class:`~.network.dsm.DSM` are
+            reduced to given time index. Default: True.
+        overlying_grid : bool
+            Indicates whether timeseries in
+            :class:`~.network.overlying_grid.OverlyingGrid` are reduced to
+            given time index. Default: True.
+
+        """
+        reduce_timeseries_data_to_given_timeindex(
+            self,
+            timeindex,
+            freq=freq,
+            timeseries=timeseries,
+            electromobility=electromobility,
+            save_ev_soc_initial=save_ev_soc_initial,
+            heat_pump=heat_pump,
+            dsm=dsm,
+            overlying_grid=overlying_grid,
+        )
 
 
 def import_edisgo_from_pickle(filename, path=""):

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -18,6 +18,7 @@ from edisgo import EDisGo
 from edisgo.edisgo import import_edisgo_from_files
 from edisgo.flex_opt.reinforce_grid import enhanced_reinforce_grid
 from edisgo.network.results import Results
+from edisgo.tools.tools import reduce_timeseries_data_to_given_timeindex
 
 
 class TestEDisGo:
@@ -2068,6 +2069,30 @@ class TestEDisGo:
         assert len(self.edisgo.timeseries.loads_active_power) == 8
         assert len(self.edisgo.heat_pump.cop_df) == 4
         assert len(self.edisgo.dsm.p_max) == 4
+
+    def test_reduce_timeseries_data_to_given_timeindex(self):
+        """
+        EDisGo.reduce_timeseries_data_to_given_timeindex is a thin wrapper
+        around edisgo.tools.tools.reduce_timeseries_data_to_given_timeindex,
+        added for discoverability (eDisGo#703 checklist item 7). Must produce
+        the same result as calling the free function directly.
+        """
+        self.setup_worst_case_time_series()
+        target_timeindex = self.edisgo.timeseries.timeindex[:2]
+
+        edisgo_via_method = deepcopy(self.edisgo)
+        edisgo_via_method.reduce_timeseries_data_to_given_timeindex(target_timeindex)
+
+        edisgo_via_function = deepcopy(self.edisgo)
+        reduce_timeseries_data_to_given_timeindex(edisgo_via_function, target_timeindex)
+
+        assert_frame_equal(
+            edisgo_via_method.timeseries.loads_active_power,
+            edisgo_via_function.timeseries.loads_active_power,
+        )
+        pd.testing.assert_index_equal(
+            edisgo_via_method.timeseries.timeindex, target_timeindex
+        )
 
 
 class TestEDisGoFunc:


### PR DESCRIPTION
## Expose `reduce_timeseries_data_to_given_timeindex` on the `EDisGo` class

Part of the #703 checklist (time-series writers not uniformly respecting a pre-existing `timeindex`). Item 7 of 7, the last item — see `docs_notes/issue_temporal_reduction_flexibility_bands.md` for the full checklist.

### Problem

`reduce_timeseries_data_to_given_timeindex` (`edisgo/tools/tools.py`) is a well-implemented, correct function that trims `TimeSeries`, `Electromobility.flexibility_bands` (with year-align), `HeatPump`, `DSM`, and `OverlyingGrid` attributes consistently to a target timeindex — but it's only ever importable from `edisgo.tools.tools`, never exposed on the `EDisGo` class. Its only prior callers were internal run-pipeline tasks; anyone using `EDisGo` directly had no discoverable way to find or use it.

### Fix

Added `EDisGo.reduce_timeseries_data_to_given_timeindex(...)`, a thin wrapper delegating to the existing free function — same signature/defaults, mirroring how `EDisGo.resample_timeseries` already delegates to underlying implementations. No changes to the tested logic in `tools.py`; the three existing internal call sites can keep importing the free function directly.

### Testing

- [x] New smoke test confirming the method produces identical results to calling the free function directly (via `deepcopy` comparison) — fails (`AttributeError`) pre-fix, passes post-fix
- [x] Full `test_edisgo.py` suite (39 tests) passes with no collateral changes
