### PR TITLE
feat(reinforce): add traceable reinforce_log to Results

### DIFF
--- a/edisgo/flex_opt/check_tech_constraints.py
+++ b/edisgo/flex_opt/check_tech_constraints.py
@@ -938,10 +938,21 @@ def _voltage_issues_helper(edisgo_obj, buses, split_voltage_band):
         edisgo_obj, buses=buses, split_voltage_band=split_voltage_band
     )
     # drop buses without voltage issues
-    voltage_dev = voltage_dev[voltage_dev != 0].dropna(how="all", axis=1).abs()
+    voltage_dev = voltage_dev[voltage_dev != 0].dropna(how="all", axis=1)
+    voltage_dev_abs = voltage_dev.abs()
     # determine absolute maximum voltage deviation and time step it occurs
-    crit_buses["abs_max_voltage_dev"] = voltage_dev.max()
-    crit_buses["time_index"] = voltage_dev.idxmax()
+    crit_buses["abs_max_voltage_dev"] = voltage_dev_abs.max()
+    crit_buses["time_index"] = voltage_dev_abs.idxmax()
+    # signed voltage deviation at the same (bus, time_index) as abs_max_voltage_dev
+    if crit_buses.empty:
+        # DataFrame.apply(axis=1) on an empty frame can return an empty
+        # DataFrame instead of an empty Series (depends on the dtype of the
+        # dropped columns' index), which breaks the column assignment below
+        crit_buses["max_voltage_dev"] = pd.Series(dtype=float)
+    else:
+        crit_buses["max_voltage_dev"] = crit_buses.apply(
+            lambda row: voltage_dev.at[row["time_index"], row.name], axis=1
+        )
     # sort descending by maximum voltage deviation
     if not crit_buses.empty:
         crit_buses.sort_values(

--- a/edisgo/flex_opt/reinforce_grid.py
+++ b/edisgo/flex_opt/reinforce_grid.py
@@ -21,8 +21,13 @@ import pandas as pd
 
 from edisgo.flex_opt import check_tech_constraints as checks
 from edisgo.flex_opt import exceptions, reinforce_measures
-from edisgo.flex_opt.costs import grid_expansion_costs
+from edisgo.flex_opt.costs import (
+    grid_expansion_costs,
+    line_expansion_costs,
+    transformer_expansion_costs,
+)
 from edisgo.flex_opt.reinforce_measures import separate_lv_grid
+from edisgo.network.grids import LVGrid
 from edisgo.tools import tools
 from edisgo.tools.temporal_complexity_reduction import get_most_critical_time_steps
 
@@ -42,6 +47,7 @@ def reinforce_grid(
     mode: str | None = None,
     without_generator_import: bool = False,
     n_minus_one: bool = False,
+    log_reinforcement: bool = True,
     **kwargs,
 ) -> Results:
     """
@@ -82,6 +88,12 @@ def reinforce_grid(
         Determines whether n-1 security should be checked. Currently, n-1 security
         cannot be handled correctly, wherefore the case where this parameter is set to
         True will lead to an error being raised. Default: False.
+    log_reinforcement : bool
+        If True, every reinforcement measure is appended as a row to
+        :attr:`~.network.results.Results.reinforce_log`, logged via an INFO
+        message, and a cost summary grouped by trigger, issue case and
+        voltage level is logged at the end of the run. If False, none of this
+        happens and `reinforce_log` is left untouched. Default: True.
 
     Other Parameters
     -----------------
@@ -180,6 +192,12 @@ def reinforce_grid(
                 )
 
     iteration_step = 1
+    existing_reinforce_log = edisgo.results.reinforce_log
+    run_id = (
+        0
+        if existing_reinforce_log.empty
+        else int(existing_reinforce_log["run_id"].max()) + 1
+    )
     lv_grid_id = kwargs.get("lv_grid_id", None)
     scale_timeseries = kwargs.get("scale_timeseries", None)
     if mode == "lv" and lv_grid_id:
@@ -260,6 +278,21 @@ def reinforce_grid(
             _add_transformer_changes_to_equipment_changes(
                 edisgo, transformer_changes, iteration_step, "removed"
             )
+            # removed transformers are not logged here: they carry no cost of
+            # their own (grid_expansion_costs() never costs "removed" rows
+            # either, see costs.py) and, for the "replace with standard
+            # transformers" case, are already gone from the topology by this
+            # point, so a cost lookup for them would raise a KeyError
+            _add_reinforcement_log_entries(
+                edisgo,
+                iteration_step,
+                "hv_mv_station_overload",
+                "overloading",
+                overloaded_mv_station,
+                transformer_changes["added"],
+                run_id=run_id,
+                log_reinforcement=log_reinforcement,
+            )
 
         if not overloaded_lv_stations.empty:
             # reinforce distribution substations
@@ -275,6 +308,18 @@ def reinforce_grid(
             _add_transformer_changes_to_equipment_changes(
                 edisgo, transformer_changes, iteration_step, "removed"
             )
+            # removed transformers are not logged here, see comment on the
+            # hv_mv_station_overload case above
+            _add_reinforcement_log_entries(
+                edisgo,
+                iteration_step,
+                "mv_lv_station_overload",
+                "overloading",
+                overloaded_lv_stations,
+                transformer_changes["added"],
+                run_id=run_id,
+                log_reinforcement=log_reinforcement,
+            )
 
         if not crit_lines.empty:
             # reinforce lines
@@ -285,6 +330,28 @@ def reinforce_grid(
             _add_lines_changes_to_equipment_changes(
                 edisgo, lines_changes, iteration_step
             )
+            for overload_voltage_level, overload_stage in (
+                ("mv", "mv_line_overload"),
+                ("lv", "lv_line_overload"),
+            ):
+                level_lines = crit_lines[
+                    crit_lines.voltage_level == overload_voltage_level
+                ].index
+                level_changes = {
+                    name: lines_changes[name]
+                    for name in level_lines
+                    if name in lines_changes
+                }
+                _add_reinforcement_log_entries(
+                    edisgo,
+                    iteration_step,
+                    overload_stage,
+                    "overloading",
+                    crit_lines,
+                    level_changes,
+                    run_id=run_id,
+                    log_reinforcement=log_reinforcement,
+                )
 
         # run power flow analysis again (after updating pypsa object) and check
         # if all over-loading problems were solved
@@ -363,13 +430,25 @@ def reinforce_grid(
     while_counter = 0
     while not crit_nodes.empty and while_counter < max_while_iterations:
         # reinforce lines
-        lines_changes = reinforce_measures.reinforce_lines_voltage_issues(
+        lines_changes, node_mapping = reinforce_measures.reinforce_lines_voltage_issues(
             edisgo,
             edisgo.topology.mv_grid,
             crit_nodes,
+            return_node_mapping=True,
         )
         # write changed lines to results.equipment_changes
         _add_lines_changes_to_equipment_changes(edisgo, lines_changes, iteration_step)
+        _add_reinforcement_log_entries(
+            edisgo,
+            iteration_step,
+            "mv_voltage",
+            "voltage",
+            crit_nodes,
+            lines_changes,
+            run_id=run_id,
+            mapping=node_mapping,
+            log_reinforcement=log_reinforcement,
+        )
 
         # run power flow analysis again (after updating pypsa object) and check
         # if all over-voltage problems were solved
@@ -424,14 +503,25 @@ def reinforce_grid(
         while_counter = 0
         while not crit_stations.empty and while_counter < max_while_iterations:
             # reinforce distribution substations
-            transformer_changes = (
+            transformer_changes, node_mapping = (
                 reinforce_measures.reinforce_mv_lv_station_voltage_issues(
-                    edisgo, crit_stations
+                    edisgo, crit_stations, return_node_mapping=True
                 )
             )
             # write added transformers to results.equipment_changes
             _add_transformer_changes_to_equipment_changes(
                 edisgo, transformer_changes, iteration_step, "added"
+            )
+            _add_reinforcement_log_entries(
+                edisgo,
+                iteration_step,
+                "mv_lv_voltage",
+                "voltage",
+                crit_stations,
+                transformer_changes["added"],
+                run_id=run_id,
+                mapping=node_mapping,
+                log_reinforcement=log_reinforcement,
             )
 
             # run power flow analysis again (after updating pypsa object) and
@@ -488,14 +578,29 @@ def reinforce_grid(
             # for every topology in crit_nodes do reinforcement
             for grid_id in crit_nodes.lv_grid_id.unique():
                 # reinforce lines
-                lines_changes = reinforce_measures.reinforce_lines_voltage_issues(
-                    edisgo,
-                    edisgo.topology.get_lv_grid(int(grid_id)),
-                    crit_nodes[crit_nodes.lv_grid_id == grid_id],
+                grid_crit_nodes = crit_nodes[crit_nodes.lv_grid_id == grid_id]
+                lines_changes, node_mapping = (
+                    reinforce_measures.reinforce_lines_voltage_issues(
+                        edisgo,
+                        edisgo.topology.get_lv_grid(int(grid_id)),
+                        grid_crit_nodes,
+                        return_node_mapping=True,
+                    )
                 )
                 # write changed lines to results.equipment_changes
                 _add_lines_changes_to_equipment_changes(
                     edisgo, lines_changes, iteration_step
+                )
+                _add_reinforcement_log_entries(
+                    edisgo,
+                    iteration_step,
+                    "lv_voltage",
+                    "voltage",
+                    grid_crit_nodes,
+                    lines_changes,
+                    run_id=run_id,
+                    mapping=node_mapping,
+                    log_reinforcement=log_reinforcement,
                 )
 
             # run power flow analysis again (after updating pypsa object)
@@ -584,6 +689,21 @@ def reinforce_grid(
             _add_transformer_changes_to_equipment_changes(
                 edisgo, transformer_changes, iteration_step, "removed"
             )
+            # removed transformers are not logged here: they carry no cost of
+            # their own (grid_expansion_costs() never costs "removed" rows
+            # either, see costs.py) and, for the "replace with standard
+            # transformers" case, are already gone from the topology by this
+            # point, so a cost lookup for them would raise a KeyError
+            _add_reinforcement_log_entries(
+                edisgo,
+                iteration_step,
+                "hv_mv_station_overload",
+                "overloading",
+                overloaded_mv_station,
+                transformer_changes["added"],
+                run_id=run_id,
+                log_reinforcement=log_reinforcement,
+            )
 
         if not overloaded_lv_stations.empty:
             # reinforce substations
@@ -599,6 +719,18 @@ def reinforce_grid(
             _add_transformer_changes_to_equipment_changes(
                 edisgo, transformer_changes, iteration_step, "removed"
             )
+            # removed transformers are not logged here, see comment on the
+            # hv_mv_station_overload case above
+            _add_reinforcement_log_entries(
+                edisgo,
+                iteration_step,
+                "mv_lv_station_overload",
+                "overloading",
+                overloaded_lv_stations,
+                transformer_changes["added"],
+                run_id=run_id,
+                log_reinforcement=log_reinforcement,
+            )
 
         if not crit_lines.empty:
             # reinforce lines
@@ -609,6 +741,28 @@ def reinforce_grid(
             _add_lines_changes_to_equipment_changes(
                 edisgo, lines_changes, iteration_step
             )
+            for overload_voltage_level, overload_stage in (
+                ("mv", "mv_line_overload"),
+                ("lv", "lv_line_overload"),
+            ):
+                level_lines = crit_lines[
+                    crit_lines.voltage_level == overload_voltage_level
+                ].index
+                level_changes = {
+                    name: lines_changes[name]
+                    for name in level_lines
+                    if name in lines_changes
+                }
+                _add_reinforcement_log_entries(
+                    edisgo,
+                    iteration_step,
+                    overload_stage,
+                    "overloading",
+                    crit_lines,
+                    level_changes,
+                    run_id=run_id,
+                    log_reinforcement=log_reinforcement,
+                )
 
         # run power flow analysis again (after updating pypsa object) and check
         # if all over-loading problems were solved
@@ -684,6 +838,18 @@ def reinforce_grid(
     edisgo.results.grid_expansion_costs = grid_expansion_costs(
         edisgo, without_generator_import=without_generator_import
     )
+
+    if log_reinforcement:
+        run_log = edisgo.results.reinforce_log
+        run_log = run_log[run_log["run_id"] == run_id] if not run_log.empty else run_log
+        if not run_log.empty:
+            cost_summary = run_log.groupby(["trigger", "issue_case", "voltage_level"])[
+                "costs"
+            ].sum()
+            logger.info(
+                f"==> Reinforcement cost summary for run {run_id} (kEUR):\n"
+                f"{cost_summary}"
+            )
 
     return edisgo.results
 
@@ -1240,3 +1406,265 @@ def _add_transformer_changes_to_equipment_changes(
     )
 
     edisgo.results.equipment_changes = pd.concat(df_list)
+
+
+def _add_reinforcement_log_entries(
+    edisgo: EDisGo,
+    iteration_step: int,
+    stage: str,
+    trigger: str,
+    issues: pd.DataFrame,
+    changes: dict,
+    *,
+    run_id: int,
+    mapping: dict | None = None,
+    log_reinforcement: bool = True,
+) -> None:
+    """
+    Appends one row per (violation, changed component) to
+    :attr:`~.network.results.Results.reinforce_log`.
+
+    `issues` is the critical-component dataframe as returned by
+    :func:`~.flex_opt.check_tech_constraints.voltage_issues` (indexed by bus,
+    trigger "voltage") or by the overloading checks in
+    :mod:`~.flex_opt.check_tech_constraints` (indexed by line or station,
+    trigger "overloading"). `changes` is either the flat
+    {changed_line: quantity} dict returned by
+    :func:`~.flex_opt.reinforce_measures.reinforce_lines_voltage_issues` /
+    `reinforce_lines_overloading`, or one of the per-station
+    {station: [transformer_names]} sub-dicts ("added"/"removed") returned by
+    the station reinforcement functions. `mapping` is a {changed_component:
+    critical_component} dict, optionally returned by
+    `reinforce_lines_voltage_issues` / `reinforce_mv_lv_station_voltage_issues`
+    (`return_node_mapping=True`), needed whenever `changes` is not already
+    keyed (directly, or - for station changes - via one of its list values)
+    by the critical component itself; for overloading, `mapping` is None.
+
+    'value'/'limit' are the actual measured quantity and the allowed
+    threshold it exceeded, in the physical unit of the trigger: p.u. voltage
+    for trigger "voltage" (both derived from the already-known signed
+    deviation, i.e. no extra power-flow lookup beyond `edisgo.results.v_res`),
+    MVA apparent power for trigger "overloading" on lines (both derived from
+    the already-known relative overload, via `edisgo.results.s_res`). For
+    station overloading (trigger "overloading", `issues` indexed by station
+    and carrying 's_missing' instead of 'max_rel_overload'), 'value' is the
+    missing apparent power in MVA, and 'limit' is NaN, since by the time this
+    function runs the station's transformer set has already been changed by
+    the reinforcement measure, so there is no reliable pre-reinforcement
+    apparent power/allowed-capacity pair left to derive a limit from.
+
+    `run_id` distinguishes separate calls to
+    :func:`~.flex_opt.reinforce_grid.reinforce_grid` (e.g. from
+    `enhanced_reinforce_grid` or `catch_convergence_reinforce_grid` calling it
+    repeatedly), since `iteration_step` only counts within one such call.
+
+    If `log_reinforcement` is False, this function is a no-op: no row is
+    appended and no logging happens.
+    """
+    if not log_reinforcement or not changes:
+        return
+
+    # only used to look up s_nom_after for added transformers, which - unlike
+    # removed ones - are still present in the topology at this point
+    all_transformers = pd.concat(
+        [edisgo.topology.transformers_hvmv_df, edisgo.topology.transformers_df]
+    )
+
+    # a line reinforced across several iterations (e.g. one more parallel
+    # standard line added per iteration until a voltage issue is resolved)
+    # is logged once per iteration, but earthworks are only incurred once
+    # per line - grid_expansion_costs() reflects this by summing quantity
+    # per line across the whole run before costing; replicate that here by
+    # only charging earthworks on a line's first appearance in this run_id
+    existing_log = edisgo.results.reinforce_log
+    lines_already_costed = (
+        set()
+        if existing_log.empty
+        else set(existing_log.loc[existing_log["run_id"] == run_id, "changed_component"])
+    )
+
+    rows = []
+    for key, value in changes.items():
+        if isinstance(value, (list, tuple, np.ndarray)):
+            # station reinforcement: value is the list of transformers
+            # added/removed for the critical station. Usually key is the
+            # critical station itself, but for some producers (e.g.
+            # reinforce_mv_lv_station_voltage_issues()) key is an internal
+            # grouping label (str(grid)) that does not match `issues`'
+            # index directly; mapping then resolves the actual triggering
+            # station from one of the changed transformers.
+            changed_components_quantities = [(name, 1) for name in value]
+            criterion_component = (
+                mapping[changed_components_quantities[0][0]]
+                if mapping is not None
+                else key
+            )
+        elif mapping is not None:
+            # voltage-triggered line reinforcement: key is the changed line,
+            # mapping resolves it to the critical node that triggered it
+            criterion_component = mapping[key]
+            changed_components_quantities = [(key, value)]
+        elif isinstance(value, (int, float, np.integer, np.floating)):
+            # overloading-triggered line reinforcement: key is both the
+            # changed line and the critical component (1:1). Quantity is
+            # a float here, not an int, when it comes from
+            # reinforce_lines_overloading() -> _add_parallel_standard_lines(),
+            # which derives it from a pandas Series subtraction.
+            criterion_component = key
+            changed_components_quantities = [(key, value)]
+        else:
+            raise ValueError(
+                f"Unexpected shape of 'changes' entry for key '{key}': "
+                f"{value!r}."
+            )
+
+        issue = issues.loc[criterion_component]
+        time_index = issue["time_index"]
+        if "lv_grid_id" in issues.columns:
+            # voltage issues already carry it (None for MV-level issues)
+            lv_grid_id = issue["lv_grid_id"]
+        elif "grid" in issues.columns and isinstance(issue["grid"], LVGrid):
+            # LV/MV-LV station overloading: the LVGrid object is right there;
+            # None for HV/MV station overloading (issue["grid"] is an MVGrid)
+            lv_grid_id = issue["grid"].id
+        elif criterion_component in edisgo.topology.lines_df.index:
+            # line overloading: derive from the violated line's first bus;
+            # NaN for MV lines (their buses have no lv_grid_id), normalized
+            # to None to match the other cases
+            bus0 = edisgo.topology.lines_df.at[criterion_component, "bus0"]
+            grid_id = edisgo.topology.buses_df.at[bus0, "lv_grid_id"]
+            lv_grid_id = None if pd.isna(grid_id) else grid_id
+        else:
+            lv_grid_id = None
+        issue_case = edisgo.timeseries.timesteps_load_feedin_case[time_index]
+
+        if trigger == "voltage":
+            # max_voltage_dev = actual voltage - allowed limit (see
+            # voltage_deviation_from_allowed_voltage_limits()), so the
+            # allowed limit can be recovered from the two without a new
+            # lookup function; overvoltage/undervoltage is decided by the
+            # deviation's sign, not by the (always positive) voltage itself
+            voltage_dev = issue["max_voltage_dev"]
+            issue_value = edisgo.results.v_res.at[time_index, criterion_component]
+            limit = issue_value - voltage_dev
+            issue_type = "overvoltage" if voltage_dev > 0 else "undervoltage"
+        elif trigger == "overloading":
+            if "max_rel_overload" in issues.columns:
+                # max_rel_overload = actual apparent power / allowed
+                # apparent power (see lines_relative_load()), so the
+                # allowed capacity can likewise be recovered arithmetically
+                relative_load = issue["max_rel_overload"]
+                issue_value = edisgo.results.s_res.at[time_index, criterion_component]
+                limit = issue_value / relative_load
+            else:
+                # station overloading: no s_res entry to fall back on, since
+                # by this point the station's transformer set has already
+                # been changed by the reinforcement measure
+                issue_value = issue["s_missing"]
+                limit = np.nan
+            issue_type = "overloading"
+        else:
+            raise ValueError(f"Trigger '{trigger}' is not a valid option.")
+
+        is_line = changed_components_quantities[0][0] in edisgo.topology.lines_df.index
+        group_equipment = set()
+        group_length = 0.0
+        group_quantity = 0.0
+        group_costs = 0.0
+
+        for changed_component, quantity in changed_components_quantities:
+            if is_line:
+                line_costs = line_expansion_costs(edisgo, [changed_component])
+                equipment = edisgo.topology.lines_df.at[
+                    changed_component, "type_info"
+                ]
+                voltage_level = line_costs.at[changed_component, "voltage_level"]
+                costs_earthworks = (
+                    0.0
+                    if changed_component in lines_already_costed
+                    else line_costs.at[changed_component, "costs_earthworks"]
+                )
+                lines_already_costed.add(changed_component)
+                costs = (
+                    costs_earthworks
+                    + line_costs.at[changed_component, "costs_cable"] * quantity
+                )
+                length_km = (
+                    quantity
+                    * edisgo.topology.lines_df.at[changed_component, "length"]
+                )
+                num_parallel_after = edisgo.topology.lines_df.at[
+                    changed_component, "num_parallel"
+                ]
+                s_nom_after = edisgo.topology.lines_df.at[changed_component, "s_nom"]
+                group_length += length_km
+            else:
+                transformer_costs = transformer_expansion_costs(
+                    edisgo, [changed_component]
+                )
+                equipment = changed_component
+                voltage_level = transformer_costs.at[
+                    changed_component, "voltage_level"
+                ]
+                costs = transformer_costs.at[changed_component, "costs"]
+                # length/num_parallel are line-only concepts
+                length_km = np.nan
+                num_parallel_after = np.nan
+                s_nom_after = all_transformers.at[changed_component, "s_nom"]
+
+            group_equipment.add(equipment)
+            group_quantity += quantity
+            group_costs += costs
+
+            rows.append(
+                {
+                    "run_id": run_id,
+                    "iteration_step": iteration_step,
+                    "reinforcement_stage": stage,
+                    "trigger": trigger,
+                    "criterion_component": criterion_component,
+                    "voltage_level": voltage_level,
+                    "lv_grid_id": lv_grid_id,
+                    "time_index": time_index,
+                    "value": issue_value,
+                    "limit": limit,
+                    "issue_type": issue_type,
+                    "issue_case": issue_case,
+                    "changed_component": changed_component,
+                    "equipment": equipment,
+                    "quantity": quantity,
+                    "length_km": length_km,
+                    "num_parallel_after": num_parallel_after,
+                    "s_nom_after": s_nom_after,
+                    "costs": costs,
+                }
+            )
+
+        # one human-readable line per violation, aggregating all components
+        # changed to resolve it (e.g. several new parallel lines/transformers).
+        # Shown as deviation/ratio rather than the absolute value/limit now
+        # stored in the DataFrame, since that reads more naturally (e.g.
+        # "overvoltage 0.031 p.u." rather than "overvoltage 1.081 p.u.")
+        if trigger == "voltage":
+            headline = f"{issue_type} {abs(voltage_dev):.3f} p.u."
+        elif "max_rel_overload" in issues.columns:
+            headline = f"overloading {relative_load:.3f} p.u. > 1.000 p.u."
+        else:
+            headline = f"overloading {issue_value:.3f} MVA missing"
+
+        noun = "line(s)" if is_line else "transformer(s)"
+        equipment_str = "/".join(sorted(group_equipment))
+        length_str = f", {group_length:.2f} km" if is_line else ""
+
+        logger.info(
+            f"Iteration {iteration_step} | {stage} | {criterion_component}: "
+            f"{headline}\n"
+            f"  at {time_index:%Y-%m-%d %H:%M} "
+            f"({issue_case.replace('_', ' ')}) -> "
+            f"{group_quantity:g} {noun}, {equipment_str}{length_str}, "
+            f"{group_costs:.1f} kEUR"
+        )
+
+    edisgo.results.reinforce_log = pd.concat(
+        [edisgo.results.reinforce_log, pd.DataFrame(rows)]
+    )

--- a/edisgo/flex_opt/reinforce_measures.py
+++ b/edisgo/flex_opt/reinforce_measures.py
@@ -296,7 +296,9 @@ def _reinforce_station_overloading(edisgo_obj, critical_stations, voltage_level)
     return transformers_changes
 
 
-def reinforce_mv_lv_station_voltage_issues(edisgo_obj, critical_stations):
+def reinforce_mv_lv_station_voltage_issues(
+    edisgo_obj, critical_stations, return_node_mapping=False
+):
     """
     Reinforce MV/LV substations due to voltage issues.
 
@@ -309,6 +311,10 @@ def reinforce_mv_lv_station_voltage_issues(edisgo_obj, critical_stations):
         Dataframe with maximum deviations from allowed lower or upper voltage limits
         in p.u. for all MV-LV stations with voltage issues. For more information on
         dataframe see :func:`~.flex_opt.check_tech_constraints.voltage_issues`.
+    return_node_mapping : bool
+        If True, additionally returns a dictionary mapping each added
+        transformer to the critical station (as in the index of
+        `critical_stations`) that triggered its reinforcement. Default: False.
 
     Returns
     -------
@@ -321,6 +327,10 @@ def reinforce_mv_lv_station_voltage_issues(edisgo_obj, critical_stations):
                        'Grid_10': ['transformer_reinforced_10']
                        }
             }
