### PR TITLE
fix: reduce dumb/reduced/flexibility_bands to the active timeindex be…

### DIFF
--- a/edisgo/flex_opt/charging_strategies.py
+++ b/edisgo/flex_opt/charging_strategies.py
@@ -192,6 +192,27 @@ def charging_strategy(
 
         edisgo_obj.timeseries.resample(freq=simbev_timedelta)
 
+    # Map each SimBEV step position (0 .. len_ts - 1, the same positional
+    # space as park_start_timesteps/the placement slices below) to whether it
+    # is present in the active timeindex (`target_timeindex`). `dumb` and
+    # `reduced` place each event's demand deterministically at
+    # [start, start+stop) - rather than building the full-SimBEV-length
+    # series unconditionally and cropping the *output* down to the active
+    # timeindex afterwards (as before), the placement itself is now clipped
+    # to whatever of that interval is actually in-window, so an event's
+    # reported energy is a direct consequence of which positions get
+    # written, not a separate proration calculation (see ADR 0002).
+    # `resample=True` means `target_timeindex` predates an internal
+    # frequency round-trip and is no longer in the same step space as
+    # `park_start_timesteps` - the crop-after-build step already skips
+    # trimming in that case (see the module docstring), so this reduction is
+    # skipped here too and every step is treated as in-window, preserving
+    # today's (build-full) behavior only for that known limitation.
+    if resample:
+        step_in_window = np.ones(len_ts, dtype=bool)
+    else:
+        step_in_window = np.isin(timeindex, target_timeindex)
+
     if strategy == "dumb":
         # "dumb" charging
         # Collect each charging park's series and add them to the time series in a
@@ -214,7 +235,15 @@ def charging_strategy(
             for _, start, stop, cap in charging_processes_df[
                 RELEVANT_CHARGING_STRATEGIES_COLUMNS["dumb"]
             ].itertuples():
-                dummy_ts[start : start + stop] += cap
+                # Write only to in-window positions of the deterministic
+                # charging interval [start, start+stop) - if the active
+                # timeindex has a gap inside this interval, every in-window
+                # sub-slice still gets the event's full, unscaled power (see
+                # ADR 0002); out-of-window positions are simply not written.
+                in_window_idx = (
+                    np.flatnonzero(step_in_window[start : start + stop]) + start
+                )
+                dummy_ts[in_window_idx] += cap
 
             cp_ts[cp.edisgo_id] = dummy_ts
 
@@ -253,12 +282,20 @@ def charging_strategy(
             ) in charging_processes_df[
                 RELEVANT_CHARGING_STRATEGIES_COLUMNS["reduced"]
             ].itertuples():
+                # See the "dumb" branch above for why the placement slice
+                # itself (not a separate energy calculation) is clipped to
+                # in-window positions.
                 if use_case == "public" or use_case == "hpc":
                     # if the charging process takes place in a "public" setting
                     # the charging is "dumb"
-                    dummy_ts[start : start + stop_dumb] += cap_dumb
+                    start_, stop_, cap = start, stop_dumb, cap_dumb
                 else:
-                    dummy_ts[start : start + stop_reduced] += cap_reduced
+                    start_, stop_, cap = start, stop_reduced, cap_reduced
+
+                in_window_idx = (
+                    np.flatnonzero(step_in_window[start_ : start_ + stop_]) + start_
+                )
+                dummy_ts[in_window_idx] += cap
 
             cp_ts[cp.edisgo_id] = dummy_ts
 

--- a/edisgo/network/electromobility.py
+++ b/edisgo/network/electromobility.py
@@ -489,6 +489,91 @@ class Electromobility:
                 start=start_date, periods=t_max + 1, freq=f"{stepsize}min"
             )
 
+        # Reduce to only the charging processes actually needed for
+        # edisgo_obj.timeseries.timeindex, instead of always building over
+        # every process regardless of how much shorter the active timeindex
+        # is (see ADR 0002). SimBEV's calendar (start_date) is typically a
+        # fixed reference year independent of the scenario year, so the
+        # active timeindex is inverse year-shifted onto that calendar to
+        # find which SimBEV steps are actually relevant - this mirrors the
+        # forward year-shift `align_series_to_timeindex` already applies to
+        # the built bands further down. Only events overlapping that window
+        # are kept (mirrors dumb/reduced/residual: zero overlap -> zero
+        # contribution, not a special case).
+        #
+        # The array itself is NOT truncated to the window's end, only
+        # (potentially) to the earliest relevant event's start: clamping a
+        # retained event's true end down to an artificial array boundary
+        # would push it onto the `end == n_steps - 1` edge case below (a
+        # pre-existing, unrelated exclusion for events ending exactly on the
+        # array's last row) for every boundary-straddling event, silently
+        # dropping their contribution entirely rather than only trimming it.
+        # The array is instead sized to comfortably cover every retained
+        # event's true end - the pre-existing final `.loc[edisgo_timeindex]`
+        # step below still discards whatever trailing rows aren't needed.
+        edisgo_timeindex = edisgo_obj.timeseries.timeindex
+        if len(edisgo_timeindex) > 0:
+            year_diff = flex_band_index[0].year - edisgo_timeindex[0].year
+            simbev_calendar_timeindex = edisgo_timeindex + pd.DateOffset(
+                years=year_diff
+            )
+            window_start_step = int(
+                (simbev_calendar_timeindex.min() - flex_band_index[0])
+                / pd.Timedelta(f"{stepsize}min")
+            )
+            window_end_step = int(
+                (simbev_calendar_timeindex.max() - flex_band_index[0])
+                / pd.Timedelta(f"{stepsize}min")
+            )
+
+            overlaps_window = (
+                self.charging_processes_df.park_end_timesteps >= window_start_step
+            ) & (self.charging_processes_df.park_start_timesteps <= window_end_step)
+            relevant_processes = self.charging_processes_df.loc[overlaps_window]
+
+            if relevant_processes.empty:
+                # No event overlaps the active window at all (e.g. the
+                # window falls entirely outside SimBEV's simulated range) -
+                # size the array to the window itself so the final
+                # `.loc[edisgo_timeindex]` step still produces the expected
+                # shape (filled with NaN via `align_series_to_timeindex`,
+                # exactly as the pre-existing full-span build already would
+                # have for this case), without ever touching t_max, which
+                # only bounds where real event data can be, not the window.
+                array_start_step = window_start_step
+                array_end_step = window_end_step
+            else:
+                array_start_step = min(
+                    window_start_step,
+                    int(relevant_processes.park_start_timesteps.min()),
+                )
+                # Cover every retained event's true end (never clamped down
+                # below it) as well as the active window's own end. +1 extra
+                # step of padding mirrors the pre-existing `end_date + 1 day`
+                # padding on the full-span build (see above) - it exists so
+                # a retained event's true end never lands exactly on the
+                # array's last row, which would otherwise trip the
+                # pre-existing `end == n_steps - 1` exclusion below for
+                # every such event instead of just the rare full-span case
+                # it originally guarded against.
+                array_end_step = (
+                    max(
+                        window_end_step,
+                        int(relevant_processes.park_end_timesteps.max()),
+                    )
+                    + 1
+                )
+
+            flex_band_index = pd.date_range(
+                start=flex_band_index[0]
+                + pd.Timedelta(f"{array_start_step * stepsize}min"),
+                periods=max(array_end_step - array_start_step + 1, 0),
+                freq=f"{stepsize}min",
+            )
+        else:
+            relevant_processes = self.charging_processes_df
+            array_start_step = 0
+
         # set up bands
         n_steps = len(flex_band_index)
         tmp_idx = range(n_steps)
@@ -502,14 +587,21 @@ class Electromobility:
         # map every charging process to the column (charging point) it belongs to;
         # processes of charging points outside `cps` map to -1 and are dropped
         park_to_cp = self.integrated_charging_parks_df["edisgo_id"]
-        proc = self.charging_processes_df
+        proc = relevant_processes
         col = cps.index.get_indexer(proc["charging_park_id"].map(park_to_cp))
-        end_all = proc["park_end_timesteps"].to_numpy()
+        # shift into the (possibly truncated) array's own step space - never
+        # clamped, since the array was sized to cover every retained event's
+        # true end above
+        start_all = proc["park_start_timesteps"].to_numpy() - array_start_step
+        end_all = proc["park_end_timesteps"].to_numpy() - array_start_step
         # the last time step can lead to problems --> skip those processes
         keep = (col >= 0) & (end_all != n_steps - 1)
 
         col = col[keep]
-        sub = proc.loc[keep]
+        sub = proc.loc[keep].assign(
+            park_start_timesteps=start_all[keep],
+            park_end_timesteps=end_all[keep],
+        )
         start = sub["park_start_timesteps"].to_numpy().astype(int)
         end = sub["park_end_timesteps"].to_numpy().astype(int)
         power = sub["nominal_charging_capacity_kW"].to_numpy(dtype=float)

--- a/tests/flex_opt/test_charging_strategy.py
+++ b/tests/flex_opt/test_charging_strategy.py
@@ -396,6 +396,147 @@ class TestChargingStrategy:
         # no NaNs, no crash from writing into a position that doesn't exist
         assert not written.isna().any()
 
+    @pytest.mark.parametrize("strategy", ["dumb", "reduced"])
+    def test_dumb_reduced_clip_placement_to_active_timeindex(self, strategy):
+        """
+        Regression test for ADR 0002: dumb/reduced must clip their
+        deterministic charging placement slice to the active timeindex
+        instead of building the full-SimBEV-length series and relying on a
+        later crop - a charging interval that extends beyond the active
+        timeindex must only ever be written for its in-window positions,
+        at unchanged (unscaled) power.
+        """
+        # active timeindex ends at step 92 (93 steps: 0-92)
+        timeindex = pd.date_range("1/1/2011", periods=93, freq="15min")
+        edisgo, park_id = self._setup_edisgo_with_single_synthetic_event(
+            timeindex,
+            park_start_timesteps=90,
+            park_end_timesteps=149,
+            chargingdemand_kWh=12.0,
+        )
+        edisgo_id = edisgo.electromobility.integrated_charging_parks_df.at[
+            park_id, "edisgo_id"
+        ]
+
+        charging_strategy(edisgo, strategy=strategy)
+
+        written = edisgo.timeseries.loads_active_power[edisgo_id]
+        nonzero = written[written != 0]
+
+        # written series must match the active timeindex exactly - no extra
+        # rows for steps beyond it (nothing fabricated/built past the window)
+        pd.testing.assert_index_equal(written.index, timeindex)
+        # only in-window steps (<= step 92, i.e. before 1/1/2011 23:15) may
+        # ever carry a nonzero value
+        assert (nonzero.index <= timeindex[-1]).all()
+        assert len(nonzero) > 0
+
+        # compare against the same event given a timeindex long enough to
+        # cover its whole charging interval - the clipped case must report
+        # strictly less energy, since some of its charging steps fall
+        # outside the shorter active timeindex
+        long_timeindex = pd.date_range("1/1/2011", periods=150, freq="15min")
+        edisgo_long, park_id_long = self._setup_edisgo_with_single_synthetic_event(
+            long_timeindex,
+            park_start_timesteps=90,
+            park_end_timesteps=149,
+            chargingdemand_kWh=12.0,
+        )
+        edisgo_id_long = edisgo_long.electromobility.integrated_charging_parks_df.at[
+            park_id_long, "edisgo_id"
+        ]
+        charging_strategy(edisgo_long, strategy=strategy)
+        full_energy = edisgo_long.timeseries.loads_active_power[edisgo_id_long].sum()
+
+        assert 0 < written.sum() < full_energy
+
+        # power at each in-window step must be unchanged (no proration of
+        # the rate itself) - every nonzero value equals the same per-step
+        # power the long-timeindex (unclipped) run reports
+        long_nonzero_values = edisgo_long.timeseries.loads_active_power[edisgo_id_long]
+        long_nonzero_values = long_nonzero_values[long_nonzero_values != 0]
+        assert nonzero.iloc[0] == pytest.approx(long_nonzero_values.iloc[0])
+
+    @pytest.mark.parametrize("strategy", ["dumb", "reduced"])
+    def test_dumb_reduced_fully_out_of_window_event_contributes_nothing(self, strategy):
+        """
+        Regression test for ADR 0002: an event whose deterministic charging
+        interval has zero overlap with the active timeindex must contribute
+        nothing.
+        """
+        timeindex = pd.date_range("1/1/2011", periods=96, freq="15min")  # 1 day
+        edisgo, park_id = self._setup_edisgo_with_single_synthetic_event(
+            timeindex,
+            park_start_timesteps=300,
+            park_end_timesteps=320,
+            chargingdemand_kWh=10.0,
+        )
+        edisgo_id = edisgo.electromobility.integrated_charging_parks_df.at[
+            park_id, "edisgo_id"
+        ]
+
+        charging_strategy(edisgo, strategy=strategy)
+
+        written = edisgo.timeseries.loads_active_power[edisgo_id]
+        assert (written == 0).all()
+
+    @pytest.mark.parametrize("strategy", ["dumb", "reduced"])
+    def test_dumb_reduced_respect_internal_gap(self, strategy):
+        """
+        Regression test for ADR 0002: if an event's deterministic charging
+        interval itself spans a gap in a non-contiguous active timeindex,
+        every in-window sub-slice of that interval must be written
+        independently, at full unscaled power - never a blind contiguous
+        write bridging the gap.
+        """
+        run_1 = pd.date_range("1/1/2011", periods=10, freq="15min")
+        run_2 = pd.date_range("1/1/2011", periods=10, freq="15min") + pd.Timedelta(
+            minutes=15 * 20
+        )
+        gapped_timeindex = run_1.union(run_2)
+
+        edisgo = EDisGo(ding0_grid=self.ding0_path)
+        edisgo.set_timeindex(gapped_timeindex)
+        edisgo.import_electromobility(
+            data_source="directory",
+            charging_processes_dir=self.simbev_path,
+            potential_charging_points_dir=self.tracbev_path,
+        )
+        integrated = edisgo.electromobility.integrated_charging_parks_df
+        park_id = integrated.index[0]
+        template = edisgo.electromobility.charging_processes_df[
+            edisgo.electromobility.charging_processes_df.charging_park_id == park_id
+        ].iloc[0]
+
+        # work use_case, small enough demand that minimum_charging_time (or
+        # reduced_charging_time) spans steps 5-24, straddling the gap
+        # (steps 10-19, absent from the active timeindex)
+        edisgo.electromobility.charging_processes_df = pd.DataFrame(
+            {
+                "ags": [template.ags],
+                "car_id": [0],
+                "destination": [template.destination],
+                "use_case": ["work"],
+                "nominal_charging_capacity_kW": [template.nominal_charging_capacity_kW],
+                "grid_charging_capacity_kW": [template.grid_charging_capacity_kW],
+                "chargingdemand_kWh": [2.0],
+                "park_time_timesteps": [20],
+                "park_start_timesteps": [5],
+                "park_end_timesteps": [24],
+                "charging_park_id": [park_id],
+                "charging_point_id": [template.charging_point_id],
+            }
+        )
+
+        charging_strategy(edisgo, strategy=strategy)
+
+        edisgo_id = integrated.at[park_id, "edisgo_id"]
+        written = edisgo.timeseries.loads_active_power[edisgo_id]
+
+        pd.testing.assert_index_equal(written.index, gapped_timeindex)
+        # no NaNs, no crash from writing into a position that doesn't exist
+        assert not written.isna().any()
+
     def test_charging_strategy_with_subset_of_parks(self):
         """
         Charging strategies can be applied to different subsets of charging parks

--- a/tests/network/test_electromobility.py
+++ b/tests/network/test_electromobility.py
@@ -217,6 +217,253 @@ class TestElectromobility:
             # must not raise KeyError
             edisgo_obj.electromobility.flexibility_bands[key].loc[short_timeindex]
 
+    def test_get_flexibility_bands_carries_forward_true_start_end(self):
+        """
+        Regression test for ADR 0002: upper_energy/lower_energy must reflect
+        each event's TRUE park_start_timesteps/park_end_timesteps, even when
+        the active timeindex's window starts after (or ends before) that
+        true start/end - the bands must not be reset to zero / re-anchored
+        at the window's own edge. Verified by comparing the same event's
+        band value at a shared calendar timestamp, once built over the full
+        SimBEV span and once built over a window starting after the event's
+        true park_start_timesteps.
+        """
+        edisgo_obj = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo_obj, self.simbev_path, self.tracbev_path
+        )
+        electromobility_import.distribute_charging_demand(edisgo_obj)
+        electromobility_import.integrate_charging_parks(edisgo_obj)
+
+        full_timeindex = pd.date_range("1/1/2011", periods=200, freq="15min")
+        edisgo_obj.set_timeindex(full_timeindex)
+        full_bands = edisgo_obj.electromobility.get_flexibility_bands(
+            edisgo_obj, ["work", "public", "home", "hpc"]
+        )
+
+        # pick a charging point/timestamp where upper_energy is already
+        # elevated (i.e. charging started earlier and hasn't finished) -
+        # windowing from here on must preserve that value, not reset to 0
+        upper_energy_full = full_bands["upper_energy"]
+        nonzero_mask = upper_energy_full > 0
+        elevated_positions = nonzero_mask[nonzero_mask.any(axis=1)]
+        assert not elevated_positions.empty
+        window_start = elevated_positions.index[len(elevated_positions.index) // 2]
+        cp_id = elevated_positions.loc[window_start][
+            elevated_positions.loc[window_start]
+        ].index[0]
+        expected_value = upper_energy_full.loc[window_start, cp_id]
+        assert expected_value > 0
+
+        edisgo_obj_windowed = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo_obj_windowed, self.simbev_path, self.tracbev_path
+        )
+        electromobility_import.distribute_charging_demand(edisgo_obj_windowed)
+        electromobility_import.integrate_charging_parks(edisgo_obj_windowed)
+        windowed_timeindex = full_timeindex[full_timeindex >= window_start]
+        edisgo_obj_windowed.set_timeindex(windowed_timeindex)
+
+        windowed_bands = edisgo_obj_windowed.electromobility.get_flexibility_bands(
+            edisgo_obj_windowed, ["work", "public", "home", "hpc"]
+        )
+        windowed_value = windowed_bands["upper_energy"].loc[window_start, cp_id]
+
+        assert windowed_value == pytest.approx(expected_value)
+
+    def test_get_flexibility_bands_reflects_partial_progress_for_unfinished_event(self):
+        """
+        Regression test for ADR 0002: even though get_flexibility_bands now
+        filters out charging processes with zero overlap with the active
+        timeindex (see test_get_flexibility_bands_excludes_events_and_limits_
+        array_size below), a RETAINED event that straddles the window
+        boundary must still report only the energy that charging-so-far
+        implies at each in-window timestep - never the event's full
+        (possibly not-yet-delivered) chargingdemand_kWh and never a naive
+        proportional share of it. upper_energy/lower_energy are cumulative
+        running totals of physically possible charging progress, not a
+        fixed total being allocated, and this must hold regardless of
+        whether the array is sized to SimBEV's full range or only to what's
+        needed.
+        """
+        edisgo_obj = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo_obj, self.simbev_path, self.tracbev_path
+        )
+        electromobility_import.distribute_charging_demand(edisgo_obj)
+        electromobility_import.integrate_charging_parks(edisgo_obj)
+
+        integrated = edisgo_obj.electromobility.integrated_charging_parks_df
+        park_id = integrated.index[0]
+        template = edisgo_obj.electromobility.charging_processes_df[
+            edisgo_obj.electromobility.charging_processes_df.charging_park_id == park_id
+        ].iloc[0]
+        edisgo_id = integrated.at[park_id, "edisgo_id"]
+
+        # event needs 60 steps of charging at 10 kW (150 kWh) to fulfil its
+        # demand, parked for 100 steps [50, 149] - charging is NOT finished
+        # by step 95 (needs steps 50-109)
+        edisgo_obj.electromobility.charging_processes_df = pd.DataFrame(
+            {
+                "ags": [template.ags],
+                "car_id": [0],
+                "destination": [template.destination],
+                "use_case": [template.use_case],
+                "nominal_charging_capacity_kW": [10.0],
+                "grid_charging_capacity_kW": [10.0],
+                "chargingdemand_kWh": [150.0],
+                "park_time_timesteps": [100],
+                "park_start_timesteps": [50],
+                "park_end_timesteps": [149],
+                "charging_park_id": [park_id],
+                "charging_point_id": [template.charging_point_id],
+            }
+        )
+
+        # active timeindex ends at step 95 - 46 steps into the 60-step
+        # charge (steps 50-95 inclusive = 46 steps)
+        timeindex = pd.date_range("1/1/2011", periods=96, freq="15min")
+        edisgo_obj.set_timeindex(timeindex)
+
+        bands = edisgo_obj.electromobility.get_flexibility_bands(
+            edisgo_obj, [template.use_case]
+        )
+        upper_energy_at_cutoff = bands["upper_energy"][edisgo_id].iloc[-1]
+
+        steps_charged_by_cutoff = 46
+        expected_kWh = steps_charged_by_cutoff * 10.0 / 4  # 10 kW, 15-min steps
+        full_demand_kWh = 150.0
+        proportional_share_kWh = full_demand_kWh * steps_charged_by_cutoff / 60
+
+        assert upper_energy_at_cutoff * 1e3 == pytest.approx(expected_kWh)
+        # must not be the full (not-yet-delivered) demand ...
+        assert upper_energy_at_cutoff * 1e3 != pytest.approx(full_demand_kWh)
+        # ... and not a naive proportional share of it either (they happen
+        # to coincide here only because chargingdemand_kWh/park_time_timesteps
+        # is linear - assert the true value directly, not this coincidence)
+        assert expected_kWh == pytest.approx(proportional_share_kWh)
+
+    def test_get_flexibility_bands_excludes_events_and_limits_array_size(self):
+        """
+        Regression test for ADR 0002: get_flexibility_bands must not build
+        over SimBEV's entire simulated range (nor over every charging
+        process) regardless of how much shorter the active timeindex is -
+        this was the actual "build full, then crop" waste this ADR targets,
+        distinct from (and originally mistaken for) mere value-correctness
+        after the final .loc[edisgo_timeindex] clip. A fully out-of-window
+        event must not extend the internal construction array at all, and
+        the returned bands must still be correct and exactly the active
+        timeindex's length.
+        """
+        edisgo_obj = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo_obj, self.simbev_path, self.tracbev_path
+        )
+        electromobility_import.distribute_charging_demand(edisgo_obj)
+        electromobility_import.integrate_charging_parks(edisgo_obj)
+
+        integrated = edisgo_obj.electromobility.integrated_charging_parks_df
+        park_id = integrated.index[0]
+        template = edisgo_obj.electromobility.charging_processes_df[
+            edisgo_obj.electromobility.charging_processes_df.charging_park_id == park_id
+        ].iloc[0]
+        edisgo_id = integrated.at[park_id, "edisgo_id"]
+
+        # one event fully inside the active window, one event far outside
+        # it (near the end of SimBEV's simulated week) that must not affect
+        # the construction array's size at all
+        edisgo_obj.electromobility.charging_processes_df = pd.DataFrame(
+            {
+                "ags": [template.ags, template.ags],
+                "car_id": [0, 1],
+                "destination": [template.destination, template.destination],
+                "use_case": [template.use_case, template.use_case],
+                "nominal_charging_capacity_kW": [10.0, 10.0],
+                "grid_charging_capacity_kW": [10.0, 10.0],
+                "chargingdemand_kWh": [10.0, 10.0],
+                "park_time_timesteps": [20, 20],
+                "park_start_timesteps": [10, 600],
+                "park_end_timesteps": [29, 619],
+                "charging_park_id": [park_id, park_id],
+                "charging_point_id": [
+                    template.charging_point_id,
+                    template.charging_point_id,
+                ],
+            }
+        )
+
+        timeindex = pd.date_range("1/1/2011", periods=96, freq="15min")  # 1 day
+        edisgo_obj.set_timeindex(timeindex)
+
+        orig_zeros = np.zeros
+        shapes = []
+
+        def spy_zeros(shape, *a, **kw):
+            shapes.append(shape)
+            return orig_zeros(shape, *a, **kw)
+
+        np.zeros = spy_zeros
+        try:
+            bands = edisgo_obj.electromobility.get_flexibility_bands(
+                edisgo_obj, [template.use_case]
+            )
+        finally:
+            np.zeros = orig_zeros
+
+        # construction arrays must be far smaller than SimBEV's full
+        # simulated week (672 steps) - sized only around the active window
+        # and the in-window event, not the far-away out-of-window one
+        assert all(shape[0] < 200 for shape in shapes)
+
+        # returned bands are still correct: exactly the active timeindex's
+        # length, and reflect only the in-window event's contribution
+        assert_index_equal(bands["upper_power"].index, timeindex)
+        assert bands["upper_power"][edisgo_id].sum() > 0
+
+    def test_get_flexibility_bands_clips_independently_per_gapped_interval(self):
+        """
+        Regression test for ADR 0002: with a non-contiguous active
+        timeindex, each disjoint interval's bands must match exactly what a
+        standalone run scoped to just that interval would produce - i.e.
+        clipping the true, full band per interval, with no interaction
+        between intervals.
+        """
+        edisgo_obj = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo_obj, self.simbev_path, self.tracbev_path
+        )
+        electromobility_import.distribute_charging_demand(edisgo_obj)
+        electromobility_import.integrate_charging_parks(edisgo_obj)
+
+        run_1 = pd.date_range("1/1/2011", periods=24, freq="15min")
+        run_2 = pd.date_range("1/1/2011", periods=24, freq="15min") + pd.Timedelta(
+            days=3
+        )
+        gapped_timeindex = run_1.union(run_2)
+        edisgo_obj.set_timeindex(gapped_timeindex)
+
+        gapped_bands = edisgo_obj.electromobility.get_flexibility_bands(
+            edisgo_obj, ["work", "public", "home", "hpc"]
+        )
+
+        edisgo_obj_run1 = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        electromobility_import.import_electromobility_from_dir(
+            edisgo_obj_run1, self.simbev_path, self.tracbev_path
+        )
+        electromobility_import.distribute_charging_demand(edisgo_obj_run1)
+        electromobility_import.integrate_charging_parks(edisgo_obj_run1)
+        edisgo_obj_run1.set_timeindex(run_1)
+        run1_bands = edisgo_obj_run1.electromobility.get_flexibility_bands(
+            edisgo_obj_run1, ["work", "public", "home", "hpc"]
+        )
+
+        for key in ("upper_power", "lower_energy", "upper_energy"):
+            assert_frame_equal(
+                gapped_bands[key].loc[run_1],
+                run1_bands[key],
+                check_freq=False,
+            )
+
     def test_get_flexibility_bands_empty_timeindex_is_a_no_op(self):
         """
         With no timeindex set at all, get_flexibility_bands must return the


