### PR TITLE
Fix simple example notebooks: disable background map, robust LV grid …

### DIFF
--- a/doc/tutorials/simple_example.ipynb
+++ b/doc/tutorials/simple_example.ipynb
@@ -243,7 +243,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edisgo.plot_mv_grid_topology(technologies=True)"
+    "# Note: background_map=True (the default) fetches map tiles over the\n",
+    "# internet via contextily and can be slow or fail without connectivity.\n",
+    "# It is disabled here; set it to True if you have internet access and\n",
+    "# want a georeferenced background map.\n",
+    "edisgo.plot_mv_grid_topology(technologies=True, background_map=False)"
    ]
   },
   {
@@ -375,10 +379,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get single LV grid by providing its name or ID\n",
-    "lv_grid = edisgo.topology.get_lv_grid(\n",
-    "    \"LVGrid_170173\"\n",
-    ")  # edisgo.topology.get_lv_grid(170173) yields the same"
+    "# Get single LV grid. Instead of hardcoding a grid name/ID (which may not\n",
+    "# exist or may be empty depending on the grid data used), we pick the LV\n",
+    "# grid with the most loads to reliably demonstrate the following cells.\n",
+    "lv_grid = max(\n",
+    "    edisgo.topology.mv_grid.lv_grids, key=lambda lv_grid: len(lv_grid.loads_df)\n",
+    ")"
    ]
   },
   {
@@ -404,7 +410,12 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "A single grid's generators, loads, storage units and switches can also be\nretrieved as [Generator](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Generator.html) object,\n[Load](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Load.html) object, [Storage](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Storage.html) object, and\n[Switch](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Switch.html) objects, respecitvely:"
+   "source": [
+    "A single grid's generators, loads, storage units and switches can also be\n",
+    "retrieved as [Generator](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Generator.html) object,\n",
+    "[Load](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Load.html) object, [Storage](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Storage.html) object, and\n",
+    "[Switch](https://edisgo.readthedocs.io/en/dev/autoapi/edisgo/network/components/Switch.html) objects, respecitvely:"
+   ]
   },
   {
    "cell_type": "code",
@@ -496,8 +507,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# draw graph of one of the LV grids\n",
-    "lv_grid = list(edisgo.topology.mv_grid.lv_grids)[5]\n",
+    "# draw graph of the LV grid selected above\n",
     "nx.draw(lv_grid.graph)"
    ]
   },
@@ -557,7 +567,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edisgo.plot_mv_grid_topology(technologies=True)"
+    "# Note: background_map=True (the default) fetches map tiles over the\n",
+    "# internet via contextily and can be slow or fail without connectivity.\n",
+    "# It is disabled here; set it to True if you have internet access and\n",
+    "# want a georeferenced background map.\n",
+    "edisgo.plot_mv_grid_topology(technologies=True, background_map=False)"
    ]
   },
   {

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,6 +8,7 @@ Changelog for each release.
     :local:
     :backlinks: top
 
+.. include::  whatsnew/v0-3-1.rst
 .. include::  whatsnew/v0-3-0.rst
 .. include::  whatsnew/v0-2-1.rst
 .. include::  whatsnew/v0-2-0.rst

--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -1,0 +1,12 @@
+Release v0.3.1
+================
+
+Release date: <month> <day>, <year>
+
+Changes
+-------
+
+* Fixed simple example notebook: disabled the background map on the MV grid topology
+  plots (fetching map tiles could take tens of minutes or fail without a fast
+  internet connection) and replaced a hardcoded LV grid selection that broke when
+  used with certain grid data `#276 <https://github.com/openego/eDisGo/issues/276>`_

--- a/examples/edisgo_simple_example.ipynb
+++ b/examples/edisgo_simple_example.ipynb
@@ -243,7 +243,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edisgo.plot_mv_grid_topology(technologies=True)"
+    "# Note: background_map=True (the default) fetches map tiles over the\n",
+    "# internet via contextily and can be slow or fail without connectivity.\n",
+    "# It is disabled here; set it to True if you have internet access and\n",
+    "# want a georeferenced background map.\n",
+    "edisgo.plot_mv_grid_topology(technologies=True, background_map=False)"
    ]
   },
   {
@@ -375,10 +379,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get single LV grid by providing its name or ID\n",
-    "lv_grid = edisgo.topology.get_lv_grid(\n",
-    "    \"LVGrid_170173\"\n",
-    ")  # edisgo.topology.get_lv_grid(170173) yields the same"
+    "# Get single LV grid. Instead of hardcoding a grid name/ID (which may not\n",
+    "# exist or may be empty depending on the grid data used), we pick the LV\n",
+    "# grid with the most loads to reliably demonstrate the following cells.\n",
+    "lv_grid = max(\n",
+    "    edisgo.topology.mv_grid.lv_grids, key=lambda lv_grid: len(lv_grid.loads_df)\n",
+    ")"
    ]
   },
   {
@@ -501,8 +507,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# draw graph of one of the LV grids\n",
-    "lv_grid = list(edisgo.topology.mv_grid.lv_grids)[5]\n",
+    "# draw graph of the LV grid selected above\n",
     "nx.draw(lv_grid.graph)"
    ]
   },
@@ -562,7 +567,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edisgo.plot_mv_grid_topology(technologies=True)"
+    "# Note: background_map=True (the default) fetches map tiles over the\n",
+    "# internet via contextily and can be slow or fail without connectivity.\n",
+    "# It is disabled here; set it to True if you have internet access and\n",
+    "# want a georeferenced background map.\n",
+    "edisgo.plot_mv_grid_topology(technologies=True, background_map=False)"
    ]
   },
   {


### PR DESCRIPTION
# Description

plot_mv_grid_topology() defaults to background_map=True, which fetches map tiles via contextily and can hang for tens of minutes or fail without a good internet connection. Disabled in the example notebooks with a note on how to re-enable it.

Also replaced a hardcoded LV grid ("LVGrid_170173" / index 5), which has no loads with some grid data (e.g. ding0_test_network_1), with a selection that picks the LV grid with the most loads.

Fixes #276

Supersedes the abandoned, unmergeable PR #292.


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [x] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
