### PR TITLE
Route the overlying grid's district-heating feed-in into the runner pipeline

### DIFF
--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -71,3 +71,8 @@ Changes
   set of labels that would collapse onto duplicates is left unchanged with a
   warning, because a duplicate ID makes the lookups downstream return a DataFrame
   where a Series is expected
+* ``load_from_base`` now declares that it provides the overlying grid and applies the
+  district-heating label normalisation to what it restored. A pipeline continuing
+  from a saved grid with ``import_overlying_grid: true`` was rejected by the
+  validator although the data was there, and the labels of the restored frames were
+  left as written

--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -26,7 +26,9 @@ Changes
   config that does define one replaces the preset's step list wholesale and is
   unaffected. The task declares ``requires={"overlying_grid"}``, which
   ``import_overlying_grid_data`` now provides, so a pipeline that puts the two in
-  the wrong order is rejected instead of silently skipping the subtraction
+  the wrong order is rejected. Note that this catches a wrong *order* only —
+  with ``overlying_grid.enabled: false`` there is no feed-in to subtract and the
+  task still does the merge half silently
 * Normalised the district-heating column labels of ``feedin_district_heating`` and
   ``thermal_storage_units_central_soc`` to the string of an integer (``"130"``) in
   ``import_overlying_grid_data``. Both consumers look the ID up in that form, so a float
@@ -61,3 +63,11 @@ Changes
   heater that cannot be attached to a heat pump is integrated as a component of its
   own, so an area can legitimately hold resistive heaters only. Such an area is now
   left unmerged with a warning naming the sectors it contains
+* Hardened the district-heating label normalisation in
+  ``import_overlying_grid_data``: labels are read one at a time, so a single
+  unreadable one (a ``NaN`` from a geo-join miss, say) no longer leaves every other
+  label of the frame unnormalised; ``OverflowError``, which an ``inf`` label raises
+  and which is not a ``ValueError``, is caught rather than killing the run; and a
+  set of labels that would collapse onto duplicates is left unchanged with a
+  warning, because a duplicate ID makes the lookups downstream return a DataFrame
+  where a Series is expected

--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -54,3 +54,10 @@ Changes
   heater had to step in, so it depressed the grid load in the cold hours that
   determine the reinforcement need. The aggregated COP also feeds the OPF through
   ``heat_pump.cop_df``
+* Stopped :func:`~.tools.tools.aggregate_district_heating_components` raising
+  ``IndexError: index 0 is out of bounds`` on a district heating area that holds
+  several power-to-heat units but not one of each type. Central heat pumps and
+  central resistive heaters are imported by independent queries, and a resistive
+  heater that cannot be attached to a heat pump is integrated as a component of its
+  own, so an area can legitimately hold resistive heaters only. Such an area is now
+  left unmerged with a warning naming the sectors it contains

--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -13,3 +13,22 @@ Changes
   read since :meth:`~.edisgo.EDisGo.pm_optimize` started resolving ``julia`` from the
   system ``PATH``; the reference now says so instead of claiming the file points to the
   binary in use