+    dict
+        Only returned if `return_node_mapping` is True. Dictionary with name
+        of added transformers as keys and the name of the critical station
+        that triggered the transformer's addition as values.
 
     """
 
@@ -335,6 +345,7 @@ def reinforce_mv_lv_station_voltage_issues(edisgo_obj, critical_stations):
         raise KeyError("Standard MV/LV transformer is not in equipment list.")
 
     transformers_changes = {"added": {}}
+    node_mapping = {}
     # Collect the per-station new transformer frames so the topology dataframe is
     # rebuilt only once after the loop instead of once per station (avoids
     # O(stations x total_transformers) behaviour). Output is identical: the new
@@ -357,6 +368,8 @@ def reinforce_mv_lv_station_voltage_issues(edisgo_obj, critical_stations):
         # collect new transformer to be added to topology (batched after the loop)
         new_transformers_collected.append(duplicated_transformer)
         transformers_changes["added"][str(grid)] = duplicated_transformer.index.tolist()
+        for new_transformer_name in duplicated_transformer.index:
+            node_mapping[new_transformer_name] = station
 
     # add all new transformers to topology in a single concat, in station order,
     # matching the per-iteration concat behaviour.
@@ -371,10 +384,14 @@ def reinforce_mv_lv_station_voltage_issues(edisgo_obj, critical_stations):
             "issues.".format(len(transformers_changes["added"]))
         )
 
+    if return_node_mapping:
+        return transformers_changes, node_mapping
     return transformers_changes
 
 
-def reinforce_lines_voltage_issues(edisgo_obj, grid, crit_nodes):
+def reinforce_lines_voltage_issues(
+    edisgo_obj, grid, crit_nodes, return_node_mapping=False
+):
     """
     Reinforce lines in MV and LV topology due to voltage issues.
 
