### PR TITLE
docs(whatsnew): open a 0.3.1 section for post-release changes

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -8,6 +8,7 @@ Changelog for each release.
     :local:
     :backlinks: top
 
+.. include::  whatsnew/v0-3-1.rst
 .. include::  whatsnew/v0-3-0.rst
 .. include::  whatsnew/v0-2-1.rst
 .. include::  whatsnew/v0-2-0.rst

--- a/doc/whatsnew/v0-3-0.rst
+++ b/doc/whatsnew/v0-3-0.rst
@@ -167,10 +167,3 @@ Changes
   ``Packaging`` workflow now builds both artifacts, asserts that all runtime data files
   ship and that the OPF entry point resolves in an installed layout, so this cannot
   regress unnoticed again
-* Corrected the Julia version documented in ``config_opf_julia.cfg``, which still
-  pointed at ``julia-1.1.0/bin`` while the bundled ``eDisGo_OPF.jl`` package targets
-  Julia 1.12. The file is included verbatim in the configuration reference, so the
-  stale path was published in the documentation. Its ``julia_bin`` value has not been
-  read since :meth:`~.edisgo.EDisGo.pm_optimize` started resolving ``julia`` from the
-  system ``PATH``; the reference now says so instead of claiming the file points to the
-  binary in use

--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -1,0 +1,15 @@
+Release v0.3.1
+================
+
+Release date: not yet released
+
+Changes
+-------
+
+* Corrected the Julia version documented in ``config_opf_julia.cfg``, which still
+  pointed at ``julia-1.1.0/bin`` while the bundled ``eDisGo_OPF.jl`` package targets
+  Julia 1.12. The file is included verbatim in the configuration reference, so the
+  stale path was published in the documentation. Its ``julia_bin`` value has not been
+  read since :meth:`~.edisgo.EDisGo.pm_optimize` started resolving ``julia`` from the
+  system ``PATH``; the reference now says so instead of claiming the file points to the
+  binary in use


### PR DESCRIPTION
0.3.0 was published on 2026-08-03 (daf14abc set the date, the tag and the PyPI upload followed), so its changelog section describes a released artifact and must not keep growing. Every change landing on dev now belongs to the next release.

Adds `doc/whatsnew/v0-3-1.rst` and includes it above 0.3.0 in `doc/whatsnew.rst`, so the newest section stays at the top of the rendered page.

Moves the one entry that had already been appended to 0.3.0 after the release: the `config_opf_julia.cfg` Julia version correction from 1d2b5de9, committed at 14:44 on the day the release date was set at 09:08. It documents a change that is not in the 0.3.0 artifact, so readers comparing the changelog against the released package would not find it.

`Release date: not yet released` is a placeholder; it gets stamped the way daf14abc did for 0.3.0 when 0.3.1 is published.
