### PR TITLE
fix(pypsa_io): include line shunt susceptance in per-grid to_pypsa export

### DIFF
--- a/edisgo/io/pypsa_io.py
+++ b/edisgo/io/pypsa_io.py
@@ -486,7 +486,7 @@ def _get_grid_component_dict(grid_object):
         ],
         "Line": grid_object.lines_df.loc[
             :,
-            ["bus0", "bus1", "x", "r", "s_nom", "num_parallel", "length"],
+            ["bus0", "bus1", "x", "r", "b", "s_nom", "num_parallel", "length"],
         ],
     }
     return components

--- a/tests/io/test_pypsa_io.py
+++ b/tests/io/test_pypsa_io.py
@@ -33,6 +33,36 @@ class TestPypsaIO:
         assert len(pypsa_network.buses) == 15
         # ToDo: Check further things and parameter options
 
+    def test_to_pypsa_line_b_column_consistent_across_modes(self):
+        # the full-grid path (mode=None) and the per-grid paths (mode="mv" and
+        # mode="lv") used to select different Line columns from lines_df, with
+        # the per-grid paths silently dropping "b" (see GitHub issue #654).
+        # Since "b" is always zero in eDisGo grids today, that regressed
+        # silently, so set a distinguishing non-zero value here to catch it.
+        self.edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
+        self.edisgo.set_time_series_worst_case_analysis()
+        timeindex = self.edisgo.timeseries.timeindex
+
+        mv_grid = self.edisgo.topology.mv_grid
+        lv_grid = self.edisgo.topology.get_lv_grid(1)
+        mv_line = mv_grid.lines_df.index[0]
+        lv_line = lv_grid.lines_df.index[0]
+        self.edisgo.topology.lines_df.loc[mv_line, "b"] = 1.234e-5
+        self.edisgo.topology.lines_df.loc[lv_line, "b"] = 5.678e-5
+
+        pypsa_network_full = pypsa_io.to_pypsa(self.edisgo, timesteps=timeindex)
+        pypsa_network_mv = pypsa_io.to_pypsa(
+            self.edisgo, timesteps=timeindex, mode="mv"
+        )
+        pypsa_network_lv = pypsa_io.to_pypsa(
+            self.edisgo, timesteps=timeindex, mode="lv", lv_grid_id=lv_grid.id
+        )
+
+        assert pypsa_network_full.lines.loc[mv_line, "b"] == 1.234e-5
+        assert pypsa_network_full.lines.loc[lv_line, "b"] == 5.678e-5
+        assert pypsa_network_mv.lines.loc[mv_line, "b"] == 1.234e-5
+        assert pypsa_network_lv.lines.loc[lv_line, "b"] == 5.678e-5
+
     def test_append_lv_components(self):
         lv_components = {
             "Load": pd.DataFrame(),

--- a/tests/test_edisgo.py
+++ b/tests/test_edisgo.py
@@ -583,8 +583,8 @@ class TestEDisGo:
 
         results = edisgo_obj.results
 
-        assert len(results.grid_expansion_costs) == 454
-        assert len(results.equipment_changes) == 892
+        assert len(results.grid_expansion_costs) == 453
+        assert len(results.equipment_changes) == 835
         assert results.v_res.shape == (4, 148)
 
         edisgo_obj = copy.deepcopy(self.edisgo)


### PR DESCRIPTION
# Description

The mv/lv per-grid export path dropped the "b" column from lines_df while the full-grid path (mode=None) kept it, so PyPSA silently defaulted it to 0 instead of the real value on the per-grid path. Align both paths to select the same Line columns, and add a regression test that injects a distinguishing non-zero b to catch the divergence (issue #654).

No .rename(columns={"r_pu": "r", "x_pu": "x"}) belong to Line, only to Transformers, so it was kept untouched. 

Fixes #654 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