@@ -386,12 +403,19 @@ def reinforce_lines_voltage_issues(edisgo_obj, grid, crit_nodes):
         Dataframe with maximum deviations from allowed lower or upper voltage limits
         in p.u. for all buses in specified grid. For more information on dataframe see
         :func:`~.flex_opt.check_tech_constraints.voltage_issues`.
+    return_node_mapping : bool
+        If True, additionally returns a dictionary mapping each reinforced line
+        to the critical node that triggered its reinforcement. Default: False.
 
     Returns
     -------
     dict
         Dictionary with name of lines as keys and the corresponding number of
         lines added as values.
+    dict
+        Only returned if `return_node_mapping` is True. Dictionary with name
+        of reinforced lines as keys and the name of the critical node that
+        triggered the line's reinforcement as values.
 
     Notes
     -----
@@ -446,6 +470,7 @@ def reinforce_lines_voltage_issues(edisgo_obj, grid, crit_nodes):
         nodes_feeder.setdefault(path[1], []).append(node)
 
     lines_changes = {}
+    node_mapping = {}
     for repr_node in nodes_feeder.keys():
         # find node farthest away
         get_weight = lambda u, v, data: data["length"]  # noqa: E731
@@ -515,6 +540,7 @@ def reinforce_lines_voltage_issues(edisgo_obj, grid, crit_nodes):
                     )
                 )
                 lines_changes[crit_line_name] = 1