+* Wired district-heating handling into the runner pipeline. The overlying grid's
+  ``feedin_district_heating`` — thermal feed-in from other heat sources such as solar
+  or geothermal — had no consumer at all: its only consumer,
+  :func:`~.tools.tools.aggregate_district_heating_components`, was called by no
+  pipeline task, so the district-heating heat demand was overstated by that feed-in
+  and the power-to-heat units of an area were never merged. A new
+  ``aggregate_district_heating`` task does both and is part of the three
+  overlying-grid presets; it is a no-op on grids without district heating
+  (openego/eGo#202). Note that this changes results for existing configs that
+  ``extends`` one of those presets without defining their own ``pipeline:`` — a
+  config that does define one replaces the preset's step list wholesale and is
+  unaffected. The task declares ``requires={"overlying_grid"}``, which
+  ``import_overlying_grid_data`` now provides, so a pipeline that puts the two in
+  the wrong order is rejected instead of silently skipping the subtraction
+* Normalised the district-heating column labels of ``feedin_district_heating`` and
+  ``thermal_storage_units_central_soc`` to the string of an integer (``"130"``) in
+  ``import_overlying_grid_data``. Both consumers look the ID up in that form, so a float
+  label from eTraGo silently missed the feed-in and raised a ``KeyError`` on the
+  central thermal-storage state of charge

--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -41,3 +41,16 @@ Changes
   into a negative load — the power-to-heat unit fed the grid instead of being
   switched off. The power flow used that injection unchecked. A warning now names
   the district heating area and the number of affected time steps
+* Corrected the aggregated COP of a district heating area in
+  :func:`~.tools.tools.aggregate_district_heating_components`. When the heat pump
+  and the resistive heater of an area are merged, the COP of the combined component
+  has to reproduce the electricity both units draw, which makes it the heat-share
+  weighted mean of the *reciprocal* COPs. The code took the arithmetic mean of the
+  COPs instead, which is never smaller, so the electricity demand of district
+  heating was systematically understated — by
+  ``(COP_hp - COP_rh)**2 / (COP_hp + COP_rh)**2`` in the worst case, i.e. 25 % for a
+  heat pump at COP 3 against a resistive heater at COP 1. The error was zero while
+  the heat pump alone covered the demand and largest exactly when the resistive
+  heater had to step in, so it depressed the grid load in the cold hours that
+  determine the reinforcement need. The aggregated COP also feeds the OPF through
+  ``heat_pump.cop_df``

--- a/doc/whatsnew/v0-3-1.rst
+++ b/doc/whatsnew/v0-3-1.rst
@@ -32,3 +32,12 @@ Changes
   ``import_overlying_grid_data``. Both consumers look the ID up in that form, so a float
   label from eTraGo silently missed the feed-in and raised a ``KeyError`` on the
   central thermal-storage state of charge
+* Bounded the district heating heat demand at zero after subtracting the overlying
+  grid's feed-in from other heat sources in
+  :func:`~.tools.tools.aggregate_district_heating_components`. In a time step where
+  solar thermal or geothermal deliver more than the network needs, the remaining
+  demand went negative, and
+  :meth:`~.edisgo.EDisGo.apply_heat_pump_operating_strategy` divided it by the COP
+  into a negative load — the power-to-heat unit fed the grid instead of being
+  switched off. The power flow used that injection unchecked. A warning now names
+  the district heating area and the number of affected time steps

--- a/edisgo/run/presets/overlying_grid_opf.yaml
+++ b/edisgo/run/presets/overlying_grid_opf.yaml
@@ -30,6 +30,9 @@ pipeline:
   - apply_heat_pump_strategy: {strategy: uncontrolled}
   - build_flexibility_bands
   - import_overlying_grid_data
+  # merge each district heating area's PtH units and subtract the overlying
+  # grid's other heat feed-in from its demand; no-op without district heating
+  - aggregate_district_heating
   - select_critical_timesteps: {method: residual_load}
   - reactive_power
   - optimize: {method: soc, opf_version: 3}

--- a/edisgo/run/presets/overlying_grid_opf_spatial.yaml
+++ b/edisgo/run/presets/overlying_grid_opf_spatial.yaml
@@ -44,6 +44,9 @@ pipeline:
   - apply_heat_pump_strategy: {strategy: uncontrolled}
   - build_flexibility_bands
   - import_overlying_grid_data
+  # merge each district heating area's PtH units and subtract the overlying
+  # grid's other heat feed-in from its demand; no-op without district heating
+  - aggregate_district_heating
   - select_critical_timesteps: {method: residual_load}   # TEMPORAL reduction
   - reactive_power
   - spatial_reduce                                        # SPATIAL: stash full grid, reduce

--- a/edisgo/run/presets/spatial_reduction_opf.yaml
+++ b/edisgo/run/presets/spatial_reduction_opf.yaml
@@ -103,6 +103,9 @@ pipeline:
   - apply_heat_pump_strategy: {strategy: uncontrolled}
   - build_flexibility_bands                    # hourly bands on the 2035 index
   - import_overlying_grid_data
+  # merge each district heating area's PtH units and subtract the overlying
+  # grid's other heat feed-in from its demand; no-op without district heating
+  - aggregate_district_heating
   - reactive_power
   - spatial_reduce                             # no-op unless spatial_reduction.enabled
   - optimize:

--- a/edisgo/run/tasks/__init__.py
+++ b/edisgo/run/tasks/__init__.py
@@ -21,7 +21,8 @@ that the runner sees them at execution time. The submodules are:
 * :mod:`.flex` — ``import_flex`` and the per-carrier imports
   (``import_heat_pumps``, ``import_home_batteries``, ``import_dsm``,
   ``import_electromobility``, ``import_generators``),
-  ``build_flexibility_bands``, and operating strategies
+  ``build_flexibility_bands``, ``aggregate_district_heating``, and
+  operating strategies
   (``apply_charging_strategy``, ``apply_heat_pump_strategy``)
 * :mod:`.analysis` — ``check_integrity``, ``analyze``, ``reinforce``,
   ``base_reinforce``, ``optimize``

--- a/edisgo/run/tasks/flex.py
+++ b/edisgo/run/tasks/flex.py
@@ -428,6 +428,89 @@ def task_apply_heat_pump_strategy(
     return edisgo
 
 
+@register_task(
+    "aggregate_district_heating",
+    requires={"overlying_grid"},
+    ts_altering=True,
+)
+def task_aggregate_district_heating(edisgo, ctx):
+    """
+    Aggregate the power-to-heat units of each district heating area and
+    subtract the overlying grid's other heat feed-in from its heat demand.
+
+    Wraps :func:`~edisgo.tools.tools.aggregate_district_heating_components`.
+    Two things happen per district heating area:
+
+    * ``overlying_grid.feedin_district_heating`` — thermal feed-in from other
+      sources such as solar or geothermal — is subtracted from the heat demand,
+      so the power-to-heat units only have to cover the remainder;
+    * the heat pump and the resistive heater of the area are merged into a
+      single component, with the rated power added up and the COP weighted by
+      each component's contribution. The resistive heater is removed from the
+      topology and its time series dropped.
+
+    Without this step the overlying grid's ``feedin_district_heating`` has no
+    consumer at all and the district heating demand is overstated by the other
+    heat sources' contribution (openego/eGo#202).
+
+    Run this AFTER ``import_overlying_grid_data`` (which supplies the feed-in
+    and normalises its district heating column labels) and BEFORE
+    ``optimize``. It is a no-op with an info-log when the grid has no district
+    heating.
+
+    Declares ``requires={"overlying_grid"}`` so the validator rejects a pipeline
+    that puts this task before ``import_overlying_grid_data``. That ordering used
+    to pass validation and then silently take the "no feed-in" branch below --
+    reintroducing openego/eGo#202 without any error.
+
+    Registered as ``ts_altering`` because it drops the resistive heater's
+    active and reactive power series and re-applies the heat-pump operating
+    strategy to the merged component: the reactive power of that component has
+    to be recomputed afterwards, so the validator rejects a pipeline that puts
+    this task after ``reactive_power``.
+
+    Parameters
+    ----------
+    edisgo : edisgo.EDisGo
+        EDisGo instance to modify in place.
+    ctx : RunContext
+        Run context.
+
+    Returns
+    -------
+    edisgo.EDisGo
+        The modified EDisGo instance.
+
+    """
+    from edisgo.tools.tools import aggregate_district_heating_components
+
+    loads_df = edisgo.topology.loads_df
+    if "district_heating_id" not in loads_df.columns or (
+        loads_df.district_heating_id.dropna().empty
+    ):
+        ctx.logger.info(
+            "Skipping 'aggregate_district_heating': grid has no district heating."
+        )
+        return edisgo
+
+    feedin = edisgo.overlying_grid.feedin_district_heating
+    if feedin is None or feedin.empty:
+        ctx.logger.info(
+            "aggregate_district_heating: no feedin_district_heating in the "
+            "overlying grid — aggregating the power-to-heat units without "
+            "subtracting other heat sources."
+        )
+    n_before = len(edisgo.topology.loads_df)
+    aggregate_district_heating_components(edisgo, feedin_district_heating=feedin)
+    n_after = len(edisgo.topology.loads_df)
+    ctx.logger.info(
+        f"aggregate_district_heating: merged the power-to-heat units of "
+        f"{int(loads_df.district_heating_id.dropna().nunique())} district heating "
+        f"area(s); {n_before - n_after} load(s) removed."
+    )
+    return edisgo
+
+
 @register_task("import_generators")
 def task_import_generators(edisgo, ctx, *, generator_scenario=None):
     """

--- a/edisgo/run/tasks/grid.py
+++ b/edisgo/run/tasks/grid.py
@@ -171,7 +171,7 @@ def load_saved_edisgo(
     return edisgo
 
 
-@register_task("load_from_base", provides={"grid"})
+@register_task("load_from_base", provides={"grid", "overlying_grid"})
 def task_load_from_base(
     edisgo,
     ctx,
@@ -246,5 +246,12 @@ def task_load_from_base(
         import_dsm=import_dsm,
         import_overlying_grid=import_overlying_grid,
     )
+    if import_overlying_grid:
+        # Same normalisation import_overlying_grid_data applies: a saved grid
+        # carries whatever labels were written, and every consumer looks the
+        # district heating ID up as the string of an integer.
+        from edisgo.run.tasks.io import normalise_district_heating_labels
+
+        normalise_district_heating_labels(edisgo.overlying_grid, ctx.logger)
     ctx.flags["grid_loaded"] = True
     return edisgo

--- a/edisgo/run/tasks/io.py
+++ b/edisgo/run/tasks/io.py
@@ -139,7 +139,7 @@ def task_save(
     return edisgo
 
 
-@register_task("import_overlying_grid_data")
+@register_task("import_overlying_grid_data", provides={"overlying_grid"})
 def task_import_overlying_grid_data(edisgo, ctx, *, overlying_grid_path=None):
     """
     Import overlying grid data into the EDisGo instance.
@@ -241,6 +241,35 @@ def task_import_overlying_grid_data(edisgo, ctx, *, overlying_grid_path=None):
             attr,
             _to_edisgo_timeindex(ts, extra_step=attr in soc_attrs),
         )
+
+    # --- 2b) normalise the district-heating column labels ---
+    # Both district-heating-indexed frames are addressed downstream by the
+    # district heating ID as the string of an integer ("130", never "130.0"):
+    # _build_heat_storage looks up thermal_storage_units_central_soc as
+    # loads_df.district_heating_id.astype(int).astype(str), and
+    # aggregate_district_heating_components matches feedin_district_heating
+    # with str(int(district)). eTraGo/CSV data arrives with float or integer
+    # labels, which silently miss (feed-in) or raise a KeyError (SoC). The
+    # in-eGo pipeline this task replaced did the same rename right before its
+    # consumers; doing it here covers every consumer at once.
+    for attr in ("feedin_district_heating", "thermal_storage_units_central_soc"):
+        df = getattr(edisgo.overlying_grid, attr)
+        if df is None or df.empty:
+            continue
+        try:
+            renamed = [str(int(float(col))) for col in df.columns]
+        except (TypeError, ValueError):
+            ctx.logger.warning(
+                f"task 'import_overlying_grid_data': could not read the columns of "
+                f"'{attr}' as district heating IDs ({list(df.columns)}) — leaving "
+                f"them unchanged. Downstream lookups expect the ID as the string "
+                f"of an integer."
+            )
+            continue
+        if renamed != list(df.columns):
+            df = df.copy()
+            df.columns = renamed
+            setattr(edisgo.overlying_grid, attr, df)
 
     # --- 3) set dispatchable/fluctuating generator time series ---
     if source == "etrago":

--- a/edisgo/run/tasks/io.py
+++ b/edisgo/run/tasks/io.py
@@ -256,14 +256,36 @@ def task_import_overlying_grid_data(edisgo, ctx, *, overlying_grid_path=None):
         df = getattr(edisgo.overlying_grid, attr)
         if df is None or df.empty:
             continue
-        try:
-            renamed = [str(int(float(col))) for col in df.columns]
-        except (TypeError, ValueError):
+        # Per column, so that one unreadable label does not leave every other
+        # label of the frame unnormalised. The realistic producer of a single bad
+        # label is a geo-join in eGo that yields NaN for a heat bus without a
+        # matching district heating area.
+        renamed, unreadable = [], []
+        for col in df.columns:
+            try:
+                renamed.append(str(int(float(col))))
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError is what inf raises, and it is not a subclass of
+                # the other two -- without it an inf label kills the whole run.
+                renamed.append(col)
+                unreadable.append(col)
+        if unreadable:
             ctx.logger.warning(
-                f"task 'import_overlying_grid_data': could not read the columns of "
-                f"'{attr}' as district heating IDs ({list(df.columns)}) — leaving "
-                f"them unchanged. Downstream lookups expect the ID as the string "
-                f"of an integer."
+                f"task 'import_overlying_grid_data': could not read "
+                f"{len(unreadable)} column label(s) of '{attr}' as district heating "
+                f"IDs ({unreadable}) — leaving those unchanged. Downstream lookups "
+                f"expect the ID as the string of an integer, so this data will not "
+                f"be found."
+            )
+        if len(set(map(str, renamed))) != len(renamed):
+            # Normalising can collapse distinct labels onto one another, e.g.
+            # 130.0 next to "130", or the "130.1" pandas produces for a duplicate
+            # CSV header. A duplicate label makes the downstream lookups return a
+            # DataFrame where a Series is expected, which fails far from here.
+            ctx.logger.warning(
+                f"task 'import_overlying_grid_data': normalising the column labels "
+                f"of '{attr}' ({list(df.columns)}) would produce duplicates "
+                f"({renamed}) — leaving them unchanged."
             )
             continue
         if renamed != list(df.columns):

--- a/edisgo/run/tasks/io.py
+++ b/edisgo/run/tasks/io.py
@@ -139,6 +139,69 @@ def task_save(
     return edisgo
 
 
+def normalise_district_heating_labels(overlying_grid, logger):
+    """
+    Rewrite the district-heating column labels as the string of an integer.
+
+    Both district-heating-indexed frames are addressed downstream by the district
+    heating ID in that form ("130", never "130.0"): ``_build_heat_storage`` looks
+    up ``thermal_storage_units_central_soc`` as
+    ``loads_df.district_heating_id.astype(int).astype(str)``, and
+    ``aggregate_district_heating_components`` matches ``feedin_district_heating``
+    with ``str(int(district))``. eTraGo and CSV data arrive with float or integer
+    labels, which silently miss (feed-in) or raise a KeyError (SoC).
+
+    Shared by the two paths that can put overlying-grid data on an EDisGo object:
+    ``import_overlying_grid_data`` and ``load_from_base``.
+
+    Parameters
+    ----------
+    overlying_grid : edisgo.network.overlying_grid.OverlyingGrid
+        Component whose frames are normalised in place.
+    logger : logging.Logger
+        Logger to report unreadable or colliding labels on.
+
+    """
+    for attr in ("feedin_district_heating", "thermal_storage_units_central_soc"):
+        df = getattr(overlying_grid, attr)
+        if df is None or df.empty:
+            continue
+        # Per column, so that one unreadable label does not leave every other
+        # label of the frame unnormalised. The realistic producer of a single bad
+        # label is a geo-join in eGo that yields NaN for a heat bus without a
+        # matching district heating area.
+        renamed, unreadable = [], []
+        for col in df.columns:
+            try:
+                renamed.append(str(int(float(col))))
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError is what inf raises, and it is not a subclass of
+                # the other two -- without it an inf label kills the whole run.
+                renamed.append(col)
+                unreadable.append(col)
+        if unreadable:
+            logger.warning(
+                f"Could not read {len(unreadable)} column label(s) of '{attr}' as "
+                f"district heating IDs ({unreadable}) — leaving those unchanged. "
+                f"Downstream lookups expect the ID as the string of an integer, so "
+                f"this data will not be found."
+            )
+        if len(set(map(str, renamed))) != len(renamed):
+            # Normalising can collapse distinct labels onto one another, e.g.
+            # 130.0 next to "130", or the "130.1" pandas produces for a duplicate
+            # CSV header. A duplicate label makes the downstream lookups return a
+            # DataFrame where a Series is expected, which fails far from here.
+            logger.warning(
+                f"Normalising the column labels of '{attr}' ({list(df.columns)}) "
+                f"would produce duplicates ({renamed}) — leaving them unchanged."
+            )
+            continue
+        if renamed != list(df.columns):
+            df = df.copy()
+            df.columns = renamed
+            setattr(overlying_grid, attr, df)
+
+
 @register_task("import_overlying_grid_data", provides={"overlying_grid"})
 def task_import_overlying_grid_data(edisgo, ctx, *, overlying_grid_path=None):
     """
@@ -243,55 +306,7 @@ def task_import_overlying_grid_data(edisgo, ctx, *, overlying_grid_path=None):
         )
 
     # --- 2b) normalise the district-heating column labels ---
-    # Both district-heating-indexed frames are addressed downstream by the
-    # district heating ID as the string of an integer ("130", never "130.0"):
-    # _build_heat_storage looks up thermal_storage_units_central_soc as
-    # loads_df.district_heating_id.astype(int).astype(str), and
-    # aggregate_district_heating_components matches feedin_district_heating
-    # with str(int(district)). eTraGo/CSV data arrives with float or integer
-    # labels, which silently miss (feed-in) or raise a KeyError (SoC). The
-    # in-eGo pipeline this task replaced did the same rename right before its
-    # consumers; doing it here covers every consumer at once.
-    for attr in ("feedin_district_heating", "thermal_storage_units_central_soc"):
-        df = getattr(edisgo.overlying_grid, attr)
-        if df is None or df.empty:
-            continue
-        # Per column, so that one unreadable label does not leave every other
-        # label of the frame unnormalised. The realistic producer of a single bad
-        # label is a geo-join in eGo that yields NaN for a heat bus without a
-        # matching district heating area.
-        renamed, unreadable = [], []
-        for col in df.columns:
-            try:
-                renamed.append(str(int(float(col))))
-            except (TypeError, ValueError, OverflowError):
-                # OverflowError is what inf raises, and it is not a subclass of
-                # the other two -- without it an inf label kills the whole run.
-                renamed.append(col)
-                unreadable.append(col)
-        if unreadable:
-            ctx.logger.warning(
-                f"task 'import_overlying_grid_data': could not read "
-                f"{len(unreadable)} column label(s) of '{attr}' as district heating "
-                f"IDs ({unreadable}) — leaving those unchanged. Downstream lookups "
-                f"expect the ID as the string of an integer, so this data will not "
-                f"be found."
-            )
-        if len(set(map(str, renamed))) != len(renamed):
-            # Normalising can collapse distinct labels onto one another, e.g.
-            # 130.0 next to "130", or the "130.1" pandas produces for a duplicate
-            # CSV header. A duplicate label makes the downstream lookups return a
-            # DataFrame where a Series is expected, which fails far from here.
-            ctx.logger.warning(
-                f"task 'import_overlying_grid_data': normalising the column labels "
-                f"of '{attr}' ({list(df.columns)}) would produce duplicates "
-                f"({renamed}) — leaving them unchanged."
-            )
-            continue
-        if renamed != list(df.columns):
-            df = df.copy()
-            df.columns = renamed
-            setattr(edisgo.overlying_grid, attr, df)
+    normalise_district_heating_labels(edisgo.overlying_grid, ctx.logger)
 
     # --- 3) set dispatchable/fluctuating generator time series ---
     if source == "etrago":

--- a/edisgo/tools/tools.py
+++ b/edisgo/tools/tools.py
@@ -1118,9 +1118,10 @@ def aggregate_district_heating_components(edisgo_obj, feedin_district_heating=No
                 ).clip(lower=0)
                 hp_p_set = edisgo_obj.topology.loads_df.at[district_hp, "p_set"]
                 if (el_demand > hp_p_set).any():
-                    # calculate COP by weighted COP of single components
-                    # (weighted by their contribution to cover heat demand)
-                    # determine percentage of contribution per component
+                    # Share of the heat demand each component covers. The heat pump
+                    # runs up to its rated power, the resistive heater covers the
+                    # rest; dividing both by el_demand gives shares of the heat,
+                    # because el_demand is heat demand over a single COP.
                     df = pd.concat(
                         [
                             (el_demand.clip(upper=hp_p_set) / el_demand)
@@ -1132,8 +1133,15 @@ def aggregate_district_heating_components(edisgo_obj, feedin_district_heating=No
                         ],
                         axis=1,
                     )
-                    new_cop = (
-                        edisgo_obj.heat_pump.cop_df[district_hps.index] * df
+                    # The aggregated COP has to reproduce the electricity demand of
+                    # the two components for the combined heat demand Q:
+                    #     Q / COP_agg = Q_hp / COP_hp + Q_rh / COP_rh
+                    # Dividing by Q makes 1 / COP_agg the heat-share-weighted mean of
+                    # the reciprocals, i.e. the harmonic mean -- not the arithmetic
+                    # mean of the COPs, which is always the larger of the two and
+                    # therefore always understates the electricity demand.
+                    new_cop = 1 / (
+                        df / edisgo_obj.heat_pump.cop_df[district_hps.index]
                     ).sum(axis=1)
                 else:
                     new_cop = edisgo_obj.heat_pump.cop_df[district_hp]

--- a/edisgo/tools/tools.py
+++ b/edisgo/tools/tools.py
@@ -1066,12 +1066,21 @@ def aggregate_district_heating_components(edisgo_obj, feedin_district_heating=No
             ]
             # in case there is more than 1 PtH unit, get name of heat pump, otherwise
             # get name of single PtH unit
-            if len(district_hps) > 1:
+            central_hps = district_hps[district_hps.sector == "district_heating"]
+            central_rhs = district_hps[
+                district_hps.sector == "district_heating_resistive_heater"
+            ]
+            if len(district_hps) > 1 and not central_hps.empty:
                 # district heat pump component
-                district_hp = district_hps[
-                    district_hps.sector == "district_heating"
-                ].index[0]
+                district_hp = central_hps.index[0]
             else:
+                # Either a single unit, or several units none of which is a heat
+                # pump -- central heat pumps and central resistive heaters are
+                # imported by independent queries, and a resistive heater that
+                # cannot be attached to a heat pump is integrated on its own
+                # (see io.heat_pump_import), so an area can hold resistive
+                # heaters only. Fall back to the first unit, which is what the
+                # single-unit case does as well.
                 district_hp = district_hps.index[0]
 
             # reduce demand by feedin from other sources (e.g. solarthermal, geothermal)
@@ -1103,11 +1112,18 @@ def aggregate_district_heating_components(edisgo_obj, feedin_district_heating=No
                         f"grid {district}."
                     )
 
-            if len(district_hps) > 1:
+            if len(district_hps) > 1 and (central_hps.empty or central_rhs.empty):
+                logger.warning(
+                    f"District heating grid {district} holds "
+                    f"{len(district_hps)} power-to-heat units but not one of each "
+                    f"type (heat pump / resistive heater), so they cannot be "
+                    f"merged into a single component. Sectors present: "
+                    f"{sorted(district_hps.sector.unique())}."
+                )
+
+            if len(district_hps) > 1 and not (central_hps.empty or central_rhs.empty):
                 # get name of resistive heater component
-                district_rh = district_hps[
-                    district_hps.sector == "district_heating_resistive_heater"
-                ].index[0]
+                district_rh = central_rhs.index[0]
                 # calculate rated power of aggregated component
                 new_p_set = edisgo_obj.topology.loads_df.loc[
                     district_hps.index

--- a/edisgo/tools/tools.py
+++ b/edisgo/tools/tools.py
@@ -1077,9 +1077,25 @@ def aggregate_district_heating_components(edisgo_obj, feedin_district_heating=No
             # reduce demand by feedin from other sources (e.g. solarthermal, geothermal)
             if not feedin_district_heating.empty:
                 if str(int(district)) in feedin_district_heating.columns:
-                    edisgo_obj.heat_pump.heat_demand_df[district_hp] = (
+                    remaining_demand = (
                         edisgo_obj.heat_pump.heat_demand_df[district_hp]
                         - feedin_district_heating[str(int(district))]
+                    )
+                    # The remaining demand is bounded below by zero: in a time step
+                    # where the other heat sources deliver more than the network
+                    # needs, the power-to-heat unit is simply switched off. Without
+                    # the bound the negative heat demand is divided by the COP in
+                    # apply_heat_pump_operating_strategy and the unit turns into a
+                    # generator feeding the grid.
+                    if (remaining_demand < 0).any():
+                        logger.warning(
+                            f"Feed-in from other heat supply sources exceeds the heat "
+                            f"demand of district heating grid {district} in "
+                            f"{int((remaining_demand < 0).sum())} time step(s). The "
+                            f"remaining heat demand is set to zero in those steps."
+                        )
+                    edisgo_obj.heat_pump.heat_demand_df[district_hp] = (
+                        remaining_demand.clip(lower=0)
                     )
                 else:
                     logger.info(

--- a/tests/run/test_district_heating_pipeline.py
+++ b/tests/run/test_district_heating_pipeline.py
@@ -1,0 +1,47 @@
+"""
+Behavioural guard for openego/eGo#202.
+
+Deliberately in its own module and importing nothing from
+:mod:`edisgo.run.tasks.flex`: a test that imports the new task by name fails
+on a tree without it with an ``ImportError``, which proves nothing about the
+behaviour. This one fails with the actual finding -- no pipeline step consumes
+``feedin_district_heating`` -- which is the regression itself.
+"""
+
+
+def test_every_overlying_grid_preset_consumes_the_feedin():
+    """
+    Behavioural guard against the regression itself, independent of the
+    task's name: for each preset that imports overlying-grid data, some
+    pipeline step must consume ``feedin_district_heating``. On dev no step
+    does, which is openego/eGo#202 -- and a test that only imports the new
+    task by name would fail there with an ImportError, proving nothing
+    about the behaviour.
+    """
+    from edisgo.run.config import load_config
+    from edisgo.run.registry import get_task_meta
+
+    consumers = {"aggregate_district_heating"}
+    for preset in (
+        "overlying_grid_opf",
+        "overlying_grid_opf_spatial",
+        "spatial_reduction_opf",
+    ):
+        cfg = load_config({"extends": preset, "grid": {"ding0_path": "/x"}})
+        steps = [
+            step if isinstance(step, str) else next(iter(step))
+            for step in cfg["pipeline"]
+        ]
+        assert "import_overlying_grid_data" in steps, preset
+        assert consumers & set(steps), (
+            f"{preset}: imports overlying-grid data but no step consumes "
+            f"feedin_district_heating -- openego/eGo#202"
+        )
+        # and the consumer must come after the import
+        assert steps.index("aggregate_district_heating") > steps.index(
+            "import_overlying_grid_data"
+        ), preset
+        # the dependency is declared, not just ordered by luck
+        assert "overlying_grid" in get_task_meta(
+            "aggregate_district_heating"
+        ).requires

--- a/tests/run/test_tasks.py
+++ b/tests/run/test_tasks.py
@@ -342,6 +342,25 @@ class TestAggregateDistrictHeating:
             }
         )
 
+    def test_load_from_base_satisfies_the_overlying_grid_requirement(self):
+        """
+        ``load_from_base(import_overlying_grid=True)`` restores the overlying
+        grid from a saved directory, so a pipeline that continues with the
+        aggregation has the data. Declaring only ``provides={"grid"}`` made the
+        validator reject that pipeline.
+        """
+        from edisgo.run.validator import validate
+
+        validate(
+            {
+                "pipeline": [
+                    {"load_from_base": {"import_overlying_grid": True}},
+                    "aggregate_district_heating",
+                    "reactive_power",
+                ]
+            }
+        )
+
     def test_validator_enforces_the_order_against_reactive_power(self):
         """
         The task drops the resistive heater's power series and re-applies the
@@ -389,7 +408,7 @@ class TestAggregateDistrictHeating:
 
         cols = list(edisgo.overlying_grid.feedin_district_heating.columns)
         assert "130" in cols, cols
-        assert "could not read" in caplog.text
+        assert "Could not read" in caplog.text
 
     def test_labels_collapsing_to_duplicates_are_left_alone(self, caplog):
         """

--- a/tests/run/test_tasks.py
+++ b/tests/run/test_tasks.py
@@ -7,6 +7,7 @@ of ``import_overlying_grid_data`` are exercised directly.
 """
 
 import glob
+import logging
 import os
 
 import pandas as pd
@@ -20,7 +21,11 @@ from edisgo.run.config import load_config
 from edisgo.run.context import RunContext
 from edisgo.run.tasks import flex as flex_tasks
 from edisgo.run.tasks.analysis import task_optimize
-from edisgo.run.tasks.flex import task_build_flexibility_bands, task_import_flex
+from edisgo.run.tasks.flex import (
+    task_aggregate_district_heating,
+    task_build_flexibility_bands,
+    task_import_flex,
+)
 from edisgo.run.tasks.io import task_import_overlying_grid_data
 from edisgo.run.tasks.timeseries import (
     task_manual_ts,
@@ -180,6 +185,175 @@ class TestImportOverlyingGridData:
         result = task_import_overlying_grid_data(edisgo_obj, ctx)
         assert result is edisgo_obj
         assert "path" in caplog.text.lower()
+
+
+def _grid_with_district_heating():
+    """
+    Small grid with one district heating area holding a heat pump and a
+    resistive heater, plus the heat-pump data the aggregation needs.
+    """
+    edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
+    edisgo.set_timeindex(pd.date_range("2011-01-01", periods=3, freq="h"))
+    for sector, p_set, bus_i in (
+        ("district_heating", 3, 27),
+        ("district_heating_resistive_heater", 2, 27),
+    ):
+        edisgo.add_component(
+            comp_type="load",
+            type="heat_pump",
+            sector=sector,
+            district_heating_id=130,
+            ts_active_power=pd.Series(
+                index=edisgo.timeseries.timeindex, data=[1.0, 1.0, 1.0]
+            ),
+            ts_reactive_power="default",
+            bus=edisgo.topology.buses_df.index[bus_i],
+            p_set=p_set,
+        )
+    hps = edisgo.topology.loads_df.index[
+        edisgo.topology.loads_df.type == "heat_pump"
+    ]
+    ti = edisgo.timeseries.timeindex
+    edisgo.heat_pump.cop_df = pd.DataFrame(
+        {hp: [3.0, 3.0, 3.0] for hp in hps}, index=ti
+    )
+    edisgo.heat_pump.heat_demand_df = pd.DataFrame(
+        {hp: [6.0, 6.0, 6.0] for hp in hps}, index=ti
+    )
+    return edisgo
+
+
+class TestAggregateDistrictHeating:
+    """
+    openego/eGo#202: ``overlying_grid.feedin_district_heating`` had no consumer
+    in the runner path, so other heat sources were never subtracted from the
+    district heating demand and the PtH units were never merged.
+    """
+
+    def test_no_district_heating_is_a_noop(self, edisgo_obj, caplog):
+        ctx = RunContext()
+        n_before = len(edisgo_obj.topology.loads_df)
+        with caplog.at_level(logging.INFO, logger="edisgo.run"):
+            assert task_aggregate_district_heating(edisgo_obj, ctx) is edisgo_obj
+        assert len(edisgo_obj.topology.loads_df) == n_before
+        assert "no district heating" in caplog.text
+
+    def test_units_are_merged(self):
+        edisgo = _grid_with_district_heating()
+        rh = edisgo.topology.loads_df.index[
+            edisgo.topology.loads_df.sector == "district_heating_resistive_heater"
+        ][0]
+        task_aggregate_district_heating(edisgo, RunContext())
+        # the resistive heater is merged into the heat pump and removed
+        assert rh not in edisgo.topology.loads_df.index
+        assert rh not in edisgo.heat_pump.heat_demand_df.columns
+        hp = edisgo.topology.loads_df.index[
+            edisgo.topology.loads_df.sector == "district_heating"
+        ][0]
+        assert edisgo.topology.loads_df.at[hp, "p_set"] == 5
+
+    def test_feedin_is_subtracted_from_the_heat_demand(self):
+        edisgo = _grid_with_district_heating()
+        hp = edisgo.topology.loads_df.index[
+            edisgo.topology.loads_df.sector == "district_heating"
+        ][0]
+        demand_before = edisgo.heat_pump.heat_demand_df[hp].copy()
+        edisgo.overlying_grid.feedin_district_heating = pd.DataFrame(
+            {"130": [1.5, 1.5, 1.5]}, index=edisgo.timeseries.timeindex
+        )
+        task_aggregate_district_heating(edisgo, RunContext())
+        pd.testing.assert_series_equal(
+            edisgo.heat_pump.heat_demand_df[hp],
+            demand_before - 1.5,
+            check_names=False,
+        )
+
+    def test_float_district_heating_ids_are_normalised_on_import(self):
+        """
+        eTraGo delivers the district heating ID as a float, but both consumers
+        look it up as the string of an integer. The import task normalises the
+        column labels so the feed-in is not silently missed.
+        """
+        edisgo = _grid_with_district_heating()
+        edisgo.overlying_grid.feedin_district_heating = pd.DataFrame(
+            {130.0: [1.5, 1.5, 1.5]}, index=edisgo.timeseries.timeindex
+        )
+        edisgo.overlying_grid.thermal_storage_units_central_soc = pd.DataFrame(
+            {"130.0": [0.5, 0.5, 0.5]}, index=edisgo.timeseries.timeindex
+        )
+        ctx = RunContext(
+            raw_config={"overlying_grid": {"enabled": True, "source": "etrago"}},
+            overlying_grid_data={},
+        )
+        task_import_overlying_grid_data(edisgo, ctx)
+        assert list(edisgo.overlying_grid.feedin_district_heating.columns) == ["130"]
+        assert list(
+            edisgo.overlying_grid.thermal_storage_units_central_soc.columns
+        ) == ["130"]
+
+        # and with the labels normalised the feed-in actually lands
+        hp = edisgo.topology.loads_df.index[
+            edisgo.topology.loads_df.sector == "district_heating"
+        ][0]
+        demand_before = edisgo.heat_pump.heat_demand_df[hp].copy()
+        task_aggregate_district_heating(edisgo, RunContext())
+        assert (edisgo.heat_pump.heat_demand_df[hp] < demand_before).all()
+
+    def test_validator_enforces_the_order_against_the_overlying_grid_import(self):
+        """
+        Putting the task before ``import_overlying_grid_data`` used to pass
+        validation and then silently take the "no feed-in" branch -- i.e.
+        reintroduce openego/eGo#202 without any error. The task declares
+        ``requires={"overlying_grid"}`` so the validator catches it.
+        """
+        from edisgo.run.validator import validate
+
+        bad_orders = [
+            # aggregation before the import
+            [
+                "setup_grid",
+                "worst_case_ts",
+                "aggregate_district_heating",
+                "import_overlying_grid_data",
+                "reactive_power",
+            ],
+            # no import at all
+            [
+                "setup_grid",
+                "worst_case_ts",
+                "aggregate_district_heating",
+                "reactive_power",
+            ],
+        ]
+        for pipeline in bad_orders:
+            with pytest.raises(ValueError, match="requires 'overlying_grid'"):
+                validate({"pipeline": pipeline})
+
+        # the correct order validates
+        validate(
+            {
+                "pipeline": [
+                    "setup_grid",
+                    "worst_case_ts",
+                    "import_overlying_grid_data",
+                    "aggregate_district_heating",
+                    "reactive_power",
+                ]
+            }
+        )
+
+    def test_non_numeric_columns_warn_and_are_kept(self, caplog):
+        edisgo = _grid_with_district_heating()
+        edisgo.overlying_grid.feedin_district_heating = pd.DataFrame(
+            {"grid1": [1.5, 1.5, 1.5]}, index=edisgo.timeseries.timeindex
+        )
+        ctx = RunContext(
+            raw_config={"overlying_grid": {"enabled": True, "source": "etrago"}},
+            overlying_grid_data={},
+        )
+        task_import_overlying_grid_data(edisgo, ctx)
+        assert list(edisgo.overlying_grid.feedin_district_heating.columns) == ["grid1"]
+        assert "district heating IDs" in caplog.text
 
 
 class TestIntervalSelectionHelpers:

--- a/tests/run/test_tasks.py
+++ b/tests/run/test_tasks.py
@@ -342,6 +342,98 @@ class TestAggregateDistrictHeating:
             }
         )
 
+    def test_validator_enforces_the_order_against_reactive_power(self):
+        """
+        The task drops the resistive heater's power series and re-applies the
+        heat-pump operating strategy, which writes active power and zeroes
+        reactive power. Running it after ``reactive_power`` would leave the
+        merged component's reactive power stale, so ``ts_altering=True``
+        makes the validator reject that order.
+        """
+        from edisgo.run.validator import validate
+
+        with pytest.raises(ValueError, match="reactive_power"):
+            validate(
+                {
+                    "pipeline": [
+                        "setup_grid",
+                        "worst_case_ts",
+                        "import_overlying_grid_data",
+                        "reactive_power",
+                        "aggregate_district_heating",
+                    ]
+                }
+            )
+
+    def test_one_unreadable_label_does_not_block_the_others(self, caplog):
+        """
+        A geo-join miss in eGo produces a single NaN column label. Normalising
+        per frame let that one label leave every other label a float, which
+        then silently missed downstream.
+        """
+        import logging
+
+        edisgo = _grid_with_district_heating()
+        edisgo.overlying_grid.feedin_district_heating = pd.DataFrame(
+            {130.0: [1.0, 1.0, 1.0], float("nan"): [0.0, 0.0, 0.0]},
+            index=edisgo.timeseries.timeindex,
+        )
+        ctx = RunContext(
+            raw_config={"overlying_grid": {"enabled": True, "source": "etrago"}}
+        )
+        ctx.overlying_grid_data = {
+            "feedin_district_heating": edisgo.overlying_grid.feedin_district_heating
+        }
+        with caplog.at_level(logging.WARNING, logger="edisgo.run"):
+            task_import_overlying_grid_data(edisgo, ctx)
+
+        cols = list(edisgo.overlying_grid.feedin_district_heating.columns)
+        assert "130" in cols, cols
+        assert "could not read" in caplog.text
+
+    def test_labels_collapsing_to_duplicates_are_left_alone(self, caplog):
+        """
+        130.0 next to "130" normalises to two identical labels, which makes the
+        downstream lookups return a DataFrame where a Series is expected.
+        """
+        import logging
+
+        edisgo = _grid_with_district_heating()
+        frame = pd.DataFrame(
+            {130.0: [1.0, 1.0, 1.0], "130": [2.0, 2.0, 2.0]},
+            index=edisgo.timeseries.timeindex,
+        )
+        ctx = RunContext(
+            raw_config={"overlying_grid": {"enabled": True, "source": "etrago"}}
+        )
+        ctx.overlying_grid_data = {"feedin_district_heating": frame}
+        with caplog.at_level(logging.WARNING, logger="edisgo.run"):
+            task_import_overlying_grid_data(edisgo, ctx)
+
+        assert list(edisgo.overlying_grid.feedin_district_heating.columns) == [
+            130.0,
+            "130",
+        ]
+        assert "would produce duplicates" in caplog.text
+
+    def test_infinite_label_does_not_kill_the_run(self, caplog):
+        """``inf`` raises OverflowError, which is not a TypeError or ValueError."""
+        import logging
+
+        edisgo = _grid_with_district_heating()
+        frame = pd.DataFrame(
+            {130.0: [1.0, 1.0, 1.0], float("inf"): [0.0, 0.0, 0.0]},
+            index=edisgo.timeseries.timeindex,
+        )
+        ctx = RunContext(
+            raw_config={"overlying_grid": {"enabled": True, "source": "etrago"}}
+        )
+        ctx.overlying_grid_data = {"feedin_district_heating": frame}
+        with caplog.at_level(logging.WARNING, logger="edisgo.run"):
+            task_import_overlying_grid_data(edisgo, ctx)
+
+        assert "130" in list(edisgo.overlying_grid.feedin_district_heating.columns)
+
     def test_non_numeric_columns_warn_and_are_kept(self, caplog):
         edisgo = _grid_with_district_heating()
         edisgo.overlying_grid.feedin_district_heating = pd.DataFrame(

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -10,6 +10,73 @@ from edisgo import EDisGo
 from edisgo.tools import tools
 
 
+def _district_heating_grid(cop_rh=1.0):
+    """
+    Small grid with one district heating area (ID 130) holding a heat pump and a
+    resistive heater, plus the heat-pump data the aggregation needs.
+    """
+    edisgo = EDisGo(ding0_grid=pytest.ding0_test_network_path)
+    edisgo.set_timeindex(pd.date_range("2011-01-01", periods=3, freq="h"))
+    for sector, p_set in (
+        ("district_heating", 2),
+        ("district_heating_resistive_heater", 5),
+    ):
+        edisgo.add_component(
+            comp_type="load",
+            type="heat_pump",
+            sector=sector,
+            district_heating_id=130,
+            ts_active_power=pd.Series(
+                index=edisgo.timeseries.timeindex, data=[1.0, 1.0, 1.0]
+            ),
+            ts_reactive_power="default",
+            bus=edisgo.topology.buses_df.index[27],
+            p_set=p_set,
+        )
+    loads = edisgo.topology.loads_df
+    hp = loads.index[loads.sector == "district_heating"][0]
+    rh = loads.index[loads.sector == "district_heating_resistive_heater"][0]
+    ti = edisgo.timeseries.timeindex
+    edisgo.heat_pump.cop_df = pd.DataFrame(
+        {hp: [3.0] * 3, rh: [cop_rh] * 3}, index=ti
+    )
+    edisgo.heat_pump.heat_demand_df = pd.DataFrame(
+        {hp: [9.0] * 3, rh: [9.0] * 3}, index=ti
+    )
+    return edisgo, hp, rh
+
+
+class TestAggregateDistrictHeatingComponents:
+    """
+    Unit tests for :func:`edisgo.tools.tools.aggregate_district_heating_components`.
+    """
+
+    def test_feedin_above_demand_does_not_produce_a_negative_demand(self, caplog):
+        """
+        Other heat sources delivering more than the network needs must switch the
+        power-to-heat unit off, not turn it into a generator.
+        """
+        import logging
+
+        edisgo, hp, _ = _district_heating_grid()
+        # 12 MW of solar thermal against a 9 MW demand in the middle time step
+        feedin = pd.DataFrame(
+            {"130": [1.0, 12.0, 1.0]}, index=edisgo.timeseries.timeindex
+        )
+        with caplog.at_level(logging.WARNING, logger="edisgo.tools.tools"):
+            tools.aggregate_district_heating_components(
+                edisgo, feedin_district_heating=feedin
+            )
+
+        demand = edisgo.heat_pump.heat_demand_df[hp]
+        assert (demand >= 0).all(), demand.tolist()
+        assert demand.iloc[1] == 0.0
+        assert "exceeds the heat demand" in caplog.text
+        # and the resulting load is not an injection
+        edisgo.apply_heat_pump_operating_strategy(heat_pump_names=[hp])
+        assert (edisgo.timeseries.loads_active_power[hp] >= 0).all()
+
+
 class TestTools:
     @classmethod
     def setup_class(self):

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -51,6 +51,39 @@ class TestAggregateDistrictHeatingComponents:
     Unit tests for :func:`edisgo.tools.tools.aggregate_district_heating_components`.
     """
 
+    def test_aggregated_cop_reproduces_the_electricity_demand(self):
+        """
+        The aggregated COP must reproduce the electricity the two components
+        actually draw, i.e. it is the harmonic mean of their COPs weighted by
+        heat share, not the arithmetic one.
+
+        Heat pump COP 3 with 2 MW rated power covers 6 MW of the 9 MW demand
+        drawing 2 MW; the resistive heater at COP 1 covers the remaining 3 MW
+        drawing 3 MW. So 5 MW in total and COP_agg = 9 / 5 = 1.8. The
+        arithmetic mean gives 2/3 * 3 + 1/3 * 1 = 2.333, i.e. 3.857 MW -- 23 %
+        of the electricity demand missing.
+        """
+        edisgo, hp, _ = _district_heating_grid(cop_rh=1.0)
+        tools.aggregate_district_heating_components(edisgo)
+
+        cop = edisgo.heat_pump.cop_df[hp]
+        demand = edisgo.heat_pump.heat_demand_df[hp]
+        assert_allclose(cop.values, 1.8)
+        # the definition that matters: heat demand over aggregated COP is the
+        # electricity the two components really draw
+        assert_allclose((demand / cop).values, 5.0)
+
+    def test_aggregated_cop_is_unchanged_while_the_heat_pump_suffices(self):
+        """
+        As long as the heat pump alone can cover the demand the resistive
+        heater never runs, so the aggregated COP stays the heat pump's.
+        """
+        edisgo, hp, _ = _district_heating_grid(cop_rh=1.0)
+        # 3 MW demand needs 1 MW electricity, below the 2 MW rated power
+        edisgo.heat_pump.heat_demand_df.loc[:, :] = 3.0
+        tools.aggregate_district_heating_components(edisgo)
+        assert_allclose(edisgo.heat_pump.cop_df[hp].values, 3.0)
+
     def test_feedin_above_demand_does_not_produce_a_negative_demand(self, caplog):
         """
         Other heat sources delivering more than the network needs must switch the

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -51,6 +51,40 @@ class TestAggregateDistrictHeatingComponents:
     Unit tests for :func:`edisgo.tools.tools.aggregate_district_heating_components`.
     """
 
+    def test_area_without_a_central_heat_pump_warns_instead_of_raising(self, caplog):
+        """
+        An area can hold several resistive heaters and no heat pump: central
+        heat pumps and central resistive heaters are imported by independent
+        queries, and a resistive heater that cannot be attached to a heat pump
+        is integrated on its own (io.heat_pump_import). Picking the heat pump
+        used to index [0] into an empty selection and raise IndexError.
+        """
+        import logging
+
+        edisgo, hp, rh = _district_heating_grid()
+        # turn the heat pump into a second resistive heater
+        edisgo.topology.loads_df.at[hp, "sector"] = (
+            "district_heating_resistive_heater"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="edisgo.tools.tools"):
+            tools.aggregate_district_heating_components(edisgo)
+
+        # no crash, both units survive, and the reason is stated
+        assert hp in edisgo.topology.loads_df.index
+        assert rh in edisgo.topology.loads_df.index
+        assert "cannot be merged" in caplog.text
+
+    def test_area_without_a_resistive_heater_is_left_alone(self):
+        """The mirror case: several units, none of them a resistive heater."""
+        edisgo, hp, rh = _district_heating_grid()
+        edisgo.topology.loads_df.at[rh, "sector"] = "district_heating"
+
+        tools.aggregate_district_heating_components(edisgo)
+
+        assert hp in edisgo.topology.loads_df.index
+        assert rh in edisgo.topology.loads_df.index
+
     def test_aggregated_cop_reproduces_the_electricity_demand(self):
         """
         The aggregated COP must reproduce the electricity the two components


### PR DESCRIPTION
Fixes openego/eGo#202.

## The problem

An eDisGo district heating area is served by up to two **electrical** units — a heat
pump and a resistive heater — while eTraGo models the area's power-to-heat as a
**single** aggregate. `edisgo.tools.tools.aggregate_district_heating_components`
is the step that reconciles the two: it subtracts the overlying grid's non-electric
heat feed-in (solar thermal, geothermal) from the area's heat demand and merges the
two units into one equivalent component.

**On `dev` that function is called by nothing.** Its only in-eGo caller
(`_run_edisgo_task_optimisation`) was replaced by the runner, and the call was not
carried over. Outside `tests/opf/test_powermodels_opf.py` and
`tests/io/test_powermodels_io.py` no code path invokes it.

Two consequences, both visible in the results reported on the issue:

* **the heat demand is overstated** by whatever the other heat sources contribute,
  because that feed-in is never subtracted; and
* **the heat pump and the resistive heater of an area are never merged**, which is why
  a grid shows `..._district_heating_resistive_heater_...` loads with no counterpart in
  the overlying-grid data. They are not missing an equivalent — the aggregation that
  would have removed them never ran.

The second point also means the OPF sees **two** flexible heat pumps for one area, each
carrying the area's full heat demand: `heat_demand_df` is filled per unit from the same
`area_id` (`io/timeseries_import.py`), so both columns hold the identical series.

## What this PR does

1. **`aggregate_district_heating` task** (`edisgo/run/tasks/flex.py`) wrapping the
   orphaned function, added to the three presets that import overlying-grid data,
   directly after `import_overlying_grid_data` — the position the in-eGo pipeline used.
   It is a no-op with an info-log on grids without district heating.

   Two registry declarations keep a wrong pipeline from failing silently:
   * `requires={"overlying_grid"}` — placing the task before the import used to validate
     and then take the "no feed-in" branch, i.e. reintroduce this bug without any error;
   * `ts_altering=True` — the task drops the resistive heater's power series and
     re-applies the heat-pump operating strategy, so a pipeline that places it after
     `reactive_power` is now rejected.

2. **`normalise_district_heating_labels`** (`edisgo/run/tasks/io.py`) rewrites the
   district-heating column labels as the string of an integer at the import boundary,
   for both `feedin_district_heating` and `thermal_storage_units_central_soc`, shared by
   `import_overlying_grid_data` and `load_from_base`. **This is load-bearing, not
   defensive** — see the validation below.

3. Three pre-existing bugs in `aggregate_district_heating_components` that become
   reachable the moment the function is actually called:
   * the remaining heat demand is **bounded at zero** — without it a time step where the
     other sources exceed the demand yields a negative demand, which divided by the COP
     turns the heat pump into a generator feeding the grid;
   * the aggregated **COP is the harmonic mean** of the components' COPs weighted by heat
     share, not the arithmetic one. `Q/COP_agg = Q_hp/COP_hp + Q_rh/COP_rh` makes
     `1/COP_agg` the weighted mean of the reciprocals. The arithmetic mean is always the
     larger of the two and therefore **always understates the electricity demand**;
   * an area holding **resistive heaters but no heat pump** no longer raises
     `IndexError`. Central heat pumps and central resistive heaters are imported by
     independent queries and a resistive heater that cannot be attached to a heat pump is
     integrated on its own, so the case is legitimate.

## Validation

Verified end to end against real data, not only fixtures: eTraGo results
(`eGon2035`, 8760 snapshots) → eGo `dev` (including the openego/eGo#206 mapping fix)
→ eDisGo, on ding0 grids 30885 / 32355 / 32377 with heat pumps imported from the
egon-data database.

### The ID chain

```
eTraGo link bus1                       52030    (heat bus id)
  -> eGo map_etrago_heat_bus_to_district_heating_id (#206)
feedin_district_heating column          2544    correct area id, dtype int64
  -> normalise_district_heating_labels (this PR)
                                       '2544'   dtype str — matches the consumer
```

eGo#206 resolves the heat bus to the district heating area correctly. But it returns a
**numpy integer**, and both consumers address the area as the string of an integer
(`aggregate_district_heating_components` matches `str(int(district))`;
`_build_heat_storage` looks up `district_heating_id.astype(int).astype(str)`).
`2544 != '2544'`, so the lookup misses **silently**, logging "There are no other heat
supply sources in district heating grid 2544".

This is why the reported mismatch persisted after eGo#206 was merged: the label was
fixed, its type was not.

### `dev` vs this branch, identical inputs

| grid  | heat demand, `dev`     | heat demand, this PR |
|-------|------------------------|----------------------|
| 30885 | 1091.4849 (unchanged)  | 1090.0953            |
| 32355 | 1091.4849 (unchanged)  | 1090.8864            |
| 32377 | 1091.4849 (unchanged)  | 1090.1043            |

On `dev` the feed-in is never subtracted on any of the three grids. The merge itself
(2 district-heating units -> 1) works in both, since it does not depend on the feed-in.

The duplicated heat demand was confirmed on all three grids: the heat pump and the
resistive heater carry byte-identical `heat_demand_df` columns (`.equals()` is `True`),
both holding the area's full demand.

### Tests

`tests/run/test_district_heating_pipeline.py` is a behavioural guard that imports
nothing from the new module: for each preset that imports overlying-grid data, some
pipeline step must consume `feedin_district_heating`. On `dev` it fails with the finding
itself —

```
AssertionError: overlying_grid_opf: imports overlying-grid data but no step
consumes feedin_district_heating -- openego/eGo#202
```

— rather than with an `ImportError`, which would prove nothing about the behaviour.

`tests/run/` and `tests/tools/test_tools.py`: 88 passed.

## Out of scope — a magnitude inconsistency that remains

Independent of this PR and not addressed by it: district heating area 2544's **full**
heat demand (~1091 MW) is assigned to each of the three MV grids, while each grid holds
only its own slice of the area's power-to-heat capacity (0.75–2.76 MW). Demand exceeds
local capacity by roughly three orders of magnitude, and the feed-in subtraction
therefore only moves the demand by ~0.1%.

The code path is correct after this PR; the magnitudes entering it are not. That looks
like a scaling question on the eGo/egon-data side and is likely the remaining reason the
central heat pump time series do not match. Worth tracking separately.