### PR TITLE
 Align `flexibility_bands` reads to the active timeindex in the OPF builder

### DIFF
--- a/edisgo/io/powermodels_io.py
+++ b/edisgo/io/powermodels_io.py
@@ -1181,7 +1181,16 @@ def _build_electromobility(edisgo_obj, psa_net, pm, s_base, flexible_cps):
         Updated array containing all charging points that allow for flexible charging.
 
     """
-    flex_bands_df = edisgo_obj.electromobility.flexibility_bands
+    # Align to the active timeindex explicitly rather than relying on
+    # flexibility_bands already being in the same order/length - correct
+    # regardless of what ran before this function (e.g. a second
+    # select_timesteps step, or direct EDisGo API use), not just when the
+    # standard run pipeline's task ordering happens to keep them aligned.
+    timeindex = edisgo_obj.timeseries.timeindex
+    flex_bands_df = {
+        key: df.loc[timeindex]
+        for key, df in edisgo_obj.electromobility.flexibility_bands.items()
+    }
     if (flex_bands_df["lower_energy"] > flex_bands_df["upper_energy"]).any().any():
         logger.warning(
             "Upper energy level is smaller than lower energy level for "
@@ -1920,21 +1929,27 @@ def _build_component_timeseries(
             }
     elif kind == "electromobility":
         if len(flexible_cps) > 0:
+            # Align to the active timeindex explicitly (see
+            # _build_electromobility for the same fix and its rationale) -
+            # also guards against a length mismatch with
+            # pm["time_series"]["num_steps"] (set from len(psa_net.snapshots)
+            # independently of flexibility_bands' own length).
+            timeindex = edisgo_obj.timeseries.timeindex
             p_set = (
-                edisgo_obj.electromobility.flexibility_bands["upper_power"][
-                    flexible_cps
+                edisgo_obj.electromobility.flexibility_bands["upper_power"].loc[
+                    timeindex, flexible_cps
                 ]
                 / s_base
             ).round(20)
             e_min = (
-                edisgo_obj.electromobility.flexibility_bands["lower_energy"][
-                    flexible_cps
+                edisgo_obj.electromobility.flexibility_bands["lower_energy"].loc[
+                    timeindex, flexible_cps
                 ]
                 / s_base
             ).round(20)
             e_max = (
-                edisgo_obj.electromobility.flexibility_bands["upper_energy"][
-                    flexible_cps
+                edisgo_obj.electromobility.flexibility_bands["upper_energy"].loc[
+                    timeindex, flexible_cps
                 ]
                 / s_base
             ).round(20)

--- a/tests/io/test_powermodels_io.py
+++ b/tests/io/test_powermodels_io.py
@@ -304,6 +304,103 @@ class TestPowermodelsIO:
             )
         )
 
+    def test_to_powermodels_flexibility_bands_wider_than_timeindex(self):
+        """
+        Regression test for eDisGo#718: _build_electromobility and
+        _build_component_timeseries used to read flexibility_bands
+        positionally (.iloc[0], .values.tolist() on the whole column)
+        instead of aligning to edisgo.timeseries.timeindex first. When
+        flexibility_bands spans more rows than the active timeindex (e.g.
+        stale data from before a later select_timesteps step), this used to
+        silently take the wrong/misaligned static p_max/e_min/e_max and
+        write a longer time series than pm["time_series"]["num_steps"] -
+        both must now be exactly scoped to the active timeindex.
+        """
+        edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
+        edisgo.set_time_series_worst_case_analysis()
+        timeindex = edisgo.timeseries.timeindex
+
+        edisgo.add_component(
+            comp_type="load",
+            type="charging_point",
+            ts_active_power=pd.Series(index=timeindex, data=[0.5] * 4),
+            ts_reactive_power="default",
+            bus=edisgo.topology.buses_df.index[32],
+            p_set=3,
+        )
+
+        # flexibility_bands spans 8 steps, twice the active 4-step timeindex,
+        # with distinctive values so misalignment is obvious
+        wide_index = pd.date_range(timeindex[0], periods=8, freq=timeindex.freq)
+        edisgo.electromobility.flexibility_bands = {
+            "lower_energy": pd.DataFrame(
+                {"Charging_Point_LVGrid_6_1": [0.0] * 8}, index=wide_index
+            ),
+            "upper_energy": pd.DataFrame(
+                {"Charging_Point_LVGrid_6_1": [9.0, 1, 2, 3, 4, 5, 6, 7]},
+                index=wide_index,
+            ),
+            "upper_power": pd.DataFrame(
+                {"Charging_Point_LVGrid_6_1": [9.0, 1, 2, 3, 4, 5, 6, 7]},
+                index=wide_index,
+            ),
+        }
+
+        pm, _ = powermodels_io.to_powermodels(
+            edisgo, flexible_cps=["Charging_Point_LVGrid_6_1"]
+        )
+
+        num_steps = pm["time_series"]["num_steps"]
+        assert num_steps == len(timeindex)
+        for key in ("p_max", "e_min", "e_max"):
+            assert len(pm["time_series"]["electromobility"]["1"][key]) == num_steps
+        assert pm["time_series"]["electromobility"]["1"]["p_max"] == [
+            9.0,
+            1.0,
+            2.0,
+            3.0,
+        ]
+        assert pm["electromobility"]["1"]["p_max"] == pytest.approx(9.0)
+
+    def test_to_powermodels_flexibility_bands_wrong_calendar_raises(self):
+        """
+        Regression test for eDisGo#718: when flexibility_bands doesn't cover
+        edisgo.timeseries.timeindex at all (genuine staleness, not just a
+        wider/narrower matching-calendar range), to_powermodels must raise a
+        clear KeyError rather than silently building wrong OPF input from
+        mismatched rows.
+        """
+        edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
+        edisgo.set_time_series_worst_case_analysis()
+        timeindex = edisgo.timeseries.timeindex
+
+        edisgo.add_component(
+            comp_type="load",
+            type="charging_point",
+            ts_active_power=pd.Series(index=timeindex, data=[0.5] * 4),
+            ts_reactive_power="default",
+            bus=edisgo.topology.buses_df.index[32],
+            p_set=3,
+        )
+
+        wrong_index = pd.date_range("2035-01-01", periods=4, freq=timeindex.freq)
+        edisgo.electromobility.flexibility_bands = {
+            "lower_energy": pd.DataFrame(
+                {"Charging_Point_LVGrid_6_1": [0.0] * 4}, index=wrong_index
+            ),
+            "upper_energy": pd.DataFrame(
+                {"Charging_Point_LVGrid_6_1": [1.0] * 4}, index=wrong_index
+            ),
+            "upper_power": pd.DataFrame(
+                {"Charging_Point_LVGrid_6_1": [1.0] * 4}, index=wrong_index
+            ),
+        }
+
+        with pytest.raises(KeyError):
+            powermodels_io.to_powermodels(
+                edisgo, flexible_cps=["Charging_Point_LVGrid_6_1"]
+            )
+
     def test__get_pf(self):
         self.edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
         self.edisgo.set_time_series_worst_case_analysis()


### PR DESCRIPTION
## Align `flexibility_bands` reads to the active timeindex in the OPF builder

Fixes #718.

### Problem

`_build_electromobility` and `_build_component_timeseries`'s electromobility branch read `edisgo_obj.electromobility.flexibility_bands` **positionally** (`.iloc[0]` for static bounds, `.values.tolist()` for the full per-timestep column) instead of aligning to `edisgo_obj.timeseries.timeindex` first. This was only safe because the standard run pipeline always finalizes the timeindex before building bands and running `optimize` — an implicit ordering convention, not something either function or the validator enforced. Breaking that ordering (e.g. changing the timeindex again after `get_flexibility_bands`, or direct `EDisGo` API use) would silently feed wrong/misaligned or length-mismatched OPF input to PowerModels/Julia, rather than raising a clear error.

### Fix

Both functions now explicitly select `flexibility_bands[key].loc[timeindex]` (or `.loc[timeindex, flexible_cps]`) before any positional access — mirroring the alignment pattern already established in `Electromobility.get_flexibility_bands` (#703). A genuine mismatch (bands that don't cover the active timeindex at all) now raises `KeyError` immediately, rather than silently producing wrong data — consistent with how #703's PRs 2/3 handle the same class of staleness.

No separate length assertion against `pm["time_series"]["num_steps"]` was added: `to_powermodels` always builds `psa_net` via `edisgo_object.to_pypsa()` with no explicit `timesteps` override, so `psa_net.snapshots` (and hence `num_steps`) is always exactly `edisgo_obj.timeseries.timeindex` in this code path — the `.loc[timeindex]` alignment already guarantees the length matches.

### Testing

- [x] New test: `flexibility_bands` spanning more rows than the active timeindex (stale data) — confirmed both the static (`p_max`) and per-timestep OPF arrays are now correctly trimmed to exactly `num_steps`, matching the active timeindex; fails (length mismatch) pre-fix, passes post-fix
- [x] New test: `flexibility_bands` in a genuinely different calendar — confirmed `to_powermodels` now raises `KeyError` instead of silently succeeding; fails (no error raised) pre-fix, passes post-fix
- [x] Existing `test_powermodels_io.py` (4 tests) and `test_powermodels_opf.py` (10 tests) pass unmodified
- [x] Broader related suite (`tests/run/`, `test_electromobility.py`, `test_timeseries.py`, 100 tests) passes with no collateral changes
