### PR TITLE
fix: replace residual_load tiling with active-timeindex proration in …

### DIFF
--- a/edisgo/flex_opt/charging_strategies.py
+++ b/edisgo/flex_opt/charging_strategies.py
@@ -286,35 +286,118 @@ def charging_strategy(
             eta_cp=eta_cp,
         )
 
-        # get residual load
-        init_residual_load = edisgo_obj.timeseries.residual_load
-
         len_residual_load = int(charging_processes_df.park_end_timesteps.max())
 
-        if len(init_residual_load) >= len_residual_load:
-            init_residual_load = init_residual_load.loc[timeindex]
+        if not resample:
+            # The active timeindex can extend past the last charging event
+            # (e.g. a trailing gapped run with no events in it at all) - the
+            # step-space array built below must cover at least as far as
+            # target_timeindex itself, or the crop-after-build step later
+            # would reindex into positions that were never built, producing
+            # NaN rather than a legitimate zero.
+            target_span_steps = int(
+                (target_timeindex[-1] - target_timeindex[0])
+                / pd.Timedelta(f"{edisgo_obj.electromobility.stepsize}min")
+            )
+            len_residual_load = max(len_residual_load, target_span_steps)
+
+        # Map each SimBEV step position (0 .. len_residual_load, the same
+        # positional space as park_start_timesteps/park_end_timesteps) to
+        # whether it is present in the active timeindex (`target_timeindex`).
+        # Real residual_load only exists for `target_timeindex`. Rather than
+        # tiling (cyclically repeating) it to cover steps beyond the active
+        # timeindex - which would rank timesteps against a fabricated,
+        # non-periodic-in-reality signal (see ADR 0001) - steps outside the
+        # active timeindex are simply marked as having no usable data.
+        # `resample=True` means `target_timeindex` predates an internal
+        # frequency round-trip and is no longer in the same step space as
+        # `park_start_timesteps` - the crop-after-build step already skips
+        # trimming in that case (see the module docstring), so this reduction
+        # is skipped here too and every step is treated as in-window,
+        # preserving today's (tiling) behavior only for that known
+        # limitation.
+        if resample:
+            step_in_window = np.ones(len_residual_load + 1, dtype=bool)
         else:
-            while len(init_residual_load) < len_residual_load:
-                len_rl = len(init_residual_load)
-                len_append = min(len_rl, len_residual_load - len_rl)
+            step_in_window = np.isin(
+                pd.date_range(
+                    target_timeindex[0],
+                    periods=len_residual_load + 1,
+                    freq=f"{edisgo_obj.electromobility.stepsize}min",
+                ),
+                target_timeindex,
+            )
+        in_window_steps_cumsum = np.concatenate(([0], np.cumsum(step_in_window)))
 
-                s_append = init_residual_load.iloc[:len_append]
+        if not resample:
+            # Events are reduced to the active timeindex before being
+            # scheduled: fully in-window events are untouched, fully
+            # out-of-window events are dropped, and boundary-straddling
+            # events have their charging demand prorated by how much of
+            # their parking time is actually observable. This mirrors
+            # `harmonize_charging_processes_df`'s own derivation of
+            # `minimum_charging_time` from demand and nominal power.
+            parking_time = (
+                charging_processes_df.park_end_timesteps
+                - charging_processes_df.park_start_timesteps
+                + 1
+            )
+            overlap_steps = (
+                in_window_steps_cumsum[
+                    charging_processes_df.park_end_timesteps.to_numpy() + 1
+                ]
+                - in_window_steps_cumsum[
+                    charging_processes_df.park_start_timesteps.to_numpy()
+                ]
+            )
 
-                init_residual_load = pd.concat(
-                    [
-                        init_residual_load,
-                        s_append,
-                    ],
-                    ignore_index=True,
-                )
+            # drop events with zero overlap - nothing to schedule, no
+            # residual_load data exists for them at all
+            in_window = overlap_steps > 0
+            charging_processes_df = charging_processes_df.loc[in_window]
+            in_window_fraction = (
+                (overlap_steps[in_window]) / (parking_time.to_numpy()[in_window])
+            )
 