### PR DESCRIPTION
## Summary
- Follow-up to #703, addressing `docs/adr/0002-charging-time-series-reduced-to-active-timeindex-before-building.md` (the `residual` half was #726).
- `dumb`/`reduced` now clip their deterministic charging placement slice to whatever overlaps the active timeindex, rather than writing unconditionally at full SimBEV length. A gap inside a single event's charging interval is handled correctly: each in-window sub-slice is written independently, at full unscaled power.
- `get_flexibility_bands` had the same underlying issue as the strategies, just harder to spot: its clipped *output values* were already correct, but *construction* built over every charging process and SimBEV's entire simulated range regardless of the active timeindex's length. Now filters to overlapping events first (correctly inverse-year-shifting the active timeindex onto SimBEV's own calendar) and sizes the construction array to only what's needed — confirmed via instrumentation to cut array size roughly 6x for a 1-day-of-7 example. Also fixes an interaction with a pre-existing edge case (an event whose true end lands exactly on the array's last row is silently excluded) that the tighter sizing would otherwise trigger systematically instead of rarely.
- Both ADRs updated to record what was actually implemented, including the corrected finding on `flexibility_bands` (an earlier version of this work concluded no change was needed there, based on checking value-correctness but not construction scope).

## Test plan
- [x] 6 new tests in `tests/flex_opt/test_charging_strategy.py`: clip-to-active-timeindex (parametrized dumb/reduced), fully-out-of-window contributes nothing (parametrized), internal-gap handling (parametrized).
- [x] 3 new tests in `tests/network/test_electromobility.py`: partial-progress correctness for a straddling/unfinished event, gapped-timeindex bands match a standalone per-interval run exactly, and the actual scope/array-size reduction (instrumented to assert construction arrays stay well below SimBEV's full range).
- [x] Full `tests/flex_opt/test_charging_strategy.py` (17 tests) and `tests/network/test_electromobility.py` (20 tests) pass.
- [x] Collateral: `tests/flex_opt/` + `tests/network/` + `tests/run/` + `tests/io/test_electromobility_import.py` + `tests/io/test_powermodels_io.py`, excluding known-flaky `_oedb` tests (live DB dependency, confirmed unrelated) — 230 passed, 1 skipped.
- [x] `ruff check` / `ruff format` clean.
