### PR TITLE
fix: preserve gaps in the timeindex when resampling

### DIFF
--- a/edisgo/network/dsm.py
+++ b/edisgo/network/dsm.py
@@ -168,6 +168,11 @@ class DSM:
         freq : str, optional
             See :attr:`~.EDisGo.resample_timeseries` for more information.
 
+        Notes
+        -----
+        A gapped index is resampled per contiguous run - see
+        :func:`edisgo.tools.tools.split_into_contiguous_runs`.
+
         """
         for attr in self._attributes:
             attr_index = getattr(self, attr).index

--- a/edisgo/network/heat.py
+++ b/edisgo/network/heat.py
@@ -602,6 +602,11 @@ class HeatPump:
         freq : str, optional
             See :attr:`~.EDisGo.resample_timeseries` for more information.
 
+        Notes
+        -----
+        A gapped index is resampled per contiguous run - see
+        :func:`edisgo.tools.tools.split_into_contiguous_runs`.
+
         """
         for attr in self._timeseries_attributes:
             attr_index = getattr(self, attr).index

--- a/edisgo/network/overlying_grid.py
+++ b/edisgo/network/overlying_grid.py
@@ -106,6 +106,7 @@ class OverlyingGrid:
         self.renewables_potential = kwargs.get(
             "renewables_potential", pd.Series(dtype="float64")
         )