-        init_residual_load = init_residual_load.to_numpy()
+            scaled_demand_kWh = (
+                charging_processes_df.harmonized_chargingdemand * in_window_fraction
+            )
+            scaled_minimum_charging_time = (
+                scaled_demand_kWh
+                / charging_processes_df.nominal_charging_capacity_kW
+                * 60
+                / edisgo_obj.electromobility.stepsize
+            )
+            scaled_minimum_charging_time = np.ceil(scaled_minimum_charging_time).astype(
+                np.uint16
+            )
+
+            # defensive clamp: proration preserves
+            # minimum_charging_time <= parking_time, so this should only ever
+            # bind on pre-existing anomalous input (an event whose full,
+            # unscaled demand already didn't fit its own parking time)
+            scaled_minimum_charging_time = np.minimum(
+                scaled_minimum_charging_time, overlap_steps[in_window]
+            )
+
+            charging_processes_df = charging_processes_df.assign(
+                minimum_charging_time=scaled_minimum_charging_time,
+                flex_time=charging_processes_df.park_time_timesteps
+                - scaled_minimum_charging_time,
+            )
+
+        # get residual load; steps outside the active timeindex carry no
+        # real data (see above) and are set to NaN so they can never be
+        # selected as charging candidates below
+        init_residual_load = edisgo_obj.timeseries.residual_load
 
         timeindex_residual = pd.date_range(
             edisgo_obj.timeseries.timeindex[0],
-            periods=len(init_residual_load),
+            periods=len_residual_load + 1,
             freq=f"{edisgo_obj.electromobility.stepsize}min",
         )