+                node_mapping[crit_line_name] = node
 
             # if critical line is not yet a standard line replace old
             # line by a standard line
@@ -524,6 +550,7 @@ def reinforce_lines_voltage_issues(edisgo_obj, grid, crit_nodes):
                 # standard lines is iterated
                 edisgo_obj.topology.change_line_type([crit_line_name], standard_line)
                 lines_changes[crit_line_name] = 1
+                node_mapping[crit_line_name] = node
 
         # if node_2_3 is not a representative, disconnect line
         else:
@@ -543,6 +570,7 @@ def reinforce_lines_voltage_issues(edisgo_obj, grid, crit_nodes):
             )
             edisgo_obj.topology.change_line_type([crit_line_name], standard_line)
             lines_changes[crit_line_name] = 1
+            node_mapping[crit_line_name] = node
             # TODO: Include switch disconnector
 
     if not lines_changes:
@@ -551,6 +579,8 @@ def reinforce_lines_voltage_issues(edisgo_obj, grid, crit_nodes):
             "issues."
         )
 
+    if return_node_mapping:
+        return lines_changes, node_mapping
     return lines_changes
 
 

--- a/edisgo/network/results.py
+++ b/edisgo/network/results.py
@@ -54,6 +54,7 @@ def _get_matching_dict_of_attributes_and_file_names():
         "grid_expansion_costs": "grid_expansion_costs",
         "unresolved_issues": "unresolved_issues",
         "equipment_changes": "equipment_changes",
