### PR TITLE
Add presets to seperate building the grids from optimizing them

### DIFF
--- a/edisgo/run/presets/optimize_prebuild_grid.yaml
+++ b/edisgo/run/presets/optimize_prebuild_grid.yaml
@@ -1,0 +1,123 @@
+_comment: |
+  UC5 — OPF with configurable timestep selection (manual OR auto):
+  Like UC4 (full flexibility OPF with HV requirements), but the time index
+  is reduced to a selected subset instead of a fixed window. The mode is
+  chosen in the timeseries_selection block below (typically overridden in
+  the run script).
+
+  The pipeline carries TWO select_timesteps steps, each with a `position`:
+  - position: pre_import  (before import_heat_pumps) — acts only in MANUAL
+    mode. It sets the explicit time index, which the heat-pump/DSM imports
+    and oedb_ts then use to fetch only the selected steps (cheap).
+  - position: post_grid   (after import_overlying_grid_data, before
+    reactive_power) — acts only in AUTO mode. It needs all active-power
+    time series (incl. overlying-grid generation) set to run the scoring
+    power flow via get_most_critical_time_intervals.
+  Whichever mode is configured, the other positioned step is a no-op.
+
+  Auto mode normally yields two disconnected intervals (one overloading,
+  one voltage). They are kept separate (a gap in the time index); if they
+  overlap, a non-overlapping pair is chosen if possible, otherwise they are
+  concatenated into one interval. A later optimize step can detect the gap
+  and run separate optimizations per interval.
+
+_workflow:
+  - setup_grid: load ding0 topology
+  - import_generators / import_home_batteries
+  - select_timesteps (pre_import): manual only — set explicit time index
+  - import_heat_pumps / import_dsm: fetch only selected steps (manual)
+  - import_electromobility: dumb charging, flex bands
+  - oedb_ts: real wind/solar + load time series
+  - apply_charging_strategy / apply_heat_pump_strategy
+  - build_flexibility_bands: EV bands on the fixed hourly index
+  - import_overlying_grid_data: HV constraints from CSV dir
+  - select_timesteps (post_grid): auto only — reduce to critical intervals
+  - reactive_power: fixed cosphi on the reduced index
+  - optimize: pm_optimize with flex assets
+  - reinforce / save
+
+# Self-contained (no `extends`): everything uc4_example provided is inlined
+# below, so this preset can be run on its own via
+#   run_edisgo({"extends": "uc5_select_timesteps", "grid": {"ding0_path": ...}})
+scenario: eGon2035
+
+grid:
+  ding0_path: "/path/to/ding0_grid"
+  legacy_ding0_grids: false
+
+database:
+  local
+
+# No explicit base time index is set. oedb_ts falls back to a full year derived
+# from the scenario when none is given, which is what auto interval selection
+# needs (week-long critical intervals to pick from). For manual selection the
+# pre-import select_timesteps step sets the index instead.
+
+overlying_grid:
+  enabled: true          # set true to activate import_overlying_grid_data
+  source: csv            # "csv" (load from path) or "etrago" (kwarg)
+  path: "/storage/JoDa/edisgo_playground/overlying_grid_data"
+
+results:
+  directory: results/uc5_select_timesteps
+
+# Top-level block read by the select_timesteps task via ctx.raw_config.
+# eGo can inject this block the same way it injects overlying_grid.
+# Set `mode` (and its parameters) here or override it in the run script.
+timeseries_selection:
+  mode: auto
+  # auto method: "power_flow" (default, scores intervals via a power flow) or
+  # "residual_load" (no power flow — the weeks ending at the max/min residual-load
+  # time steps; requires overlying-grid data).
+  method: residual_load
+  # --- shared auto parameters (both methods) ---
+  time_steps_per_time_interval: 168  # one week (must be a multiple of 24)
+  time_step_day_start: 4             # hour of day the intervals start/end on
+  # --- power_flow method parameters ---
+  percentage: 1.0
+  save_steps: true                   # write selected intervals CSV to results_dir
+  use_troubleshooting_mode: true     # handle power-flow non-convergence
+  overloading_factor: 0.95
+  voltage_deviation_factor: 0.95
+  # --- manual parameters (used when mode: manual) ---
+  # timestamps: ["2035-01-15 08:00", "2035-01-15 9:00", "2035-01-15 10:00"]
+  # or a range instead of `timestamps`:
+  start: "2035-01-15 00:00"
+  periods: 24
+  freq: h
+
+# Top-level block read by the spatial_reduce/spatial_restore tasks via
+# ctx.raw_config. eGo can inject this block the same way it injects
+# overlying_grid/timeseries_selection (global `spatial_reduction` default +
+# per-grid `spatial_reduction_per_grid` override keyed by mv_grid_id).
+spatial_reduction:
+  enabled: true          # set true to activate spatial_reduce/spatial_restore
+  mode: kmeansdijkstra               # clustering mode for spatial_complexity_reduction
+  cluster_area: feeder
+  reduction_factor: 0.3
+  reduction_factor_not_focused: False
+  aggregation_mode: false  # start with false; true enables load/generator merging
+
+pipeline:
+  - load_prebuild_grid:
+      path: "/hdd-disk/ego-results/prepared_grids"
+      import_electromobility: true
+      import_heat_pump: true
+      import_dsm: true
+      import_timeseries: true
+  - import_overlying_grid_data
+  - select_timesteps: {position: post_grid}    # acts in auto mode only
+  - reactive_power
+  - spatial_reduce
+  - optimize:
+      flexible: [heat_pumps, storage, charging_points, dsm]
+      method: soc
+      opf_version: 2
+  - reinforce:
+      catch_convergence_problems: true
+  - save:
+      archive: true
+      save_opf_results: true
+      save_heatpump: true
+      save_electromobility: true
+      save_timeseries: true