+
     @property
     def _attributes(self):
         return [
@@ -269,6 +270,11 @@ class OverlyingGrid:
 
         freq : str, optional
             See :attr:`~.EDisGo.resample_timeseries` for more information.
+
+        Notes
+        -----
+        A gapped index is resampled per contiguous run - see
+        :func:`edisgo.tools.tools.split_into_contiguous_runs`.
 
         """
         # get frequency of time series data

--- a/edisgo/network/timeseries.py
+++ b/edisgo/network/timeseries.py
@@ -27,6 +27,7 @@ from edisgo.tools.tools import (
     assign_voltage_level_to_component,
     check_timeindex_coverage,
     resample,
+    split_into_contiguous_runs,
 )
 
 if TYPE_CHECKING:
@@ -2325,20 +2326,33 @@ class TimeSeries:
 
         resample(self, freq_orig, method, freq)
 
-        # create new index
-        if pd.Timedelta(freq) < freq_orig:  # up-sampling
-            index = pd.date_range(
-                self.timeindex[0],
-                self.timeindex[-1] + freq_orig,
-                freq=freq,
-                inclusive="left",
-            )
-        else:  # down-sampling
-            index = pd.date_range(
-                self.timeindex[0],
-                self.timeindex[-1],
-                freq=freq,
-            )
+        # Rebuild the new index per contiguous run of the original timeindex
+        # (mirroring how `resample()` above already resamples the data
+        # per-run) and union them back together, so a gap in the original
+        # timeindex (e.g. from `select_timesteps` in auto mode) is preserved
+        # here too, rather than bridged by one date_range(first, last, freq)
+        # span.
+        freq_td = pd.Timedelta(freq)
+        new_indices = []
+        for run in split_into_contiguous_runs(
+            pd.DataFrame(index=self.timeindex), freq_orig
+        ):
+            if freq_td < freq_orig:  # up-sampling
+                new_indices.append(
+                    pd.date_range(
+                        run.index[0],
+                        run.index[-1] + freq_orig,
+                        freq=freq,
+                        inclusive="left",
+                    )
+                )
+            else:  # down-sampling
+                new_indices.append(
+                    pd.date_range(run.index[0], run.index[-1], freq=freq)
+                )
+        index = new_indices[0]
+        for other in new_indices[1:]:
+            index = index.union(other)
 
         # set new timeindex
         self._timeindex = index

--- a/edisgo/tools/tools.py
+++ b/edisgo/tools/tools.py
@@ -1367,6 +1367,51 @@ def reduce_timeseries_data_to_given_timeindex(
                     )
 
 
+def split_into_contiguous_runs(df, freq_orig):
+    """
+    Splits a DataFrame with a (possibly gapped) `DatetimeIndex` into its
+    maximal contiguous runs.
+
+    A run boundary is any gap between consecutive index entries strictly
+    larger than `freq_orig`. Used by :func:`resample` so that resampling a
+    gapped timeindex (e.g. as produced by ``select_timesteps`` in auto mode,
+    which deliberately keeps two disjoint intervals separate) resamples each
+    contiguous block independently, rather than silently bridging the gap
+    with resample artifacts (pandas' own `.resample()` always buckets
+    contiguously across whatever span the data's index covers, filling any
+    gap with forward-filled/averaged data rather than leaving it empty).
+
+    Parameters
+    ----------
+    df : :pandas:`pandas.DataFrame<DataFrame>`
+        DataFrame with a :pandas:`pandas.DatetimeIndex<DatetimeIndex>`.
+        Assumed non-empty and sorted.
+    freq_orig : :pandas:`pandas.Timedelta<Timedelta>`
+        Frequency of the original time series data. Any gap larger than this
+        is treated as a run boundary.
+
+    Returns
+    -------
+    list(:pandas:`pandas.DataFrame<DataFrame>`)
+        The contiguous runs, in order. A continuous `df` returns a
+        single-element list containing `df` itself unchanged.
+
+    """
+    if len(df.index) < 2:
+        return [df]
+    gaps = df.index.to_series().diff().iloc[1:]
+    run_boundaries = np.flatnonzero((gaps > freq_orig).to_numpy()) + 1
+    if len(run_boundaries) == 0:
+        return [df]
+    return [
+        df.iloc[start:end]
+        for start, end in zip(
+            [0, *run_boundaries.tolist()],
+            [*run_boundaries.tolist(), len(df.index)],
+        )
+    ]
+
+
 def resample(
     object,
     freq_orig,
@@ -1396,58 +1441,46 @@ def resample(
         List of attributes to resample. Per default, all attributes specified in
         respective object's `_attributes` are resampled.
 
+    Notes
+    -----
+    A gapped index (e.g. as produced by ``select_timesteps`` in auto mode) is
+    resampled per contiguous run (see :func:`split_into_contiguous_runs`), so
+    a gap is preserved rather than silently bridged with resample artifacts.
+
     """
     if attr_to_resample is None:
         attr_to_resample = object._attributes
+    freq_orig = pd.Timedelta(freq_orig)
+    freq = pd.Timedelta(freq) if not isinstance(freq, pd.Timedelta) else freq
+    up_sampling = freq < freq_orig
 
-    # add time step at the end of the time series in case of up-sampling so that
-    # last time interval in the original time series is still included
-    df_dict = {}
+    if method not in ("interpolate", "ffill", "bfill"):
+        raise NotImplementedError(f"Resampling method {method} is not implemented.")
+
     for attr in attr_to_resample:
-        if not getattr(object, attr).empty:
-            df_dict[attr] = getattr(object, attr)
-            if pd.Timedelta(freq) < freq_orig:  # up-sampling
-                new_dates = pd.DatetimeIndex([df_dict[attr].index[-1] + freq_orig])
-            else:  # down-sampling
-                new_dates = pd.DatetimeIndex([df_dict[attr].index[-1]])
-            df_dict[attr] = (
-                df_dict[attr]
-                .reindex(df_dict[attr].index.union(new_dates).unique().sort_values())
-                .ffill()
-            )
+        df = getattr(object, attr)
+        if df.empty:
+            continue
 
-    # resample time series
-    if pd.Timedelta(freq) < freq_orig:  # up-sampling
-        if method == "interpolate":
-            for attr in df_dict.keys():
-                setattr(
-                    object,
-                    attr,
-                    df_dict[attr].resample(freq, closed="left").interpolate().iloc[:-1],
-                )
-        elif method == "ffill":
-            for attr in df_dict.keys():
-                setattr(
-                    object,
-                    attr,
-                    df_dict[attr].resample(freq, closed="left").ffill().iloc[:-1],
-                )
-        elif method == "bfill":
-            for attr in df_dict.keys():
-                setattr(
-                    object,
-                    attr,
-                    df_dict[attr].resample(freq, closed="left").bfill().iloc[:-1],
-                )
-        else:
-            raise NotImplementedError(f"Resampling method {method} is not implemented.")
-    else:  # down-sampling
-        for attr in df_dict.keys():
-            setattr(
-                object,
-                attr,
-                df_dict[attr].resample(freq).mean(),
-            )
+        resampled_runs = []
+        for run in split_into_contiguous_runs(df, freq_orig):
+            # add time step at the end of the run in case of up-sampling so
+            # that the last time interval in the run is still included
+            if up_sampling:
+                new_dates = pd.DatetimeIndex([run.index[-1] + freq_orig])
+            else:
+                new_dates = pd.DatetimeIndex([run.index[-1]])
+            run = run.reindex(run.index.union(new_dates).unique().sort_values()).ffill()
+
+            if up_sampling:
+                resampled = getattr(run.resample(freq, closed="left"), method)().iloc[
+                    :-1
+                ]
+            else:
+                resampled = run.resample(freq).mean()
+            resampled_runs.append(resampled)
+
+        setattr(object, attr, pd.concat(resampled_runs))
 
 
 def reduce_memory_usage(df: pd.DataFrame, show_reduction: bool = False) -> pd.DataFrame:

--- a/tests/network/test_dsm.py
+++ b/tests/network/test_dsm.py
@@ -93,6 +93,22 @@ class TestDSM:
         self.dsm.e_max = pd.DataFrame()
         self.dsm.resample()
 
+    def test_resample_preserves_gapped_index(self):
+        """
+        Regression test: resampling a gapped index must not bridge the gap
+        with resample artifacts.
+        """
+        gapped_index = pd.date_range("2035-01-08", periods=24, freq="h").union(
+            pd.date_range("2035-06-10", periods=24, freq="h")
+        )
+        dsm = DSM()
+        dsm.p_max = pd.DataFrame({"load_1": [5.0] * 48}, index=gapped_index)
+
+        dsm.resample(freq="15min")
+        gap = dsm.p_max.index.to_series().diff().max()
+        assert gap > pd.Timedelta("15min")
+        assert len(dsm.p_max) == 192  # 2 runs * 24h * 4 (15min steps/h)
+
     def test_to_csv(self):
         # test with default values
         save_dir = os.path.join(os.getcwd(), "dsm_csv")

--- a/tests/network/test_heat.py
+++ b/tests/network/test_heat.py
@@ -363,6 +363,23 @@ class TestHeatPump:
         assert len(heatpump.heat_demand_df) == 2
         assert len(heatpump.cop_df) == 2
 
+    def test_resample_timeseries_preserves_gapped_index(self):
+        """
+        Regression test: resampling a gapped index must not bridge the gap
+        with resample artifacts (pandas' own .resample() would otherwise
+        fabricate contiguous data across it).
+        """
+        gapped_index = pd.date_range("2035-01-08", periods=24, freq="h").union(
+            pd.date_range("2035-06-10", periods=24, freq="h")
+        )
+        heatpump = HeatPump()
+        heatpump.cop_df = pd.DataFrame({"hp1": [5.0] * 48}, index=gapped_index)
+
+        heatpump.resample_timeseries(freq="15min")
+        gap = heatpump.cop_df.index.to_series().diff().max()
+        assert gap > pd.Timedelta("15min")
+        assert len(heatpump.cop_df) == 192  # 2 runs * 24h * 4 (15min steps/h)
+
     def test_check_integrity(self, caplog):
         # check for empty HeatPump class
         heatpump = HeatPump()

--- a/tests/network/test_overlying_grid.py
+++ b/tests/network/test_overlying_grid.py
@@ -156,6 +156,24 @@ class TestOverlyingGrid:
             "Data cannot be resampled as it only contains one time step." in caplog.text
         )
 
