### PR TITLE
ci: rerun OEDB tests on transient OEP connection errors

### DIFF
--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -164,8 +164,9 @@ jobs:
       - name: Run tests (Linux)
         if: runner.os == 'Linux' && matrix.name-suffix != 'coverage'
         run: |
-          python -m pip install "pytest<9.2.0" "nbclient<0.12.0"
-          python -m pytest --runslow --runonlinux --disable-warnings --color=yes -v
+          python -m pip install "pytest<9.2.0" "nbclient<0.12.0" "pytest-rerunfailures<17.0.0"
+          python -m pytest --runslow --runonlinux --disable-warnings --color=yes -v \
+            --reruns 2 --reruns-delay 15 --only-rerun "Connection(Error|Exception)|Timeout"
         env:
           OEP_TOKEN: ${{ secrets.OEP_TOKEN }}
 
@@ -174,7 +175,9 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           python -m pip install "pytest<9.2.0" "nbclient<0.12.0"
-          python -m pytest --runslow --disable-warnings --color=yes -v
+          # Keep the pytest call on one line: this step runs in PowerShell, where "\"
+          # is not a line continuation, so a wrapped command fails to parse.
+          python -m pytest --runslow --disable-warnings --color=yes -v --reruns 2 --reruns-delay 15 --only-rerun "Connection(Error|Exception)|Timeout"
         env:
           OEP_TOKEN: ${{ secrets.OEP_TOKEN }}
 
@@ -182,8 +185,9 @@ jobs:
       - name: Run tests with coverage and submit to Coveralls
         if: runner.os == 'Linux' && matrix.python-version == 3.12 && matrix.name-suffix == 'coverage'
         run: |
-          pip install "pytest<9.2.0" "nbclient<0.12.0" coveralls
-          coverage run --source=edisgo -m pytest --runslow --runonlinux --disable-warnings --color=yes -v
+          pip install "pytest<9.2.0" "nbclient<0.12.0" "pytest-rerunfailures<17.0.0" coveralls
+          coverage run --source=edisgo -m pytest --runslow --runonlinux --disable-warnings --color=yes -v \
+            --reruns 2 --reruns-delay 15 --only-rerun "Connection(Error|Exception)|Timeout"
           coveralls
         env:
           OEP_TOKEN: ${{ secrets.OEP_TOKEN }}


### PR DESCRIPTION
# Description

The OEDB tests hit the live OEP, which intermittently returns 503/504 (oedialect
`ConnectionException`) or refuses the connection outright (requests `ConnectionError`).
These transient outages fail otherwise-green CI runs — over the last few runs a
*different* job failed each time (`basic py3.10` on dev, `coverage py3.12` on #701),
which is the signature of a flaky network dependency rather than a real regression.

- Adds `pytest-rerunfailures` to the Linux basic + coverage install steps. It is
  declared in `setup.py`'s dev extras, which the Linux jobs do not install; the Windows
  job already gets it through `eDisGo_env_dev.yml`, which pins `-e .[dev]`.
- Retries network failures only: `--reruns 2 --reruns-delay 15 --only-rerun
  "Connection(Error|Exception)|Timeout"`, so genuine assertion and logic failures still
  fail immediately without wasting three attempts on them.

Only two tests are marked `runonlinux`, so the OEP-hitting tests run on Windows as well
and get the same treatment there.

The Windows invocation deliberately stays on a single line: that step runs in PowerShell
(the job sets no `defaults: shell:`), where `\` is not a line continuation, so a wrapped
command aborts before pytest even starts with
`ParserError: Missing expression after unary operator '--'.`

Fixes no issue — CI hygiene.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] No new packages needed (`pytest-rerunfailures` was already in the dev extras)