--- a/edisgo/run/presets/prepare_and_save_grid.yaml
+++ b/edisgo/run/presets/prepare_and_save_grid.yaml
@@ -1,0 +1,109 @@
+_comment: |
+  UC5 — OPF with configurable timestep selection (manual OR auto):
+  Like UC4 (full flexibility OPF with HV requirements), but the time index
+  is reduced to a selected subset instead of a fixed window. The mode is
+  chosen in the timeseries_selection block below (typically overridden in
+  the run script).
+
+  The pipeline carries TWO select_timesteps steps, each with a `position`:
+  - position: pre_import  (before import_heat_pumps) — acts only in MANUAL
+    mode. It sets the explicit time index, which the heat-pump/DSM imports
+    and oedb_ts then use to fetch only the selected steps (cheap).
+  - position: post_grid   (after import_overlying_grid_data, before
+    reactive_power) — acts only in AUTO mode. It needs all active-power
+    time series (incl. overlying-grid generation) set to run the scoring
+    power flow via get_most_critical_time_intervals.
+  Whichever mode is configured, the other positioned step is a no-op.
+
+  Auto mode normally yields two disconnected intervals (one overloading,
+  one voltage). They are kept separate (a gap in the time index); if they
+  overlap, a non-overlapping pair is chosen if possible, otherwise they are
+  concatenated into one interval. A later optimize step can detect the gap
+  and run separate optimizations per interval.
+
+_workflow:
+  - setup_grid: load ding0 topology
+  - import_generators / import_home_batteries
+  - select_timesteps (pre_import): manual only — set explicit time index
+  - import_heat_pumps / import_dsm: fetch only selected steps (manual)
+  - import_electromobility: dumb charging, flex bands
+  - oedb_ts: real wind/solar + load time series
+  - apply_charging_strategy / apply_heat_pump_strategy
+  - build_flexibility_bands: EV bands on the fixed hourly index
+  - import_overlying_grid_data: HV constraints from CSV dir
+  - select_timesteps (post_grid): auto only — reduce to critical intervals
+  - reactive_power: fixed cosphi on the reduced index
+  - optimize: pm_optimize with flex assets
+  - reinforce / save
+
+# Self-contained (no `extends`): everything uc4_example provided is inlined
+# below, so this preset can be run on its own via
+#   run_edisgo({"extends": "uc5_select_timesteps", "grid": {"ding0_path": ...}})
+scenario: eGon2035
+
+grid:
+  ding0_path: "/path/to/ding0_grid"
+  legacy_ding0_grids: false
+
+database:
+  local
+
+# No explicit base time index is set. oedb_ts falls back to a full year derived
+# from the scenario when none is given, which is what auto interval selection
+# needs (week-long critical intervals to pick from). For manual selection the
+# pre-import select_timesteps step sets the index instead.
+
+overlying_grid:
+  enabled: true          # set true to activate import_overlying_grid_data
+  source: csv            # "csv" (load from path) or "etrago" (kwarg)
+  path: "/storage/JoDa/edisgo_playground/overlying_grid_data"
+
+results:
+  directory: results/uc5_select_timesteps
+
+# Top-level block read by the select_timesteps task via ctx.raw_config.
+# eGo can inject this block the same way it injects overlying_grid.
+# Set `mode` (and its parameters) here or override it in the run script.
+timeseries_selection:
+  mode: auto
+  # auto method: "power_flow" (default, scores intervals via a power flow) or
+  # "residual_load" (no power flow — the weeks ending at the max/min residual-load
+  # time steps; requires overlying-grid data).
+  method: residual_load
+  # --- shared auto parameters (both methods) ---
+  time_steps_per_time_interval: 168  # one week (must be a multiple of 24)
+  time_step_day_start: 4             # hour of day the intervals start/end on
+  # --- power_flow method parameters ---
+  percentage: 1.0
+  save_steps: true                   # write selected intervals CSV to results_dir
+  use_troubleshooting_mode: true     # handle power-flow non-convergence
+  overloading_factor: 0.95
+  voltage_deviation_factor: 0.95
+  # --- manual parameters (used when mode: manual) ---
+  # timestamps: ["2035-01-15 08:00", "2035-01-15 9:00", "2035-01-15 10:00"]
+  # or a range instead of `timestamps`:
+  start: "2035-01-15 00:00"
+  periods: 24
+  freq: h
+
+pipeline:
+  - setup_grid
+  - import_generators
+  - import_home_batteries
+  - import_heat_pumps
+  - import_dsm
+  - import_electromobility:
+      charging_strategy: null
+      # flexibility bands are built later (build_flexibility_bands), once the
+      # analysis time index is fixed, so they are resampled to it
+  - oedb_ts:
+      dispatchable: {other: 0.7}
+  - apply_charging_strategy: {strategy: dumb}
+  - apply_heat_pump_strategy: {strategy: uncontrolled}
+  - build_flexibility_bands                    # hourly bands on the 2035 index
+  - save:
+      archive: true
+      save_heatpump: true
+      save_electromobility: true
+      save_timeseries: true
+      save_dsm: true