+    def test_resample_preserves_gapped_index(self):
+        """
+        Regression test: resampling a gapped index must not bridge the gap
+        with resample artifacts.
+        """
+        gapped_index = pd.date_range("2035-01-08", periods=24, freq="h").union(
+            pd.date_range("2035-06-10", periods=24, freq="h")
+        )
+        overlying_grid = OverlyingGrid()
+        overlying_grid.feedin_district_heating = pd.DataFrame(
+            {"dh1": [1.4] * 48}, index=gapped_index
+        )
+
+        overlying_grid.resample(freq="15min")
+        gap = overlying_grid.feedin_district_heating.index.to_series().diff().max()
+        assert gap > pd.Timedelta("15min")
+        assert len(overlying_grid.feedin_district_heating) == 192
+
 
 class TestOverlyingGridFunc:
     @classmethod

--- a/tests/network/test_timeseries.py
+++ b/tests/network/test_timeseries.py
@@ -2581,6 +2581,30 @@ class TestTimeSeries:
             atol=1e-5,
         )
 
+    def test_resample_preserves_gapped_timeindex(self):
+        """
+        Regression test: resampling a gapped timeindex (as produced by
+        select_timesteps in auto mode, which deliberately keeps two disjoint
+        intervals separate) must not bridge the gap with resample artifacts -
+        the gap must survive an up-sample/down-sample round-trip, and the
+        timeindex must be restored exactly.
+        """
+        gapped_index = pd.date_range("2035-01-08", periods=24, freq="h").union(
+            pd.date_range("2035-06-10", periods=24, freq="h")
+        )
+        self.edisgo.set_timeindex(gapped_index)
+        gen = self.edisgo.topology.generators_df.index[0]
+        self.edisgo.set_time_series_manual(
+            generators_p=pd.DataFrame({gen: [0.1] * 48}, index=gapped_index)
+        )
+
+        self.edisgo.timeseries.resample(freq="15min")
+        gap = self.edisgo.timeseries.timeindex.to_series().diff().max()
+        assert gap > pd.Timedelta("15min")
+
+        self.edisgo.timeseries.resample(freq="1h")
+        assert_index_equal(self.edisgo.timeseries.timeindex, gapped_index)
+
     def test_scale_timeseries(self):
         self.edisgo.set_time_series_worst_case_analysis()
         edisgo_scaled = copy.deepcopy(self.edisgo)