+        "reinforce_log": "reinforce_log",
     }
     return powerflow_results_dict, grid_expansion_results_dict
 
@@ -347,6 +348,40 @@ class Results:
     @equipment_changes.setter
     def equipment_changes(self, df):
         self._equipment_changes = df
+
+    @property
+    def reinforce_log(self):
+        """
+        Tracks per-violation reinforcement measures in long format.
+
+        For each grid reinforcement iteration step, holds one row per
+        combination of a detected issue (voltage or overloading violation)
+        and the equipment changed to resolve it, so that measures can be
+        traced back to the violation that triggered them.
+
+        Parameters
+        ----------
+        df : :pandas:`pandas.DataFrame<DataFrame>`
+            Dataframe with one row per (violation, changed component) pair.
+
+            Provide this if you want to set values. For retrieval of data do
+            not pass an argument.
+
+        Returns
+        -------
+        :pandas:`pandas.DataFrame<DataFrame>`
+            Dataframe with one row per (violation, changed component) pair.
+            For more information on the dataframe see input parameter `df`.
+
+        """
+        try:
+            return self._reinforce_log
+        except Exception:
+            return pd.DataFrame()
+
+    @reinforce_log.setter
+    def reinforce_log(self, df):
+        self._reinforce_log = df
 
     @property
     def grid_expansion_costs(self):