### PR DESCRIPTION
# Description

Introduces two new presets: 
- prepare_and_save_grid
- optimize_prebuild_grids

The first one creates the grid and adds all components for the scenario and saves it into the given directory. 
The second one imports a grid build with the previous preset, adds overlying grid data, selects relevant timesteps and optimizes the grid. 
This way, calculation time can be reduced and the distribution of charging points (see #742) is the same in different model runs.

Could be a solution for #742

Warning: Line https://github.com/openego/eDisGo/blob/d25f93e2ebd0714f77baadf6ae21ced009b246ae/edisgo/run/presets/optimize_prebuild_grid.yaml#L103 still includes a hard-coded path because I didn't know how to wire it to edisgo correctly. 

@joda9 and @MoritzSchloesser: Feel free to close this PR if you want to fix this differently :) 

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] New and adjusted code is formatted using the `pre-commit` hooks
- [ ] New and adjusted code includes type hinting now
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The Read the Docs documentation is compiling correctly
- [ ] If new packages are needed, I added them the [setup.py](https://github.com/openego/eDisGo/blob/dev/setup.py), and if needed the [rtd_requirements.txt](https://github.com/openego/eDisGo/blob/dev/rtd_requirements.txt), the [eDisGo_env.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env.yml) and the [eDisGo_env_dev.yml](https://github.com/openego/eDisGo/blob/dev/eDisGo_env_dev.yml).
- [ ] I have added new features to the corresponding [whatsnew](https://github.com/openego/eDisGo/tree/dev/doc/whatsnew) file