### PR DESCRIPTION
## Fix shared `tools.resample()` (and `TimeSeries.resample()`'s own timeindex rebuild) silently closing gaps

Fixes #<issue-number-once-filed> — see `docs_notes/issue_shared_resample_closes_timeindex_gaps.md` for the full write-up (found during the #703 PR series while implementing PR 1 and PR 6, tracked separately since it's a distinct pre-existing bug in shared infrastructure).

### Problem

`edisgo.timeseries.timeindex` (or any sibling container's own index) can legitimately be gapped — e.g. `select_timesteps` in auto mode deliberately keeps two disjoint intervals separate. The shared `tools.resample()` function calls pandas' own `.resample()` directly on each attribute's data, which always produces a contiguous bucket sequence spanning the data's own min-to-max timestamp — any gap gets silently filled with resample artifacts (forward-filled/averaged copies of adjacent real values), not preserved as a gap.

`TimeSeries.resample` compounds this: after calling the shared function, it also rebuilds `self._timeindex` via one `pd.date_range(first, last, freq)` span, discarding the gap from the index itself, not just the data.

Affects every caller of the shared function: `TimeSeries.resample`, `HeatPump.resample_timeseries`, `DSM.resample`, `OverlyingGrid.resample`. `Electromobility.resample` is unaffected — it already warns on non-continuous input rather than silently fabricating data.

### Fix

- New `split_into_contiguous_runs` helper splits a DataFrame into its maximal contiguous runs (a run boundary is any gap larger than the original frequency). The shared `resample()` function now resamples each run independently and concatenates the results, so gaps are never bridged.
- `TimeSeries.resample`'s own `_timeindex` rebuild now reconstructs the new index per contiguous run (unioned together), fixing the compounding issue on top of the shared function's fix.

### Testing

- [x] New regression test per affected class (`TimeSeries`, `HeatPump`, `DSM`, `OverlyingGrid`) — each confirms a gapped index survives a resample round-trip with the gap intact; `TimeSeries`'s test additionally confirms the timeindex is restored exactly after an up-sample/down-sample round-trip
- [x] All four fail against the pre-fix code (gap fully bridged, e.g. 48 rows → 14,784 rows / 3,696 rows in the worked examples) and pass with the fix
- [x] Existing `test_resample`/`test_resample_timeseries` tests for all four classes pass unmodified — confirms the refactor is behavior-preserving for the continuous (non-gapped) case
- [x] Broader collateral suite (network/run/flex_opt/tools, 400+ tests) passes with no regressions
