### PR TITLE
Adjusted the time exponent used in the heat storage energy constraint…

### DIFF
--- a/edisgo/opf/eDisGo_OPF.jl/src/core/constraint.jl
+++ b/edisgo/opf/eDisGo_OPF.jl/src/core/constraint.jl
@@ -53,7 +53,7 @@ function constraint_store_state(pm::AbstractBFModelEdisgo, n_1::Int, n_2::Int, i
         hse_2 = PowerModels.var(pm, n_2, :hse, i)
         hse_1 = PowerModels.var(pm, n_1, :hse, i)
 
-        JuMP.@constraint(pm.model, hse_2 - hse_1 * (1 - p_loss)^(1/24) == - time_elapsed*phs_2)  # Eq. (3.23)
+        JuMP.@constraint(pm.model, hse_2 - hse_1 * (1 - p_loss)^(time_elapsed/24) == - time_elapsed*phs_2)  # Eq. (3.23)
     elseif kind == "dsm"
         pdsm_2 = PowerModels.var(pm, n_2, :pdsm, i)
         dsme_2 = PowerModels.var(pm, n_2, :dsme, i)


### PR DESCRIPTION
… for inter-time-step state-of-charge coupling. Now fractions of hours can be simulated.

# Description

The equation of the constraint_store_state() function no has the elapsed time now in the exponent making fractions of hours possible to propperly calculate.

Fixes #697 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
