### PR TITLE
chore(release): prepare 0.3.0 — metadata, authors, citation info and changelog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,61 @@
+# Consolidates the multiple git identities contributors committed under, so that
+# `git shortlog -sne` and `git log --author=...` report one entry per person.
+# Format: Canonical Name <canonical@email> [<other@email> | Commit Name <other@email>]
+# See https://git-scm.com/docs/gitmailmap
+
+Jonas Danke <jonas.danke@rl-institut.de>
+Jonas Danke <jonas.danke@rl-institut.de> <66819219+joda9@users.noreply.github.com>
+# two commits were authored with Jonas' name but Kilian's address; match on both
+# fields so Kilian's own commits are not reassigned
+Jonas Danke <jonas.danke@rl-institut.de> Jonas Danke <kilian.helfenbein@rl-institut.de>
+
+Moritz Schlösser <moritz.schloesser@rl-institut.de>
+Moritz Schlösser <moritz.schloesser@rl-institut.de> <moritz.schloesser@gmx.de>
+
+Maike Held <maike.held@rl-institut.de>
+Maike Held <maike.held@rl-institut.de> <Maike.Held@rl-institut.de>
+Maike Held <maike.held@rl-institut.de> <56869935+maike93he@users.noreply.github.com>
+Maike Held <maike.held@rl-institut.de> <RL-INSTITUT\maike.held@rli-vm-01.rl-institut.local>
+
+Birgit Schachler <birgit.schachler@rl-institut.de>
+Birgit Schachler <birgit.schachler@rl-institut.de> <RL-INSTITUT\birgit.schachler@solydxk>
+
+Anya Heider <anya.heider@rl-institut.de>
+Anya Heider <anya.heider@rl-institut.de> <Anya.Heider@rl-institut.de>
+Anya Heider <anya.heider@rl-institut.de> <50416149+AnyaHe@users.noreply.github.com>
+
+Kilian Helfenbein <kilian.helfenbein@rl-institut.de>
+Kilian Helfenbein <kilian.helfenbein@rl-institut.de> <Kilian.Helfenbein@rl-institut.de>
+Kilian Helfenbein <kilian.helfenbein@rl-institut.de> <46815982+khelfen@users.noreply.github.com>
+Kilian Helfenbein <kilian.helfenbein@rl-institut.de> <s0554994@htw-berlin.de>
+
+Guido Plessmann <guido.plessmann@rl-institut.de>
+Guido Plessmann <guido.plessmann@rl-institut.de> <gplssm@users.noreply.github.com>
+
+Jonathan Amme <jonathan.amme@rl-institut.de>
+
+Bharadwaj Narasimhan <bharadwaj.narasimhan@rl-institut.de>
+Bharadwaj Narasimhan <bharadwaj.narasimhan@rl-institut.de> <29677472+boltbeard@users.noreply.github.com>
+Bharadwaj Narasimhan <bharadwaj.narasimhan@rl-institut.de> <RL-INSTITUT\bharadwaj.narasimhan@rli-nb-26lin.rl-institut.local>
+
+Elias Trommer <elias.trommer@rl-institut.de>
+Elias Trommer <elias.trommer@rl-institut.de> <elias_trommer@gmx.de>
+
+Jaap Pedersen <jaappedersen@posteo.net>
+Jaap Pedersen <jaappedersen@posteo.net> <RL-INSTITUT\jaap.pedersen@rli-nb-13.rl-institut.local>
+
+Malte Jahn <malte.jahn@rl-institut.de>
+
+Jonas Jeckstadt <jonas.jeckstadt@rl-institut.de>
+Jonas Jeckstadt <jonas.jeckstadt@rl-institut.de> <RL-INSTITUT\jonas.jeckstadt@rli-nb-44.rl-institut.local>
+
+mltja <mltja+github@mailbox.org>
+mltja <mltja+github@mailbox.org> <82087381+mltja@users.noreply.github.com>
+
+Nader Algherbawi <nadergherbawi@gmail.com>
+
+Santiago Infantino Moreno <santiago.infantino.moreno@gmail.com>
+
+Malte Scharf <malte.scharf@googlemail.com>
+
+Martin Soethe <martin.soethe@gmx.de>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,67 @@
+# Authors
+
+eDisGo is developed at the [Reiner Lemoine Institut gGmbH](https://reiner-lemoine-institut.de/)
+and grew out of the [open_eGo](https://openegoproject.wordpress.com/) research project.
+
+## Maintainers
+
+Currently developing and maintaining eDisGo:
+
+- Jonas Danke <jonas.danke@rl-institut.de>
+- Moritz Schlösser <moritz.schloesser@rl-institut.de>
+
+## Contributors
+
+Everyone who has contributed code, ordered by number of commits (`git shortlog -sn`,
+identities consolidated via [`.mailmap`](.mailmap)):
+
+| Contributor | Commits |
+|---|---|
+| Birgit Schachler | 2307 |
+| Maike Held | 453 |
+| Guido Plessmann | 364 |
+| Kilian Helfenbein | 268 |
+| Jonathan Amme | 258 |
+| Jonas Danke | 227 |
+| Anya Heider | 176 |
+| Bharadwaj Narasimhan | 157 |
+| Elias Trommer | 65 |
+| Malte Jahn | 50 |
+| Jaap Pedersen | 48 |
+| mltja | 29 |
+| Nader Algherbawi | 18 |
+| Jonas Jeckstadt | 8 |
+| Moritz Schlösser | 7 |
+| Santiago Infantino Moreno | 6 |
+| Malte Scharf | 1 |
+| Martin Soethe | 1 |
+
+The bundled Julia OPF package (`edisgo/opf/eDisGo_OPF.jl`) was written by Maike Held.
+
+## Contributions to release 0.3.0
+
+Commits since `v0.2.1`:
+
+| Contributor | Commits |
+|---|---|
+| Birgit Schachler | 597 |
+| Maike Held | 377 |
+| Jonas Danke | 227 |
+| Kilian Helfenbein | 60 |
+| Malte Jahn | 18 |
+| Nader Algherbawi | 18 |
+| mltja | 17 |
+| Jonas Jeckstadt | 8 |
+| Anya Heider | 7 |
+| Moritz Schlösser | 7 |
+
+To regenerate these numbers:
+
+```bash
+git shortlog -sn                # all time
+git shortlog -sn v0.2.1..dev    # this release
+```
+
+The authoritative record of who wrote what is the version control history; this file
+is a convenience summary. Contributions are also credited per change in
+[`doc/whatsnew`](doc/whatsnew).

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,78 @@
+# Citation metadata for eDisGo. GitHub renders this as "Cite this repository".
+# Format specification: https://citation-file-format.github.io/
+#
+# Author order puts the current maintainers first, then the largest contributors to
+# the codebase. The complete list of everyone who has contributed is in AUTHORS.md,
+# and the authoritative record is the version control history.
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: eDisGo
+abstract: >-
+  eDisGo (Electrical Distribution Grid Optimization) is a Python toolbox for
+  analysing flexibility options in electrical distribution grids. It models
+  medium- and low-voltage grids, runs power flow and grid reinforcement, and
+  optimises the dispatch of flexibilities such as electric vehicles, heat pumps,
+  storage and demand-side management with a multi-period optimal power flow.
+type: software
+license: AGPL-3.0-or-later
+version: 0.3.0
+date-released: "2026-07-29"
+repository-code: "https://github.com/openego/eDisGo"
+url: "https://edisgo.readthedocs.io/"
+keywords:
+  - distribution grid
+  - power flow
+  - grid reinforcement
+  - flexibility
+  - optimal power flow
+  - energy system modelling
+authors:
+  - given-names: Jonas
+    family-names: Danke
+    email: jonas.danke@rl-institut.de
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Moritz
+    family-names: Schlösser
+    email: moritz.schloesser@rl-institut.de
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Maike
+    family-names: Held
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Birgit
+    family-names: Schachler
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Guido
+    family-names: Plessmann
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Kilian
+    family-names: Helfenbein
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Jonathan
+    family-names: Amme
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Anya
+    family-names: Heider
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Bharadwaj
+    family-names: Narasimhan
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Elias
+    family-names: Trommer
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Malte
+    family-names: Jahn
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Jaap
+    family-names: Pedersen
+  - name: mltja
+  - given-names: Nader
+    family-names: Algherbawi
+  - given-names: Jonas
+    family-names: Jeckstadt
+    affiliation: Reiner Lemoine Institut gGmbH
+  - given-names: Santiago
+    family-names: Infantino Moreno
+  - given-names: Malte
+    family-names: Scharf
+  - given-names: Martin
+    family-names: Soethe

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -265,7 +265,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "eDisGo"
-copyright = "2017, open_eGo-Team"
+copyright = "2017-2026, open_eGo-Team"
 author = "open_eGo-Team"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/whatsnew/v0-3-0.rst
+++ b/doc/whatsnew/v0-3-0.rst
@@ -1,7 +1,7 @@
 Release v0.3.0
 ================
 
-Release date: unreleased (development version)
+Release date: July 29, 2026
 
 Changes
 -------
@@ -123,6 +123,42 @@ Changes
   and added in-depth methodology pages for power flow, grid reinforcement, complexity
   reduction and the flexibility optimisation. Tutorial notebooks are now rendered via
   nbsphinx and unmaintained methods are collected in a dedicated legacy section.
+* Added a declarative pipeline runner, :mod:`edisgo.run`: a whole eDisGo study is
+  described as a flat ``pipeline:`` list of named tasks in a YAML or JSON config and
+  executed through the single entry point :func:`~.run.runner.run_edisgo`. Tasks live
+  in :mod:`edisgo.run.tasks` (grid import, time series, flexibilities, analysis,
+  optimisation, spatial reduction, I/O) and register themselves with a
+  requires/provides contract that :mod:`~.run.validator` checks before anything runs,
+  so a misordered or incomplete config fails immediately instead of halfway through a
+  long run. Configs can build on a bundled preset (``worst_case``, ``flex_opf``,
+  ``overlying_grid_opf``, ``spatial_reduction_opf``, ``overlying_grid_opf_spatial``)
+  or on another config file via ``extends:``
+  `#731 <https://github.com/openego/eDisGo/pull/731>`_
+* Integrated spatial complexity reduction into the run pipeline via ``spatial_reduce``
+  and ``spatial_restore`` tasks bracketing ``optimize``, so the optimal power flow can
+  run on a spatially reduced grid while grid reinforcement still runs on the full
+  topology. The new
+  :func:`~.tools.spatial_complexity_reduction.apply_reduced_results_to_full_grid` maps
+  the optimised dispatch of flexible components back onto the full grid, by name or
+  disaggregated onto the aggregated members per time step, weighted by each member's
+  pre-optimisation flexibility envelope
+  `#706 <https://github.com/openego/eDisGo/pull/706>`_
+* Reworked the optimal power flow to accept feasible but non-optimal solutions instead
+  of aborting and computing an irreducible inconsistent subsystem, to solve long
+  horizons interval by interval, and to write results back robustly across intervals
+  including the solver status and state-of-charge handling
+* Reworked the database access in :mod:`~.io.db`: the source (a local egon-data
+  database or the open energy platform) is now auto-detected, the SSH tunnel is
+  hardened and closed at process exit, pooled connections survive long multi-grid runs,
+  and etrago tables are resolved in the ``grid`` schema when running against local
+  egon-data
+* Scoped :meth:`~.network.electromobility.Electromobility.get_flexibility_bands` to the
+  active time index. It previously only resampled the bands to the active *frequency*,
+  so after selecting a shorter time window the flexibility bands kept spanning the full
+  underlying SimBEV data range and consumers indexing them by
+  ``edisgo.timeseries.timeindex`` could hit missing time steps
+* Added standardised SPDX license headers to all source files
+  `#607 <https://github.com/openego/eDisGo/pull/607>`_
 * Fixed the Julia OPF sources not being packaged: ``edisgo/opf/eDisGo_OPF.jl`` was
   missing from every sdist and wheel, so :meth:`~.edisgo.EDisGo.pm_optimize` failed in
   any non-editable installation (for instance eGo's

--- a/setup.py
+++ b/setup.py
@@ -94,18 +94,43 @@ extras = {"dev": dev_requirements}
 
 setup(
     name="eDisGo",
-    version="0.3.0dev",
+    version="0.3.0",
     packages=find_packages(),
     url="https://github.com/openego/eDisGo",
+    project_urls={
+        "Documentation": "https://edisgo.readthedocs.io/",
+        "Source": "https://github.com/openego/eDisGo",
+        "Changelog": "https://edisgo.readthedocs.io/en/dev/whatsnew.html",
+        "Issues": "https://github.com/openego/eDisGo/issues",
+    },
     license="GNU Affero General Public License v3.0",
+    # Maintainers first, then the largest contributors. The complete list is in
+    # AUTHORS.md and CITATION.cff.
     author=(
-        "birgits, AnyaHe, khelfen, mltja, gplssm, nesnoj, jaappedersen, Elias, "
-        "boltbeard"
+        "Jonas Danke, Moritz Schlösser, Maike Held, birgits, AnyaHe, khelfen, "
+        "mltja, gplssm, nesnoj, jaappedersen, Elias, boltbeard"
     ),
-    author_email="anya.heider@rl-institut.de",
+    author_email="jonas.danke@rl-institut.de",
+    maintainer="Jonas Danke, Moritz Schlösser",
+    maintainer_email="jonas.danke@rl-institut.de",
     description="A python package for distribution network analysis and optimization",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
+    # numpy is pinned to 1.26.4, which has no wheels for 3.13; the test matrix covers
+    # 3.10 to 3.12.
+    python_requires=">=3.10,<3.13",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: GNU Affero General Public License v3 or later "
+        "(AGPLv3+)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Topic :: Scientific/Engineering",
+    ],
     install_requires=requirements,
     extras_require=extras,
     package_data={


### PR DESCRIPTION
# Description

Prepares the 0.3.0 release. No runtime code is touched.

**Changelog** (`ee774ccb`) — `doc/whatsnew/v0-3-0.rst` stopped at the documentation
restructuring and covered none of the work merged since. Adds entries for:

- the `edisgo.run` pipeline framework (#731)
- the spatial complexity reduction integration (#706)
- the OPF rework towards accepting feasible non-optimal solutions and per-interval solving
- the reworked database access (local egon-data vs. OEP auto-detection, hardened SSH tunnel)
- the `get_flexibility_bands` time-index scoping
- the SPDX license headers (#607)

Also sets the release date.

**Metadata** (`bc2501d4`)

- `setup.py`: version `0.3.0` (was `0.3.0dev`, which normalises to `0.3.0.dev0`), plus
  the metadata PyPI has been missing entirely — `python_requires` (`>=3.10,<3.13`:
  numpy is pinned to 1.26.4, which has no 3.13 wheels, and the test matrix covers 3.10
  to 3.12), trove classifiers and `project_urls`.
- Authors: Jonas Danke and Moritz Schlösser are maintaining eDisGo now, so they lead the
  author field and are named as maintainers; the previous contributors stay listed.
  Maike Held was missing from it entirely despite being the second-largest contributor.
- `AUTHORS.md` and `CITATION.cff` are new. Neither existed, so there was no complete
  credit list outside the git history, and GitHub had nothing to render for
  "Cite this repository".
- `.mailmap` consolidates the identities people committed under: git counted 43 distinct
  authors for 19 actual people. Two commits were authored with Jonas' name but Kilian's
  address, so that entry matches on both fields rather than reassigning all of Kilian's
  commits.
- `doc/conf.py`: extend the stale copyright year (`author` intentionally unchanged).

## Verification

- `twine check` passes on both the wheel and the sdist
- the wheel METADATA carries the new author/maintainer/classifiers and
  `Requires-Python: >=3.10,<3.13`, and the version is `0.3.0`, not `0.3.0.dev0`
- `CITATION.cff` parses with all required CFF 1.2.0 fields present
- the changelog RST builds without syntax errors, and every `:func:`/`:mod:`/`:meth:`
  target referenced in the new entries exists in the code
- `ruff check` and `ruff format` clean

## Type of change

- [x] New feature (non-breaking change which adds functionality) — release metadata only

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] No new packages needed
- [x] I have added new features to the corresponding whatsnew file
- [ ] The Read the Docs documentation is compiling correctly — the `Docs link check`
      workflow is red on `dev` as well, i.e. pre-existing and unrelated to this PR