+        init_residual_load = init_residual_load.reindex(timeindex_residual).to_numpy()
+        init_residual_load[~step_in_window] = np.nan
 
         dummy_ts = pd.DataFrame(
             data=0.0, columns=[_.id for _ in charging_parks], index=timeindex_residual
@@ -335,7 +418,15 @@ def charging_strategy(
             RELEVANT_CHARGING_STRATEGIES_COLUMNS["residual_dumb"]
         ].itertuples():
             try:
-                dummy_ts.loc[:, cp_id].iloc[start : start + stop] += cap
+                # Write only to in-window positions of the deterministic
+                # charging interval [start, start+stop) - if the active
+                # timeindex has a gap inside this interval, every in-window
+                # sub-slice still gets the event's full, unscaled power (see
+                # ADR 0002); out-of-window positions are simply not written.
+                in_window_idx = (
+                    np.flatnonzero(step_in_window[start : start + stop]) + start
+                )
+                dummy_ts.loc[:, cp_id].iloc[in_window_idx] += cap
 
             except Exception:
                 maximum_ts = len(dummy_ts)
@@ -351,11 +442,23 @@ def charging_strategy(
         for _, start, end, k, cp_id, cap in flex_charging_processes_df[
             RELEVANT_CHARGING_STRATEGIES_COLUMNS["residual"]
         ].itertuples():
-            flex_band = residual_load[start : end + 1]
+            # Restrict ranking candidates to timesteps that are both within
+            # the parking window and present in the active timeindex -
+            # `residual_load` is NaN outside the active timeindex (no real
+            # data exists there, see above), so those positions must never
+            # be selected, even if the parking window itself spans a gap.
+            candidates = np.flatnonzero(step_in_window[start : end + 1]) + start
 
-            # get k time steps with the lowest residual load in the parking
-            # time
-            idx = np.argpartition(flex_band, k)[:k] + start
+            if k >= len(candidates):
+                # k charging demand may (after proration/clamping) exactly
+                # saturate the available in-window candidates - nothing left
+                # to rank, every candidate is used.
+                idx = candidates
+            else:
+                flex_band = residual_load[candidates]
+                # get k time steps with the lowest residual load in the
+                # parking time, among the valid (in-window) candidates only
+                idx = candidates[np.argpartition(flex_band, k)[:k]]
 
             try:
                 dummy_ts[cp_id].iloc[idx] += cap

--- a/tests/flex_opt/test_charging_strategy.py
+++ b/tests/flex_opt/test_charging_strategy.py
@@ -154,6 +154,248 @@ class TestChargingStrategy:
             edisgo.timeseries._loads_active_power.index, gapped_timeindex
         )
 
+    def _setup_edisgo_with_single_synthetic_event(
+        self, timeindex, park_start_timesteps, park_end_timesteps, chargingdemand_kWh
+    ):
+        """
+        Helper for the ADR 0001 regression tests below: imports the real
+        SimBEV/TracBEV fixture (so charging park integration/topology wiring
+        is realistic), then overwrites charging_processes_df with a single,
+        fully controlled synthetic event on one of the fixture's own
+        integrated charging parks, reusing that park's own use_case/capacity
+        so `harmonize_charging_processes_df` sees realistic values.
+        """
+        edisgo = EDisGo(ding0_grid=self.ding0_path)
+        edisgo.set_timeindex(timeindex)
+        edisgo.import_electromobility(
+            data_source="directory",
+            charging_processes_dir=self.simbev_path,
+            potential_charging_points_dir=self.tracbev_path,
+        )
+        integrated = edisgo.electromobility.integrated_charging_parks_df
+        park_id = integrated.index[0]
+        template = edisgo.electromobility.charging_processes_df[
+            edisgo.electromobility.charging_processes_df.charging_park_id == park_id
+        ].iloc[0]
+
+        park_time_timesteps = park_end_timesteps - park_start_timesteps + 1
+        edisgo.electromobility.charging_processes_df = pd.DataFrame(
+            {
+                "ags": [template.ags],
+                "car_id": [0],
+                "destination": [template.destination],
+                # avoid public/hpc (always dumb-charged even under
+                # "residual") so these events exercise the flex-ranking path
+                "use_case": ["work"],
+                "nominal_charging_capacity_kW": [template.nominal_charging_capacity_kW],
+                "grid_charging_capacity_kW": [template.grid_charging_capacity_kW],
+                "chargingdemand_kWh": [chargingdemand_kWh],
+                "park_time_timesteps": [park_time_timesteps],
+                "park_start_timesteps": [park_start_timesteps],
+                "park_end_timesteps": [park_end_timesteps],
+                "charging_park_id": [park_id],
+                "charging_point_id": [template.charging_point_id],
+            }
+        )
+        return edisgo, park_id
+
+    def test_residual_drops_fully_out_of_window_events(self):
+        """
+        Regression test for ADR 0001: a charging event whose parking window
+        has zero overlap with the active timeindex must contribute nothing -
+        not be tiled/fabricated against repeated residual_load data.
+        """
+        timeindex = pd.date_range("1/1/2011", periods=96, freq="15min")  # 1 day
+        # park window entirely on day 3, well beyond the 1-day active window
+        edisgo, park_id = self._setup_edisgo_with_single_synthetic_event(
+            timeindex,
+            park_start_timesteps=300,
+            park_end_timesteps=320,
+            chargingdemand_kWh=10.0,
+        )
+
+        charging_strategy(edisgo, strategy="residual")
+
+        edisgo_id = edisgo.electromobility.integrated_charging_parks_df.at[
+            park_id, "edisgo_id"
+        ]
+        written = edisgo.timeseries.loads_active_power[edisgo_id]
+        assert (written == 0).all()
+
+    def test_residual_prorates_boundary_straddling_event(self):
+        """
+        Regression test for ADR 0001: a charging event whose parking window
+        straddles the active timeindex boundary must have its charging
+        demand prorated by the in-window fraction of its parking time, not
+        fully charged (which would require tiled/fabricated residual_load
+        data beyond the active timeindex) and not dropped.
+        """
+        timeindex = pd.date_range("1/1/2011", periods=96, freq="15min")  # steps 0-95
+        # park window [90, 149] (60 steps), only steps 90-95 (6 steps) are
+        # in-window -> in_window_fraction = 6/60 = 0.1
+        edisgo, park_id = self._setup_edisgo_with_single_synthetic_event(
+            timeindex,
+            park_start_timesteps=90,
+            park_end_timesteps=149,
+            chargingdemand_kWh=12.0,
+        )
+        edisgo_id = edisgo.electromobility.integrated_charging_parks_df.at[
+            park_id, "edisgo_id"
+        ]
+
+        charging_strategy(edisgo, strategy="residual")
+
+        written = edisgo.timeseries.loads_active_power[edisgo_id]
+
+        # only in-window steps (90-95) may carry any charging
+        assert (written.iloc[:90] == 0).all()
+        assert written.iloc[90:].sum() > 0
+
+        # compare against the same event fully inside a timeindex covering
+        # its whole parking window - the straddling case must deliver
+        # strictly less energy than the fully-observable case, since only
+        # 1/10th of its parking time is actually in-window here
+        full_timeindex = pd.date_range("1/1/2011", periods=150, freq="15min")
+        edisgo_full, park_id_full = self._setup_edisgo_with_single_synthetic_event(
+            full_timeindex,
+            park_start_timesteps=90,
+            park_end_timesteps=149,
+            chargingdemand_kWh=12.0,
+        )
+        charging_strategy(edisgo_full, strategy="residual")
+        edisgo_id_full = edisgo_full.electromobility.integrated_charging_parks_df.at[
+            park_id_full, "edisgo_id"
+        ]
+        full_energy = edisgo_full.timeseries.loads_active_power[edisgo_id_full].sum()
+
+        straddling_energy = written.sum()
+        assert 0 < straddling_energy < full_energy
+
+    def test_residual_fully_inside_event_unaffected(self):
+        """
+        Regression test for ADR 0001: an event whose parking window is
+        entirely inside the active timeindex must be scheduled exactly the
+        same regardless of how much longer the active timeindex extends
+        beyond the event's own window - proration must not affect
+        fully-observable events at all.
+        """
+        edisgo_short, park_id_short = self._setup_edisgo_with_single_synthetic_event(
+            pd.date_range("1/1/2011", periods=60, freq="15min"),
+            park_start_timesteps=10,
+            park_end_timesteps=50,
+            chargingdemand_kWh=8.0,
+        )
+        edisgo_long, park_id_long = self._setup_edisgo_with_single_synthetic_event(
+            pd.date_range("1/1/2011", periods=200, freq="15min"),
+            park_start_timesteps=10,
+            park_end_timesteps=50,
+            chargingdemand_kWh=8.0,
+        )
+
+        charging_strategy(edisgo_short, strategy="residual")
+        charging_strategy(edisgo_long, strategy="residual")
+
+        edisgo_id_short = edisgo_short.electromobility.integrated_charging_parks_df.at[
+            park_id_short, "edisgo_id"
+        ]
+        edisgo_id_long = edisgo_long.electromobility.integrated_charging_parks_df.at[
+            park_id_long, "edisgo_id"
+        ]
+        energy_short = edisgo_short.timeseries.loads_active_power[edisgo_id_short].sum()
+        energy_long = edisgo_long.timeseries.loads_active_power[edisgo_id_long].sum()
+
+        assert energy_short > 0
+        assert energy_short == pytest.approx(energy_long)
+
+    def test_residual_no_tiling_across_gapped_timeindex(self):
+        """
+        Regression test for ADR 0001: with a gapped active timeindex, an
+        event that overlaps both disjoint runs must only ever be scheduled
+        into steps actually present in the active timeindex - never into the
+        gap, and never against fabricated/tiled residual_load data.
+        """
+        # two disjoint 15-min runs: steps 0-23 and steps 100-123 (gap of 76
+        # steps in between, well beyond any real residual_load coverage)
+        run_1 = pd.date_range("1/1/2011", periods=24, freq="15min")
+        run_2 = pd.date_range("1/1/2011", periods=24, freq="15min") + pd.Timedelta(
+            minutes=15 * 100
+        )
+        gapped_timeindex = run_1.union(run_2)
+
+        edisgo, park_id = self._setup_edisgo_with_single_synthetic_event(
+            gapped_timeindex,
+            park_start_timesteps=10,
+            park_end_timesteps=110,
+            chargingdemand_kWh=6.0,
+        )
+
+        charging_strategy(edisgo, strategy="residual")
+
+        edisgo_id = edisgo.electromobility.integrated_charging_parks_df.at[
+            park_id, "edisgo_id"
+        ]
+        written = edisgo.timeseries.loads_active_power[edisgo_id]
+
+        # written series must exactly match the gapped index - nothing
+        # fabricated to bridge the gap
+        pd.testing.assert_index_equal(written.index, gapped_timeindex)
+        assert written.sum() > 0
+
+    def test_residual_dumb_subbucket_respects_internal_gap(self):
+        """
+        Regression test for ADR 0001: a "dumb-charged" event within the
+        residual strategy (use_case in {public, hpc} or flex_time == 0)
+        whose deterministic charging interval spans a gap in the active
+        timeindex must only ever write to in-window positions - never a
+        blind contiguous slice bridging the gap.
+        """
+        run_1 = pd.date_range("1/1/2011", periods=10, freq="15min")
+        run_2 = pd.date_range("1/1/2011", periods=10, freq="15min") + pd.Timedelta(
+            minutes=15 * 20
+        )
+        gapped_timeindex = run_1.union(run_2)
+
+        edisgo = EDisGo(ding0_grid=self.ding0_path)
+        edisgo.set_timeindex(gapped_timeindex)
+        edisgo.import_electromobility(
+            data_source="directory",
+            charging_processes_dir=self.simbev_path,
+            potential_charging_points_dir=self.tracbev_path,
+        )
+        integrated = edisgo.electromobility.integrated_charging_parks_df
+        park_id = integrated.index[0]
+        template = edisgo.electromobility.charging_processes_df[
+            edisgo.electromobility.charging_processes_df.charging_park_id == park_id
+        ].iloc[0]
+
+        # public use_case -> always dumb-charged even under "residual";
+        # park window [5, 24] straddles the gap (steps 10-19)
+        edisgo.electromobility.charging_processes_df = pd.DataFrame(
+            {
+                "ags": [template.ags],
+                "car_id": [0],
+                "destination": [template.destination],
+                "use_case": ["public"],
+                "nominal_charging_capacity_kW": [template.nominal_charging_capacity_kW],
+                "grid_charging_capacity_kW": [template.grid_charging_capacity_kW],
+                "chargingdemand_kWh": [2.0],
+                "park_time_timesteps": [20],
+                "park_start_timesteps": [5],
+                "park_end_timesteps": [24],
+                "charging_park_id": [park_id],
+                "charging_point_id": [template.charging_point_id],
+            }
+        )
+
+        charging_strategy(edisgo, strategy="residual")
+
+        edisgo_id = integrated.at[park_id, "edisgo_id"]
+        written = edisgo.timeseries.loads_active_power[edisgo_id]
+
+        pd.testing.assert_index_equal(written.index, gapped_timeindex)
+        # no NaNs, no crash from writing into a position that doesn't exist
+        assert not written.isna().any()
+
     def test_charging_strategy_with_subset_of_parks(self):
         """
         Charging strategies can be applied to different subsets of charging parks


### PR DESCRIPTION
## Summary
- Fixes #724 — `residual` charging strategy tiled (fabricated) `residual_load` data to cover charging events extending beyond the active eDisGo timeindex, biasing which timesteps got selected as "cheapest" for events far from the tiled window.
- Replaces tiling with restrict-to-active-window, per `docs/adr/0001-residual-charging-strategy-window-boundary-handling.md`:
  - Fully out-of-window events are dropped (zero contribution, not a special case).
  - Boundary-straddling events are prorated by their in-window parking-time fraction, recomputing `minimum_charging_time` at unchanged nominal power (with a defensive clamp for pre-existing anomalous input).
  - A non-contiguous active timeindex is handled correctly both across events and *within* a single event's window: the `residual_dumb` sub-bucket only writes to in-window sub-slices of its deterministic charging interval, and the `argpartition` ranking candidate pool excludes any out-of-window steps.

## Test plan
- [x] 5 new regression tests added to `tests/flex_opt/test_charging_strategy.py`: drop fully-out-of-window events, prorate boundary-straddling events, fully-inside events unaffected regardless of timeindex length, no tiling across a gapped active timeindex, and the internal `residual_dumb` sub-bucket respects an internal gap.
- [x] Full `tests/flex_opt/test_charging_strategy.py` (11 tests) passes.
- [x] Collateral: `tests/flex_opt/` + `tests/network/` (163 passed), `tests/run/` (52 passed), `tests/io/test_electromobility_import.py` + `tests/io/test_powermodels_io.py` + `tests/network/test_electromobility.py` (27 passed), `test_apply_charging_strategy` in `tests/test_edisgo.py`.
- [x] `ruff check` / `ruff format` clean.