@@ -725,6 +760,7 @@ class Results:
             "pfa_v_mag_pu_seed",
             "v_res",
             "i_res",
+            "reinforce_log",
         ]
         try:
             for attr in attr_to_check:
@@ -778,6 +814,8 @@ class Results:
           is saved to `equipment_changes.csv`.
         * unresolved_issues : Attribute :py:attr:`~unresolved_issues`
           is saved to `unresolved_issues.csv`.
+        * reinforce_log : Attribute :py:attr:`~reinforce_log`
+          is saved to `reinforce_log.csv`.
 
         Parameters
         ----------

--- a/tests/flex_opt/test_check_tech_constraints.py
+++ b/tests/flex_opt/test_check_tech_constraints.py
@@ -413,7 +413,7 @@ class TestCheckTechConstraints:
             self.edisgo, voltage_level="mv"
         )
         # check shape of dataframe
-        assert (3, 3) == voltage_issues.shape
+        assert (3, 4) == voltage_issues.shape
         # check under- and overvoltage deviation values
         assert list(voltage_issues.index.values) == [
             "Bus_Generator_1",
@@ -431,7 +431,7 @@ class TestCheckTechConstraints:
             self.edisgo, split_voltage_band=False, voltage_level="mv"
         )
         # check shape of dataframe
-        assert (3, 3) == voltage_issues.shape
+        assert (3, 4) == voltage_issues.shape
         # check under- and overvoltage deviation values
         assert list(voltage_issues.index.values) == [
             "Bus_Generator_1",
@@ -534,7 +534,7 @@ class TestCheckTechConstraints:
             self.edisgo, voltage_level=None
         )
         # check shape of dataframe
-        assert (6, 3) == voltage_issues.shape
+        assert (6, 4) == voltage_issues.shape
 
     def test__voltage_issues_helper(self):
         # create voltage issues
@@ -547,7 +547,7 @@ class TestCheckTechConstraints:
         )
 
         # check shape of dataframe
-        assert (3, 2) == v_violations.shape
+        assert (3, 3) == v_violations.shape
         # check under- and overvoltage deviation values
         assert list(v_violations.index.values) == [
             "Bus_Generator_1",
@@ -558,6 +558,52 @@ class TestCheckTechConstraints:
             v_violations.at["Bus_GeneratorFluctuating_2", "abs_max_voltage_dev"], 0.01
         )
         assert v_violations.at["Bus_Generator_1", "time_index"] == self.timesteps[1]
+
+    def test__voltage_issues_helper_max_voltage_dev_sign(self):
+        # create voltage issues: Bus_GeneratorFluctuating_2 has only
+        # overvoltage, Bus_GeneratorFluctuating_3 has only undervoltage, and
+        # Bus_Generator_1 has both, with the undervoltage being the larger
+        # (and therefore selected) deviation
+        self.mv_voltage_issues()
+
+        v_violations = check_tech_constraints._voltage_issues_helper(
+            self.edisgo,
+            self.edisgo.topology.mv_grid.buses_df.index,
+            split_voltage_band=False,
+        )
+
+        # overvoltage-only bus: max_voltage_dev is positive
+        assert (
+            v_violations.at["Bus_GeneratorFluctuating_2", "max_voltage_dev"] > 0
+        )
+        assert np.isclose(
+            v_violations.at["Bus_GeneratorFluctuating_2", "max_voltage_dev"], 0.01
+        )
+
+        # undervoltage-only bus: max_voltage_dev is negative
+        assert (
+            v_violations.at["Bus_GeneratorFluctuating_3", "max_voltage_dev"] < 0
+        )
+        assert np.isclose(
+            v_violations.at["Bus_GeneratorFluctuating_3", "max_voltage_dev"], -0.005
+        )
+
+        # bus with both: the larger (undervoltage) deviation is selected,
+        # matching abs_max_voltage_dev's own selection (see
+        # test__voltage_issues_helper)
+        assert v_violations.at["Bus_Generator_1", "max_voltage_dev"] < 0
+        assert np.isclose(
+            v_violations.at["Bus_Generator_1", "max_voltage_dev"], -0.02
+        )
+
+        # abs_max_voltage_dev stays positive and equal in magnitude to
+        # max_voltage_dev for all buses, regardless of over-/undervoltage
+        for bus in v_violations.index:
+            assert v_violations.at[bus, "abs_max_voltage_dev"] > 0
+            assert np.isclose(
+                v_violations.at[bus, "abs_max_voltage_dev"],
+                abs(v_violations.at[bus, "max_voltage_dev"]),
+            )
 
     def test_allowed_voltage_limits(self):
         lv_grid_1 = self.edisgo.topology.get_lv_grid(1)

--- a/tests/flex_opt/test_reinforce_grid.py
+++ b/tests/flex_opt/test_reinforce_grid.py
@@ -1,6 +1,7 @@
 import copy
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from numpy.testing import assert_array_equal
@@ -9,6 +10,7 @@ from pandas.testing import assert_frame_equal
 from edisgo import EDisGo
 from edisgo.flex_opt.costs import grid_expansion_costs
 from edisgo.flex_opt.reinforce_grid import reinforce_grid, run_separate_lv_grids
+from edisgo.network.results import Results
 
 
 class TestReinforceGrid:
@@ -62,6 +64,64 @@ class TestReinforceGrid:
             num_steps_loading=2,
         )
         assert len(res_reduced.i_res) == 2
+
+    def test_reinforce_log_costs_match_grid_expansion_costs(self):
+        # verify Step 5: reinforce_log's per-measure costs add up to the same
+        # total as grid_expansion_costs, which is the established, separately
+        # tested source of truth for total network expansion costs (see
+        # e.g. test_run_separate_lv_grids using
+        # grid_expansion_costs.total_costs.sum())
+        edisgo = copy.deepcopy(self.edisgo)
+        results = reinforce_grid(edisgo=edisgo)
+
+        reinforce_log_total = results.reinforce_log["costs"].sum()
+        grid_expansion_total = results.grid_expansion_costs["total_costs"].sum()
+
+        # both sums are built from the same line_expansion_costs() /
+        # transformer_expansion_costs() cost tables, just aggregated
+        # differently (reinforce_log: once per (violation, changed
+        # component) row; grid_expansion_costs: once per changed component
+        # across the whole equipment_changes history), so a tight
+        # floating-point tolerance covers summation-order effects only
+        assert reinforce_log_total == pytest.approx(grid_expansion_total)
+
+    def test_reinforce_log_to_csv_from_csv_roundtrip(self, tmp_path):
+        # verify Step 5: reinforce_log persists and restores correctly via
+        # Results.to_csv / Results.from_csv
+        edisgo = copy.deepcopy(self.edisgo)
+        results = reinforce_grid(edisgo=edisgo)
+
+        original_reinforce_log = results.reinforce_log.copy()
+        assert not original_reinforce_log.empty
+
+        results.to_csv(str(tmp_path))
+
+        fresh_results = Results(edisgo)
+        fresh_results.from_csv(str(tmp_path))
+        loaded_reinforce_log = fresh_results.reinforce_log.copy()
+
+        # read_csv's parse_dates=True (used generically by Results.from_csv
+        # for all grid expansion results) only parses the index column, not
+        # regular data columns, so the 'time_index' column round-trips as a
+        # string instead of a Timestamp; this is a generic limitation that
+        # would equally affect any other Results attribute with a Timestamp
+        # *column* (e.g. unresolved_issues), not something specific to
+        # reinforce_log, so it is fixed up here rather than in the property
+        loaded_reinforce_log["time_index"] = pd.to_datetime(
+            loaded_reinforce_log["time_index"]
+        )
+        # for the same generic reason, an all-None 'lv_grid_id' column
+        # (as here, since none of the triggered measures are voltage issues
+        # at a LV bus/station) round-trips as NaN/float64 instead of
+        # None/object, since CSV cannot distinguish "no value" from "no
+        # value of this dtype"
+        loaded_reinforce_log["lv_grid_id"] = (
+            loaded_reinforce_log["lv_grid_id"]
+            .astype(object)
+            .where(loaded_reinforce_log["lv_grid_id"].notna(), None)
+        )
+
+        assert_frame_equal(loaded_reinforce_log, original_reinforce_log)
 
     def test_run_separate_lv_grids(self):
         edisgo = copy.deepcopy(self.edisgo)

--- a/tests/flex_opt/test_reinforce_grid.py
+++ b/tests/flex_opt/test_reinforce_grid.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 
 from edisgo import EDisGo
-from edisgo.flex_opt.costs import grid_expansion_costs
+from edisgo.flex_opt.costs import grid_expansion_costs, line_expansion_costs
 from edisgo.flex_opt.reinforce_grid import reinforce_grid, run_separate_lv_grids
 from edisgo.network.results import Results
 
@@ -122,6 +122,102 @@ class TestReinforceGrid:
         )
 
         assert_frame_equal(loaded_reinforce_log, original_reinforce_log)
+
+    @pytest.fixture(scope="class")
+    @classmethod
+    def network_2_reinforced(cls):
+        # shared across all tests that need a scenario with voltage issues
+        # and lines reinforced across multiple iterations, neither of which
+        # ding0_test_network_1's worst-case scenario (used in setup_class)
+        # happens to produce; computed once and reused (read-only) since
+        # reinforce_grid() takes ~90s on this larger network
+        edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_2_path)
+        edisgo.set_time_series_worst_case_analysis()
+        edisgo.analyze()
+        results = edisgo.reinforce()
+        return edisgo, results
+
+    @pytest.mark.slow
+    def test_reinforce_log_earthworks_charged_once_per_line(
+        self, network_2_reinforced
+    ):
+        # regression test: a line reinforced across several iterations (e.g.
+        # repeated parallel-line additions to resolve a persistent voltage
+        # issue) must only be charged earthworks once, not once per
+        # iteration - the trench is only dug once, no matter how many
+        # parallel cables end up in it (see costs.line_expansion_costs()).
+        edisgo, results = network_2_reinforced
+
+        log = results.reinforce_log
+        line_rows = log[log["changed_component"].isin(edisgo.topology.lines_df.index)]
+        counts = line_rows["changed_component"].value_counts()
+        repeated_lines = counts[counts > 1].index
+
+        # sanity check that this test actually exercises the scenario it is
+        # meant to guard, and isn't silently vacuous
+        assert len(repeated_lines) > 0
+
+        checked_at_least_one_line = False
+        for line in repeated_lines:
+            rows = line_rows[line_rows["changed_component"] == line]
+            # skip lines whose type was changed to something new between
+            # calls - accumulating cost for those has to additionally
+            # account for a separate, pre-existing quirk in
+            # grid_expansion_costs() (it only counts quantity added under
+            # the line's *final* type, silently dropping cost attributed to
+            # a since-superseded type), which is out of scope here
+            if rows["equipment"].nunique() > 1:
+                continue
+            checked_at_least_one_line = True
+
+            total_quantity = rows["quantity"].sum()
+            costs = line_expansion_costs(edisgo, [line])
+            expected_total_costs = (
+                costs.at[line, "costs_earthworks"]
+                + costs.at[line, "costs_cable"] * total_quantity
+            )
+            assert rows["costs"].sum() == pytest.approx(expected_total_costs)
+
+        assert checked_at_least_one_line
+
+    @pytest.mark.slow
+    def test_reinforce_log_voltage_trigger_reached_and_consistent(
+        self, network_2_reinforced
+    ):
+        # coverage gap found during an audit: none of the other
+        # reinforce_log tests exercise trigger == "voltage" at all
+        # (ding0_test_network_1's worst-case scenario only produces
+        # overloading violations), and "mv_lv_voltage" specifically (the
+        # station-voltage branch fixed for Bug D, resolved via
+        # reinforce_mv_lv_station_voltage_issues()) was reachable by no test
+        # at all. ding0_test_network_2 naturally exercises both.
+        _, results = network_2_reinforced
+
+        voltage_rows = results.reinforce_log[
+            results.reinforce_log["trigger"] == "voltage"
+        ]
+        assert not voltage_rows.empty
+
+        # all three voltage-triggered stages must actually be reached
+        assert {"mv_voltage", "mv_lv_voltage", "lv_voltage"}.issubset(
+            set(voltage_rows["reinforcement_stage"])
+        )
+
+        # value/limit must be real, plausible p.u. voltages (unlike station
+        # overloading, voltage issues always have a derivable limit)
+        assert voltage_rows["value"].between(0.5, 1.5).all()
+        assert voltage_rows["limit"].between(0.5, 1.5).all()
+        assert voltage_rows["limit"].notna().all()
+
+        # issue_type must be consistent with which of value/limit is larger;
+        # this scenario's worst case only produces undervoltage (heavily
+        # loaded feeders, not enough feed-in for overvoltage), so only that
+        # direction is asserted as actually occurring
+        undervoltage = voltage_rows[voltage_rows["issue_type"] == "undervoltage"]
+        overvoltage = voltage_rows[voltage_rows["issue_type"] == "overvoltage"]
+        assert not undervoltage.empty
+        assert (undervoltage["value"] < undervoltage["limit"]).all()
+        assert (overvoltage["value"] > overvoltage["limit"]).all()
 
     def test_run_separate_lv_grids(self):
         edisgo = copy.deepcopy(self.edisgo)


### PR DESCRIPTION
# Description

Results.reinforce_log is a new long-format DataFrame that records why each grid-reinforcement measure happened - the violated component, the exceeded limit, the time step and load/feed-in case - alongside what equipment_changes already tracked (what changed and at what cost), one row per (violation, changed component).

- check_tech_constraints: add a signed max_voltage_dev column, needed to derive issue_type (over-/undervoltage) and the allowed limit.
- reinforce_measures: add optional return_node_mapping to reinforce_lines_voltage_issues/reinforce_mv_lv_station_voltage_issues so voltage-triggered reinforcements can be traced back to the violating node/station.
- reinforce_grid: wire _add_reinforcement_log_entries into every stage that already writes equipment_changes; add a log_reinforcement toggle, a run_id to disambiguate repeated reinforce_grid() calls, human-readable INFO logging per violation, and an end-of-run cost summary grouped by trigger/issue_case/voltage_level.
- Add tests for the signed voltage deviation, cost consistency with grid_expansion_costs, and CSV round-tripping.

Fixes #741 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
